### PR TITLE
Remove logo in readme text in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
 SPDX-License-Identifier: MPL-2.0+
 -->
 
+<img src="https://raw.githubusercontent.com/dlr-gtlab/gtlab-core/master/src/resources/pixmaps/gt-logo.png" alt="gtlab logo" style="max-width: 100%;" class="hideindoc">
 
-# ![gtlab logo](https://raw.githubusercontent.com/dlr-gtlab/gtlab-core/master/src/resources/pixmaps/gt-logo.png)
+# About
 
 This repository includes the __GTlab core framework__. GTlab (Gas Turbine Laboratory) is a versatile
 software framework designed for multidisciplinary, collaborative research in the field of aircraft propulsion.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ SPDX-License-Identifier: MPL-2.0+
 
 <img src="https://raw.githubusercontent.com/dlr-gtlab/gtlab-core/master/src/resources/pixmaps/gt-logo.png" alt="gtlab logo" style="max-width: 100%;" class="hideindoc">
 
+<div class="hideindoc" id="badgesbox">
+ <a href='https://gtlab.readthedocs.io/en/latest/?badge=latest'>
+     <img src='https://readthedocs.org/projects/gtlab/badge/?version=latest' alt='Documentation Status' />
+ </a>
+ <!-- Add badges here-->
+</div>
+
 # About
 
 This repository includes the __GTlab core framework__. GTlab (Gas Turbine Laboratory) is a versatile

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
 SPDX-License-Identifier: MPL-2.0+
 -->
 
-<img src="https://raw.githubusercontent.com/dlr-gtlab/gtlab-core/master/src/resources/pixmaps/gt-logo.png" alt="gtlab logo" style="max-width: 100%;" class="hideindoc">
 
 <div class="hideindoc" id="badgesbox">
- <a href='https://gtlab.readthedocs.io/en/latest/?badge=latest'>
-     <img src='https://readthedocs.org/projects/gtlab/badge/?version=latest' alt='Documentation Status' />
- </a>
+ <img src="https://raw.githubusercontent.com/dlr-gtlab/gtlab-core/master/src/resources/pixmaps/gt-logo.png" alt="gtlab logo" style="max-width: 100%;">
+ 
+ <a href="https://zenodo.org/doi/10.5281/zenodo.10666586"><img src="https://zenodo.org/badge/727352741.svg" alt="DOI"></a>
+ <a href='https://gtlab.readthedocs.io/en/latest/?badge=latest'><img src='https://readthedocs.org/projects/gtlab/badge/?version=latest' alt='Documentation Status' /></a>
  <!-- Add badges here-->
 </div>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,10 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['static']
 
+html_css_files = [
+    'css/custom.css',
+]
+
 # Breathe Configuration
 breathe_projects = {"gtlab": "doxygen/xml"}
 breathe_default_project = "gtlab"

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -1,0 +1,3 @@
+.hideindoc {
+    display: none;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Small change to make the logo not appear in the readme section, since it will be already shown in the sidebar.

I also created a DOI and added the badge in the Readme: [DOI: 10.5281/zenodo.10666587](https://doi.org/10.5281/zenodo.10666587)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
