### PR TITLE
Move multiple elements in the process dock widget

### DIFF
--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1433,7 +1433,7 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
 
             if (parent != p->parentObject())
             {
-                gtWarning() << tr("It is only allowed to move elements of the"
+                gtWarning() << tr("It is only allowed to move elements of the "
                                   "same task");
                 return;
             }

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1405,9 +1405,7 @@ void
 GtProcessDock::moveElements(const QList<QModelIndex>& source,
                             const QModelIndex& target)
 {
-    if (!target.isValid()) return;
-
-    if (source.isEmpty()) return;
+    if (!target.isValid() || source.isEmpty()) return;
 
     QList<QModelIndex> mapped;
 

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1409,7 +1409,7 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
 
     QList<QModelIndex> mapped;
 
-    for (auto i : source)
+    for (QModelIndex i : source)
     {
         if (i.isValid()) mapped.append(mapToSource(i));
     }
@@ -1421,11 +1421,11 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
     /// check if all elements to move have the same parent
     GtObject* parent = nullptr;
 
-    for (auto j : mapped)
+    for (QModelndex j : qAsConst(mapped))
     {
-        if (j.model() != gtDataModel) return;
+        assert (j.model() == gtDataModel);
 
-        if (auto p = gtDataModel->objectFromIndex(j))
+        if (auto* p = gtDataModel->objectFromIndex(j))
         {
             if (!parent) parent = p->parentObject();
 

--- a/src/app/dock_widgets/process/gt_processdock.h
+++ b/src/app/dock_widgets/process/gt_processdock.h
@@ -419,6 +419,7 @@ private slots:
 
     void currentTaskGroupIndexChanged(int index);
 
+    void moveElements(const QList<QModelIndex>& source, const QModelIndex& target);
 signals:
     /**
      * @brief selectedObjectChanged

--- a/src/app/dock_widgets/process/gt_processview.cpp
+++ b/src/app/dock_widgets/process/gt_processview.cpp
@@ -11,7 +11,6 @@
 #include <QScrollBar>
 #include <QKeyEvent>
 
-#include "gt_logging.h"
 #include "gt_application.h"
 #include "gt_icons.h"
 #include "gt_processview.h"

--- a/src/app/dock_widgets/process/gt_processview.cpp
+++ b/src/app/dock_widgets/process/gt_processview.cpp
@@ -141,21 +141,21 @@ GtProcessView::mousePressEvent(QMouseEvent* event)
 {
     QTreeView::mousePressEvent(event);
 
-    //    QModelIndex index = indexAt(event->pos());
+    QModelIndex index = indexAt(event->pos());
 
-    //    if (!index.isValid())
-    //    {
-    //        if (!gtApp->currentProject())
-    //        {
-    //            return;
-    //        }
+    if (!index.isValid())
+    {
+        if (!gtApp->currentProject())
+        {
+            return;
+        }
 
-    //        assert(selectionModel());
+        assert(selectionModel());
 
-    //        clearSelection();
-    //        selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select);
-    //        emit clicked(index);
-    //    }
+        clearSelection();
+        selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select);
+        emit clicked(index);
+    }
 }
 
 void

--- a/src/app/dock_widgets/process/gt_processview.cpp
+++ b/src/app/dock_widgets/process/gt_processview.cpp
@@ -13,6 +13,7 @@
 
 #include "gt_application.h"
 #include "gt_icons.h"
+#include "gt_logging.h"
 #include "gt_processview.h"
 
 GtProcessView::GtProcessView(QWidget* parent) : GtTreeView(parent)
@@ -164,7 +165,7 @@ GtProcessView::dropEvent(QDropEvent* event)
 
     QModelIndex newIndex = indexAt(event->pos());
 
-    if (newIndex.isValid() && !indexes.isEmpty())
+    if (!indexes.isEmpty())
     {
         emit moveProcessElements(indexes, newIndex);
         event->accept();

--- a/src/app/dock_widgets/process/gt_processview.cpp
+++ b/src/app/dock_widgets/process/gt_processview.cpp
@@ -11,6 +11,7 @@
 #include <QScrollBar>
 #include <QKeyEvent>
 
+#include "gt_logging.h"
 #include "gt_application.h"
 #include "gt_icons.h"
 #include "gt_processview.h"
@@ -140,21 +141,38 @@ GtProcessView::mousePressEvent(QMouseEvent* event)
 {
     QTreeView::mousePressEvent(event);
 
-    QModelIndex index = indexAt(event->pos());
+    //    QModelIndex index = indexAt(event->pos());
 
-    if (!index.isValid())
+    //    if (!index.isValid())
+    //    {
+    //        if (!gtApp->currentProject())
+    //        {
+    //            return;
+    //        }
+
+    //        assert(selectionModel());
+
+    //        clearSelection();
+    //        selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select);
+    //        emit clicked(index);
+    //    }
+}
+
+void
+GtProcessView::dropEvent(QDropEvent* event)
+{
+    QList<QModelIndex> indexes = selectionModel()->selectedIndexes();
+
+    QModelIndex newIndex = indexAt(event->pos());
+
+    if (newIndex.isValid() && !indexes.isEmpty())
     {
-        if (!gtApp->currentProject())
-        {
-            return;
-        }
-
-        assert(selectionModel());
-
-        clearSelection();
-        selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select);
-        emit clicked(index);
+        emit moveProcessElements(indexes, newIndex);
+        event->accept();
+        return;
     }
+
+    GtTreeView::dropEvent(event);
 }
 
 void

--- a/src/app/dock_widgets/process/gt_processview.h
+++ b/src/app/dock_widgets/process/gt_processview.h
@@ -53,6 +53,11 @@ protected:
      */
     void mousePressEvent(QMouseEvent* event) override;
 
+    /**
+     * @brief dropEvent
+     * @param event
+     */
+    void dropEvent(QDropEvent* event) override;
 signals:
     /**
      * @brief pasteProcessElement
@@ -102,6 +107,9 @@ signals:
      * @param index - modelindex for which the signal is emited
      */
     void renameProcessElement(const QModelIndex& index);
+
+    void moveProcessElements(const QList<QModelIndex>& source,
+                             const QModelIndex& target);
 };
 
 #endif // GTPROCESSVIEW_H


### PR DESCRIPTION
Multiple elements of the same parent can be moved (to another task or a different position in the same task)

## Description
the process view re implemented the drop event which emits a signal. This is connected to a slot in the process dock.

There the list of selected items and the target are checked for validity and the move is performed

## How Has This Been Tested?
By usage in the GUI 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
