### PR TITLE
Activate warning for unknown classes only in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed unicode characters not correctly saved to tasks, in particular python tasks and file properties - #1125, #45
 
+### Changed
+- Warning for unknown classes is only triggers Error dialog in developer mode of GTlab - #1160
 
 ## [2.0.6] - 2023-11-07 
 ### Fixed

--- a/src/core/gt_projectanalyzer.cpp
+++ b/src/core/gt_projectanalyzer.cpp
@@ -9,6 +9,7 @@
  *  Tel.: +49 2203 601 2907
  */
 
+#include "gt_coreapplication.h"
 #include "gt_footprint.h"
 #include "gt_objectmemento.h"
 
@@ -55,7 +56,7 @@ GtProjectAnalyzer::hasIrregularities()
         return true;
     }
 
-    if (!m_pimpl->m_unknownClasses.isEmpty())
+    if (!m_pimpl->m_unknownClasses.isEmpty() && gtApp->devMode())
     {
         return true;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The widget entries for unknown classes is only shown in dev mode

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
