### PR TITLE
Fixed encoding of tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed unicode characters not correctly saved to tasks, in particular python tasks - #1125
+
+
 ## [2.0.6] - 2023-11-07 
 ### Fixed
 - Fix examples widget for new structure of process files - #593

--- a/src/core/process_management/gt_taskgroup.cpp
+++ b/src/core/process_management/gt_taskgroup.cpp
@@ -490,24 +490,18 @@ GtTaskGroup::Impl::createTaskFromFile(const QString& filePath) const
 bool
 GtTaskGroup::Impl::saveTaskToFile(const GtTask* task, const QString& groupPath) const
 {
-    QFile taskFile(groupPath + QDir::separator() + task->uuid() +
+    QString taskFile(groupPath + QDir::separator() + task->uuid() +
                    S_TASK_FILE_EXT);
 
-
-    if (!taskFile.open(QIODevice::WriteOnly | QIODevice::Text))
-    {
-        gtError() << QObject::tr("Could not open file (%1)").arg(taskFile.fileName());
-        return false;
-    }
-
-    QTextStream out(&taskFile);
 
     QDomDocument doc;
     doc.setContent(task->toMemento().toByteArray());
 
-    out << doc.toString();
-
-    taskFile.close();
+    if (!gt::xml::writeDomDocumentToFile(taskFile, doc, false))
+    {
+        gtError() << QObject::tr("Could not open file (%1)").arg(taskFile);
+        return false;
+    }
 
     return true;
 }

--- a/src/dataprocessor/gt_xmlutilities.cpp
+++ b/src/dataprocessor/gt_xmlutilities.cpp
@@ -127,6 +127,7 @@ gt::xml::writeDomDocumentToFile(const QString& filePath,
     if (attrOrdered)
     {
         QXmlStreamWriter str_w(&file);
+        str_w.setCodec("UTF-8");
         str_w.setAutoFormatting(true);
 
         str_w.writeStartDocument(QStringLiteral("1.0"));
@@ -146,7 +147,8 @@ gt::xml::writeDomDocumentToFile(const QString& filePath,
     else
     {
         QTextStream stream(&file);
-        stream << doc.toString(5);
+        stream.setCodec("UTF-8");
+        stream << doc.toString(4);
     }
 
     file.close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

GTlab assumes a UTF-8 encoding. However, tasks have been saved using the default ANSI encoding. Thus, when reading in a task, the unicode characters were misinterpreted.

Now, tasks and other xml files are forced to be written as UTF-8.

Fixes #1125

## How Has This Been Tested?

Manually using the following steps:
 - Create a python tasks
 - Insert `print("°")`
 - Save & close the project 
 - Reopen the project and open the task

The `°` character should be still the same and not replace by `?`.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
