### PR TITLE
Added CI for documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,9 @@ jobs:
       run: |
         cd docs
         sphinx-build . html
+    - name: Save as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: doc-devel
+        path: |
+          docs/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        apt install -y doxygen
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run doxygen
+      run: |
+        cd docs
+        doxygen
+    - name: Create documentation
+      run: |
+        sphinx-build . html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo apt install -y doxygen
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r docs/requirements.txt
     - name: Run doxygen
       run: |
         cd docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,5 @@ jobs:
         doxygen
     - name: Create documentation
       run: |
+        cd docs
         sphinx-build . html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apt install -y doxygen
+        sudo apt install -y doxygen
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run doxygen


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a Github Action to create the developer documentation.
Currently, the documentation is stored as a build artifact only.

Later, when the documentation has been finished, we should deploy
it to a website, e.g. github pages.

## How Has This Been Tested?

See the CI results....

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

Closes #1099 