### PR TITLE
Draft: Implemented restart dialog and app restart

### DIFF
--- a/src/app/preferences/gt_preferencesdialog.cpp
+++ b/src/app/preferences/gt_preferencesdialog.cpp
@@ -13,6 +13,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include <QProcess>
 
 #include "gt_preferencesdialog.h"
 #include "gt_preferencesapp.h"
@@ -25,6 +26,7 @@
 #include "gt_icons.h"
 #include "gt_application.h"
 #include "gt_settings.h"
+#include "qapplication.h"
 
 
 GtPreferencesDialog::GtPreferencesDialog(int initItem, QWidget* parent) :
@@ -172,6 +174,30 @@ GtPreferencesDialog::changePage(QListWidgetItem* current,
     m_pagesWidget->setCurrentIndex(m_contentsWidget->row(current));
 }
 
+void askUserAndRestart()
+{
+
+    QMessageBox dialog;
+    dialog.setWindowTitle(QObject::tr("Restart required"));
+    dialog.setText(QObject::tr("The changes require a restart "
+                               "of GTlab to take effect."));
+    auto restartButton = dialog.addButton(QObject::tr("Restart now"),
+                                       QMessageBox::AcceptRole);
+    dialog.addButton(QString(QObject::tr("Later")),
+                  QMessageBox::RejectRole);
+
+    dialog.setModal(true);
+    dialog.setIcon(QMessageBox::Information);
+    dialog.exec();
+
+    if (dialog.clickedButton() == restartButton)
+    {
+        // now restart the app
+        qApp->quit();
+        QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
+    }
+}
+
 void
 GtPreferencesDialog::saveChanges()
 {
@@ -185,8 +211,7 @@ GtPreferencesDialog::saveChanges()
 
     if (gtApp->settings()->requiresAppRestart())
     {
-        QMessageBox::information(this, tr("Restart required"),
-            tr("The changes require a restart of GTlab to take effect"));
+        askUserAndRestart();
     }
 
     accept();

--- a/src/core/settings/gt_settings.cpp
+++ b/src/core/settings/gt_settings.cpp
@@ -127,7 +127,7 @@ GtSettings::GtSettings()
                 QStringLiteral("application/general/shortCuts"),
                 initialShortCuts());
 
-    pimpl->themeSelection = registerSetting(
+    pimpl->themeSelection = registerSettingRestart(
                         QStringLiteral("application/general/themeSelection"),
                         QStringLiteral("system"));
 

--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -753,14 +753,15 @@ void
 GtApplication::setDarkMode(bool dark)
 {
     static bool initial = true;
-    m_darkMode = dark;
 
-    if (!initial)
+    if (!initial && m_darkMode != dark)
     {
         gtInfo() << tr("Theme has changed.")
                  << tr("For an optimal view of all displays, "
                        "it is recommended to restart the application.");
     }
+
+    m_darkMode = dark;
 
     initial = false;
     emit themeChanged(dark);


### PR DESCRIPTION
In GitLab by @rainman110 on Feb 9, 2023, 13:52

<!--- Provide a general summary of your changes in the Title above -->

## Description
If certain settings have changed (e.g. theme or python exe), gtlab needs a restart.

This MR adds a dialog, whether to restart or not, if these settings have changed

## How Has This Been Tested?
![image](https://my-gitlab-bucket.s3.amazonaws.com/727352741/f9f65a4bb21bc09726ac8394bafc042c0a387545dacb9ace01238a4743d8d39b/image.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.