### PR TITLE
Host and build documentation on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    pre_build:
+      - cd docs && doxygen
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -61,6 +61,6 @@ Copyright: 2023 German Aerospace Center (DLR)
 License: CC0-1.0
 
 # documentation
-Files: docs/**
+Files: docs/** .readthedocs.yml
 Copyright: 2024 German Aerospace Center (DLR)
 License: MPL-2.0+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
-furo
-breathe
-myst-parser
+Sphinx==7.2.6
+furo==2023.9.10
+breathe==4.35.0
+myst-parser==2.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a "readthedocs" integration. This service automatically builds the documentation, when the repo has changed and also hosts the HTML pages.

## How Has This Been Tested?

https://gtlab.readthedocs.io/en/latest/index.html


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
