### PR TITLE
implementation to add object to list of linkable objects

### DIFF
--- a/src/core/process_management/gt_processcomponent.cpp
+++ b/src/core/process_management/gt_processcomponent.cpp
@@ -514,3 +514,9 @@ GtProcessComponent::tempDir()
 
     return QDir(pimpl->tempPath);
 }
+
+void
+GtProcessComponent::appendToLinkObjects(QPointer<GtObject> p)
+{
+    linkedObjects().append(p);
+}

--- a/src/core/process_management/gt_processcomponent.h
+++ b/src/core/process_management/gt_processcomponent.h
@@ -256,6 +256,18 @@ public:
         return nullptr;
     }
 
+    /**
+     * @brief appendToLinkObjects
+     * The data<> function of the process elements dan only refer to objects
+     * which are collected in the list of linkable objects.
+     * With this  function here it is possible to add more objects from outside
+     * the process management system e.g. for the usage in the graph system
+     *
+     * @param p - object pointer to add to the object to the list of objects
+     * which the processcomponent can refer to in its data<> function
+     */
+    void appendToLinkObjects(QPointer<GtObject> p);
+
 public slots:
     /**
      * @brief Handles process component state changes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

For the usage of calculators in the graph system (outside the original process management) it is necessary to fill the list of linkable objects to be able to work with object links.
This is done by an additional function which enables to add objects to this list


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Usage in the graph system 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
