### PR TITLE
Resolve "Copying Multiple Messages from Output Dock using Keyboard Shortcuts does not work sometimes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed mirco stutters when new messages are appended to the output dock. - #1165
 - Fixed unicode characters not correctly saved to tasks, in particular python tasks and file properties - #1125, #45
+- Fixed copying in output dock using keyboard shortcut sometimes not working as expected. - #1136
 
 ### Changed
 - (In-)active filter buttons for the logging level in the output dock are now better distinuishable. - #606 

--- a/src/app/dock_widgets/output/gt_outputdock.cpp
+++ b/src/app/dock_widgets/output/gt_outputdock.cpp
@@ -401,6 +401,13 @@ GtOutputDock::keyPressEvent(QKeyEvent* event)
     {
         return openContextMenu();
     }
+    // TODO: fix and remove with #1175
+    if (gtApp->compareKeyEvent(event, "copy"))
+    {
+        return onCopyRequest();
+    }
+
+    return GtDockWidget::keyPressEvent(event);
 }
 
 void

--- a/src/app/dock_widgets/output/gt_outputdock.h
+++ b/src/app/dock_widgets/output/gt_outputdock.h
@@ -43,6 +43,12 @@ protected:
      */
     void projectChangedEvent(GtProject* project) override;
 
+    /**
+     * @brief keyPressEvent
+     * @param event - key press event to handle
+     */
+    void keyPressEvent(QKeyEvent* event) override;
+
 private:
     /// Log view
     GtTableView* m_logView{};
@@ -80,12 +86,6 @@ private:
      * @param indexes - list of modelIndices to be deleted
      */
     void removeItems(const QModelIndexList& indexes);
-
-    /**
-     * @brief keyPressEvent
-     * @param event - key press event to handle
-     */
-    void keyPressEvent(QKeyEvent* event) override;
 
 private slots:
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1136

Workaround by calling copy method explicitly in keyevent of output dock (see issue #1175 for future fix)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
