### PR TITLE
Resolve "Active/Inactive filter buttons of output dock widget are hard to distinguish in dark mode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed unicode characters not correctly saved to tasks, in particular python tasks and file properties - #1125, #45
 
+### Changed
+- (In-)active filter buttons for the logging level in the output dock are now better distinuishable. - #606 
 
 ## [2.0.6] - 2023-11-07 
 ### Fixed

--- a/src/app/dock_widgets/output/gt_outputdock.cpp
+++ b/src/app/dock_widgets/output/gt_outputdock.cpp
@@ -176,8 +176,9 @@ GtOutputDock::GtOutputDock()
                                        auto* reciever,
                                        auto signal){
 
-        using gt::gui::color::disabled;  // color if button is disabled
-        using gt::gui::color::highlight; // color if button is enabled
+        using gt::gui::color::lighten;
+        using gt::gui::color::disabled;
+        using gt::gui::color::text;
         using gt::gui::colorize; // use custom colors for icon
 
         auto* button = setupButton(icon, tooltip);
@@ -187,7 +188,7 @@ GtOutputDock::GtOutputDock()
         // icon ourselfes
         auto const updateIconColor = [b = QPointer<QPushButton>(button)](){
             assert (b);
-            return b->isChecked() ? highlight() : disabled();
+            return b->isChecked() ? text() : lighten(disabled(), 15);
         };
         button->setIcon(colorize(icon, gt::gui::SvgColorData{ updateIconColor }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #606.

Applied a highlighted effect to the filter buttons if they are enabled

![grafik](https://github.com/dlr-gtlab/gtlab-core/assets/52258575/fc753bcb-0782-4c8f-8191-344195f2f3fb)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
