### PR TITLE
Reduced  scopes for property container entries

### DIFF
--- a/src/app/dock_widgets/properties/gt_propertycontainerwidget.cpp
+++ b/src/app/dock_widgets/properties/gt_propertycontainerwidget.cpp
@@ -142,7 +142,7 @@ GtPropertyContainerWidget::addNewEntry(GtPropertyStructContainer& container,
             QStringLiteral(" ") +
             QObject::tr("Entry added");
 
-    auto cmd = gtApp->makeCommand(gtApp->currentProject(), cmdStr);
+    auto cmd = gtApp->makeCommand(m_obj, cmdStr);
     Q_UNUSED(cmd)
 
     container.newEntry(entryType);

--- a/src/gui/dock_widgets/properties/gt_propertymodel.cpp
+++ b/src/gui/dock_widgets/properties/gt_propertymodel.cpp
@@ -18,9 +18,6 @@
 #include "gt_propertystructcontainer.h"
 #include "gt_structproperty.h"
 #include "gt_application.h"
-#include "gt_command.h"
-#include "gt_project.h"
-#include "gt_utilities.h"
 
 GtPropertyModel::GtPropertyModel(GtObject* scope,
                                  QObject* parent) :

--- a/src/gui/dock_widgets/properties/gt_propertymodel.cpp
+++ b/src/gui/dock_widgets/properties/gt_propertymodel.cpp
@@ -437,7 +437,7 @@ GtPropertyModel::addNewStructContainerEntry(
     GtPropertyStructInstance* newEntry = nullptr;
 
     {
-        auto cmd = gtApp->makeCommand(gtApp->currentProject(),
+        auto cmd = gtApp->makeCommand(m_scope,
                                       gt::propertyItemCommandString(
                                           m_obj->objectName(),
                                           container.name(),
@@ -503,7 +503,7 @@ GtPropertyModel::removeStructContainerEntry(const QModelIndex& index)
         return;
     }
 
-    auto cmd = gtApp->makeCommand(gtApp->currentProject(),
+    auto cmd = gtApp->makeCommand(m_scope,
                                   gt::propertyItemCommandString(
                                       m_obj->objectName(),
                                       container->name(),


### PR DESCRIPTION
Closes #568

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR reduces the command  scopes from the project to the actual GtObject, when property container are modified, i.e. entries are removed and added.

## How Has This Been Tested?

I tested  it in the GUI, undo/redo still works when changing the container entries.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
