### PR TITLE
Resolve "Move members of AbstractCalculator into pimpl to provide ABI compatibilty"

### DIFF
--- a/src/core/process_management/gt_calculator.h
+++ b/src/core/process_management/gt_calculator.h
@@ -15,6 +15,8 @@
 
 #include <QPointer>
 
+#include <memory>
+
 class QDir;
 class GtModeProperty;
 class GtLabelProperty;
@@ -221,21 +223,8 @@ protected:
     QString projectPath();
 
 private:
-    /// Execution mode indicator.
-    GtModeProperty* m_execMode;
-
-    /// Execution label property
-    QPointer<GtLabelProperty> m_labelProperty;
-
-    /// Path to process/project specific temporary path.
-    QString m_tempPath;
-
-    /// Pointer to runnable associated to the calculator.
-    GtAbstractRunnable* m_runnable;
-
-    /// Fail run on warning indicator.
-    GtBoolProperty m_failRunOnWarning;
-
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
 };
 
 Q_DECLARE_METATYPE(GtCalculator*)


### PR DESCRIPTION
In GitLab by @rainman110 on Oct 12, 2022, 22:19

<!--- Provide a general summary of your changes in the Title above -->

## Description
This MR moves all private members of GtCalculator into a pimpl.
This was done to enable future ABI compatibilty when adding new members, which can be then inserted into the pimpl.

## How Has This Been Tested?
All unit tests still work.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

Closes #293