### PR TITLE
Resolve "GtEnumProperty::setValueFromVariant should fail in case the variant is not a valid enum value."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added option to skip/unskip multiple process elements at once via keyboard shortcut - #1226
 
+### Changed
+- Setting the value of a enum property via `GtEnumProperty::setValueFromVariant` does not change the value,
+  if the variant string is invalid, i.e. is not an enum value. - #609
+
 ## [2.0.9] - 2024-06-20
 ### Fixed
 - Fixed "GTlabConsole run -f project.gtlab -s" not saving changes to the project - #1254

--- a/src/dataprocessor/property/gt_enumproperty.h
+++ b/src/dataprocessor/property/gt_enumproperty.h
@@ -173,17 +173,13 @@ inline void GtEnumProperty<T>::setVal(const T value, bool* success)
 template<typename T>
 inline bool GtEnumProperty<T>::setValueFromVariant(const QVariant &value, const QString &unit)
 {
-    bool succeed = false;
-    const QString tmpVal = val.toString();
     //Check if it is possible to convert value into an enum value
-    getMetaEnum().keyToValue(tmpVal.toUtf8(), &succeed);
+    bool canConvert = false;
+    getMetaEnum().keyToValue(value.toString().toUtf8(), &canConvert);
 
-    if (succeed)
-    {
-        succeed = GtModeProperty::setValueFromVariant(val, unit);
-    }
+    if (!canConvert) return false;
 
-    return succeed;
+    return GtModeProperty::setValueFromVariant(value, unit);
 }
 
 template<typename T>

--- a/src/dataprocessor/property/gt_enumproperty.h
+++ b/src/dataprocessor/property/gt_enumproperty.h
@@ -87,6 +87,18 @@ public:
     void setVal(const T value, bool *success = nullptr);
 
     /**
+     * @brief Sets the value of this property from an variant.
+     * If the variants string cannot be converted into the respective enum, the value is not changed.
+     * In order to set the value, the GtModeProperty::setValueFromVariant method is called.
+     * @param value that should be set.
+     * @param unit is forwarded to GtModeProperty::setValueFromVariant
+     * @return if it was able to set the value and if the value is a valid for the respective enum.
+     */
+    GT_NO_DISCARD
+    bool setValueFromVariant(const QVariant& value,
+                             const QString& unit) override;
+
+    /**
      * @brief Creates a meta enum out of the template enum.
      * @return The QMetaEnum generatd.
      */
@@ -156,6 +168,22 @@ template<typename T>
 inline void GtEnumProperty<T>::setVal(const T value, bool* success)
 {
     GtModeProperty::setVal(getMetaEnum().valueToKey(static_cast<int>(value)), success);
+}
+
+template<typename T>
+inline bool GtEnumProperty<T>::setValueFromVariant(const QVariant &value, const QString &unit)
+{
+    bool succeed = false;
+    const QString tmpVal = val.toString();
+    //Check if it is possible to convert value into an enum value
+    getMetaEnum().keyToValue(tmpVal.toUtf8(), &succeed);
+
+    if (succeed)
+    {
+        succeed = GtModeProperty::setValueFromVariant(val, unit);
+    }
+
+    return succeed;
 }
 
 template<typename T>

--- a/tests/unittests/datamodel/test_gt_enumproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_enumproperty.cpp
@@ -65,3 +65,16 @@ TEST_F(TestGtEnumProperty, implicitConversions)
     m_propScoped.setVal(EnumContainer::TestScopedEnum::Pear);
     ASSERT_EQ(m_propScoped, EnumContainer::TestScopedEnum::Pear);
 }
+
+TEST_F(TestGtEnumProperty, valueFromVariant)
+{
+    m_prop.setVal(EnumContainer::TestEnum::C);
+    EXPECT_EQ(m_prop, EnumContainer::TestEnum::C);
+
+    EXPECT_TRUE(m_prop.setValueFromVariant("B", ""));
+    EXPECT_EQ(m_prop, EnumContainer::TestEnum::B);
+
+    // the value should not change, if the string is invalid
+    EXPECT_FALSE(m_prop.setValueFromVariant("InvalidString", ""));
+    EXPECT_EQ(m_prop, EnumContainer::TestEnum::B);
+}


### PR DESCRIPTION
In GitLab by @NelDav on Oct 27, 2023, 08:06

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [x] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

Closes #609