### PR TITLE
Implemented proper style switching and memory management

### DIFF
--- a/src/gui/style/gt_palette.cpp
+++ b/src/gui/style/gt_palette.cpp
@@ -145,15 +145,6 @@ gt::gui::standardTheme()
     return p;
 }
 
-namespace
-{
-    GtStyle& getStyle()
-    {
-        static GtStyle s;
-        return s;
-    }
-}
-
 
 template <typename Widget>
 void setStyle(Widget& w);
@@ -161,7 +152,7 @@ void setStyle(Widget& w);
 template <>
 void setStyle(QWidget& w)
 {
-    w.setStyle(&getStyle());
+    w.setStyle(&GtStyle::current());
 }
 
 template <>

--- a/src/gui/style/gt_style.h
+++ b/src/gui/style/gt_style.h
@@ -23,6 +23,10 @@ class GtStyle : public QProxyStyle
     Q_OBJECT
 
 public:
+    /**
+     * @brief Returns the current style
+     */
+    static GtStyle& current();
 
     /// constructor
     GtStyle();


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The original implementation (GTlab 2.0.6) created a new GtStyle Object, whenever the style has been applied to a widget. All these objected leaked memory.

The first fix was, to simply create a singleton style and apply this to the Widgets. This was not sufficient though, as the style can change and style switching was not correct anymore.

This PR adds a StyleManager under the hood that creates and stores styles on the fly and returns references to the current style.

Closes #1174

## How Has This Been Tested?

In the GUI obviously. Switching styles now works without problems, memory should also not leak.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
