### PR TITLE
Enable console application to use collections

### DIFF
--- a/src/batch/CMakeLists.txt
+++ b/src/batch/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(GTlabConsole
     PRIVATE
     GTlabCore
     GTlabDataProcessor
+    GTlabGui
     Qt5::Widgets
     Qt5::Xml
 )

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -21,6 +21,8 @@
 #include "internal/gt_commandlinefunctionhandler.h"
 #include "batchremote.h"
 
+#include "gt_application.h"
+
 #include "gt_coreapplication.h"
 #include "gt_coredatamodel.h"
 #include "gt_coreprocessexecutor.h"
@@ -1138,7 +1140,7 @@ int main(int argc, char* argv[])
     initSystemOptions();
 
     // application initialization
-    GtCoreApplication app(qApp, GtCoreApplication::AppMode::Batch);
+    GtApplication app(qApp, true, GtCoreApplication::AppMode::Batch);
 
     // version option
     if (parser.option("version"))

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -23,7 +23,7 @@
 
 #include "gt_application.h"
 
-#include "gt_coreapplication.h"
+//#include "gt_coreapplication.h"
 #include "gt_coredatamodel.h"
 #include "gt_coreprocessexecutor.h"
 #include "gt_project.h"
@@ -1168,6 +1168,7 @@ int main(int argc, char* argv[])
     }
 
     // load GTlab modules
+    app.initMdiLauncher();
     app.loadModules();
 
     // calculator initialization


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The console application now uses the GtApplication and not only the GtCoreApplication. This was required as the collections had been read from the interfaces in the mdiLauncher which is not accessible in the CoreApplication.
This is a work around as the core application should normally depend on GUI elements

## How Has This Been Tested?
The colleague who asked for the change used it successfully.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
