### PR TITLE
Make tasks groups executable from console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved performance of the python syntax highlighter - #1139
 - (In-)active filter buttons for the logging level in the output dock are now better distinuishable. - #606 
 - Warning for unknown classes is now only shown in the developer mode of GTlab - #1160
+- Changed call of process execution in console application to enable call of tasks of different task groups- #1144
 
 ## [2.0.6] - 2023-11-07 
 ### Fixed

--- a/src/batch/CMakeLists.txt
+++ b/src/batch/CMakeLists.txt
@@ -13,6 +13,7 @@ set(headers
     gt_consoleparser.h
     gt_remoteprocessrunner.h
     gt_remoteprocessrunnerstates.h
+    gt_consolerunprocess.h
 )
 
 set(sources
@@ -21,6 +22,7 @@ set(sources
     gt_consoleparser.cpp
     gt_remoteprocessrunner.cpp
     gt_remoteprocessrunnerstates.cpp
+    gt_consolerunprocess.cpp
 )
 
 if (WIN32)

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -24,10 +24,7 @@
 
 #include "gt_coreapplication.h"
 #include "gt_coredatamodel.h"
-#include "gt_coreprocessexecutor.h"
 #include "gt_project.h"
-#include "gt_projectprovider.h"
-#include "gt_task.h"
 #include "gt_footprint.h"
 #include "gt_utilities.h"
 #include "gt_consoleparser.h"
@@ -64,20 +61,20 @@ checkMetaInput(const QStringList& args)
 
     if (p.positionalArguments().size() != 1)
     {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("Invalid size of arguments for check meta!"
-                                  "Exactly one argument is required");
+        gtWarning() << QStringLiteral("ERROR: ")
+                    << QObject::tr("Invalid size of arguments for check meta!"
+                                   "Exactly one argument is required");
         return -1;
     }
 
     QString fileName = p.positionalArguments().constFirst();
 
-    qDebug() << "meta input check...";
+    gtDebug() << QObject::tr("meta input check...");
 
     if (fileName.isEmpty())
     {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("file name is empty!");
+        gtWarning() << QStringLiteral("ERROR: ")
+                    << QObject::tr("file name is empty!");
         return -1;
     }
 
@@ -85,12 +82,12 @@ checkMetaInput(const QStringList& args)
                                GtCoreApplication::version().toString(),
                                false, false))
     {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("meta input invalid!");
+        gtWarning() << QStringLiteral("ERROR: ")
+                    << QObject::tr("meta input invalid!");
         return -1;
     }
 
-    qDebug() << "meta input ok!";
+    gtDebug() << QObject::tr("meta input ok!");
     return 0;
 }
 
@@ -102,8 +99,8 @@ runMetaInput(const QStringList& args)
 
     if (p.positionalArguments().size() < 2)
     {
-        qWarning() << "Invalid arguments for runMetaInput.";
-        qWarning() << "Two arguments needed as <Input> <Output>";
+        gtWarning() << QObject::tr("Invalid arguments for runMetaInput.");
+        gtWarning() << QObject::tr("Two arguments needed as <Input> <Output>");
 
         return -1;
     }
@@ -112,45 +109,45 @@ runMetaInput(const QStringList& args)
     QString inputFileName = p.positionalArguments().constFirst();
     QString outputFileName = p.positionalArguments().at(1);
 
-    qDebug() << "meta input run...";
+    gtDebug() << QObject::tr("meta input run...");
 
     if (inputFileName.isEmpty())
     {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("input file name is empty!");
+        gtWarning() << QStringLiteral("ERROR: ")
+                    << QObject::tr("input file name is empty!");
         return -1;
     }
 
     if (outputFileName.isEmpty())
     {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("output file name is empty!");
+        gtWarning() << QStringLiteral("ERROR: ")
+                    << QObject::tr("output file name is empty!");
         return -1;
     }
 
-    qDebug() << "   input file name: " << inputFileName;
-    qDebug() << "   output file name: " << outputFileName;
+    gtDebug() << "   input file name: " << inputFileName;
+    gtDebug() << "   output file name: " << outputFileName;
 
     int inputCheck = checkMetaInput({inputFileName});
 
     if (inputCheck != 0)
     {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("meta input run failed!");
+        gtWarning() << QStringLiteral("ERROR: ")
+                    << QObject::tr("meta input run failed!");
         return inputCheck;
     }
 
-    qDebug() << "executing process...";
+    gtDebug() << QObject::tr("executing process...");
 
     if (!gt::batch::run(inputFileName, outputFileName,
                         GtCoreApplication::version().toString()))
     {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("process execution failed!");
+        gtWarning() << QStringLiteral("ERROR: ")
+                    << QObject::tr("process execution failed!");
         return -1;
     }
 
-    qDebug() << "meta input run successful!";
+    gtDebug() << QObject::tr("meta input run successful!");
 
     return 0;
 }
@@ -743,23 +740,12 @@ initSystemOptions()
                     "\n\t\t\tUsage; run_meta <input.xml> <output.xml>");
 
     // run a process
-    QList<GtCommandLineOption> runOptions;
-    runOptions.append(GtCommandLineOption{
-                          {"save", "s"},
-                           "Saves datamodel after successfull process run"});
-    runOptions.append(GtCommandLineOption{
-                          {"name", "n"}, "Define project by name"});
-    runOptions.append(GtCommandLineOption{
-                          {"file", "f"}, "Define project by file"});
-    runOptions.append(GtCommandLineOption{
-                          {"task-group", "t"}, "Define task group to use"});
-
     initPosArgument("run", gt::console::run,
                     "\tExecutes a process. \n\t\t\t"
                     "To define a project name and a process name is the "
                     "default used option to execute this command."
                     "\n\t\t\tUse --help for more details.",
-                    runOptions,
+                    gt::console::options(),
                     QList<GtCommandLineArgument>(),
                     false);
 
@@ -805,15 +791,15 @@ initModuleTest(QStringList const& arguments, GtCoreApplication& app)
 
     if (p.positionalArguments().size() != 2)
     {
-        qCritical().noquote() << QObject::tr("Error: missing module file\n");
-        qInfo().noquote()     << QObject::tr("Usage: load_module <module_file_path>");
+        gtError().noquote() << QObject::tr("Error: missing module file\n");
+        gtInfo().noquote() << QObject::tr("Usage: load_module <module_file_path>");
         return -1;
     }
 
     // extract path to the module to load
     QString moduleToLoad = p.positionalArguments().at(1);
 
-    qDebug().noquote().nospace()
+    gtDebug().noquote().nospace()
         << "\n" << QObject::tr("Try loading module '%1'\n").arg(moduleToLoad);
 
     // load GTlab modules
@@ -827,7 +813,7 @@ initModuleTest(QStringList const& arguments, GtCoreApplication& app)
 
     const auto status = success ? QObject::tr("SUCCESS") : QObject::tr("ERROR");
 
-    qDebug().noquote() << QObject::tr("\n%1 loading module '%2'")
+    gtDebug().noquote() << QObject::tr("\n%1 loading module '%2'")
                               .arg(status, moduleToLoad);
 
     return success ? 0 : -1;
@@ -929,7 +915,7 @@ int main(int argc, char* argv[])
 
     if (!app.session())
     {
-        qWarning() << "no session loaded!";
+        gtWarning() << QObject::tr("no session loaded!");
         return -1;
     }
 
@@ -956,7 +942,8 @@ int main(int argc, char* argv[])
             return 0;
         }
 
-        qWarning() << "No valid argument could be found in the arguments:";
+        gtWarning() << QObject::tr("No valid argument could be found in the "
+                                   "arguments:");
         parser.debugArguments();
         return -1;
     }
@@ -984,12 +971,12 @@ int main(int argc, char* argv[])
     }
     else
     {
-        qCritical() << "Invalid command" << mainArg;
+        gtError() << QObject::tr("Invalid command") << mainArg;
         return -1;
     }
 
-    qWarning() << QObject::tr("invalid arguments! "
-                              "use run --help for further information.");
+    gtWarning() << QObject::tr("invalid arguments! "
+                               "use run --help for further information.");
 
     parser.showHelp();
 

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -61,9 +61,8 @@ checkMetaInput(const QStringList& args)
 
     if (p.positionalArguments().size() != 1)
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("Invalid size of arguments for check meta!"
-                                   "Exactly one argument is required");
+        gtError() << QObject::tr("Invalid size of arguments for check meta!"
+                                 "Exactly one argument is required");
         return -1;
     }
 
@@ -73,8 +72,7 @@ checkMetaInput(const QStringList& args)
 
     if (fileName.isEmpty())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("file name is empty!");
+        gtError() << QObject::tr("File name is empty!");
         return -1;
     }
 
@@ -82,8 +80,7 @@ checkMetaInput(const QStringList& args)
                                GtCoreApplication::version().toString(),
                                false, false))
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("meta input invalid!");
+        gtError() << QObject::tr("Meta input invalid!");
         return -1;
     }
 
@@ -99,8 +96,8 @@ runMetaInput(const QStringList& args)
 
     if (p.positionalArguments().size() < 2)
     {
-        gtWarning() << QObject::tr("Invalid arguments for runMetaInput.");
-        gtWarning() << QObject::tr("Two arguments needed as <Input> <Output>");
+        gtError() << QObject::tr("Invalid arguments for runMetaInput.");
+        gtError() << QObject::tr("Two arguments needed as <Input> <Output>");
 
         return -1;
     }
@@ -113,15 +110,13 @@ runMetaInput(const QStringList& args)
 
     if (inputFileName.isEmpty())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("input file name is empty!");
+        gtError() << QObject::tr("input file name is empty!");
         return -1;
     }
 
     if (outputFileName.isEmpty())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("output file name is empty!");
+        gtError() << QObject::tr("output file name is empty!");
         return -1;
     }
 
@@ -132,8 +127,7 @@ runMetaInput(const QStringList& args)
 
     if (inputCheck != 0)
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("meta input run failed!");
+        gtError() << QObject::tr("Meta input run failed!");
         return inputCheck;
     }
 
@@ -142,8 +136,7 @@ runMetaInput(const QStringList& args)
     if (!gt::batch::run(inputFileName, outputFileName,
                         GtCoreApplication::version().toString()))
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("process execution failed!");
+        gtError() << QObject::tr("process execution failed!");
         return -1;
     }
 
@@ -791,7 +784,7 @@ initModuleTest(QStringList const& arguments, GtCoreApplication& app)
 
     if (p.positionalArguments().size() != 2)
     {
-        gtError().noquote() << QObject::tr("Error: missing module file\n");
+        gtError().noquote() << QObject::tr("Missing module file\n");
         gtInfo().noquote() << QObject::tr("Usage: load_module <module_file_path>");
         return -1;
     }
@@ -915,7 +908,7 @@ int main(int argc, char* argv[])
 
     if (!app.session())
     {
-        gtWarning() << QObject::tr("no session loaded!");
+        gtError() << QObject::tr("no session loaded!");
         return -1;
     }
 
@@ -942,8 +935,8 @@ int main(int argc, char* argv[])
             return 0;
         }
 
-        gtWarning() << QObject::tr("No valid argument could be found in the "
-                                   "arguments:");
+        gtError() << QObject::tr("No valid argument could be found in the "
+                                 "arguments:");
         parser.debugArguments();
         return -1;
     }
@@ -975,8 +968,8 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    gtWarning() << QObject::tr("invalid arguments! "
-                               "use run --help for further information.");
+    gtError() << QObject::tr("invalid arguments! "
+                             "use run --help for further information.");
 
     parser.showHelp();
 

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -20,6 +20,7 @@
 
 #include "internal/gt_commandlinefunctionhandler.h"
 #include "batchremote.h"
+#include "gt_consolerunprocess.h"
 
 #include "gt_coreapplication.h"
 #include "gt_coredatamodel.h"
@@ -155,185 +156,6 @@ runMetaInput(const QStringList& args)
 }
 
 int
-runProcess(const QString& projectId, const QString& processId,
-           bool save = false)
-{
-    qDebug() << "process run...";
-
-    if (projectId.isEmpty())
-    {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("project id is empty!");
-
-        return -1;
-    }
-
-    if (processId.isEmpty())
-    {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("process id is empty!");
-
-        return -1;
-    }
-
-    GtProject* project = gtApp->findProject(projectId);
-
-    if (!project)
-    {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("project not found!") <<
-                   QStringLiteral(" (") << projectId << QStringLiteral(")");
-
-        return -1;
-    }
-
-    if (!gtDataModel->GtCoreDatamodel::openProject(project))
-    {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("could not open project!") <<
-                   QStringLiteral(" (") << projectId << QStringLiteral(")");
-
-        return -1;
-    }
-
-    qDebug() << "project opened!";
-
-    // run process
-    GtTask* process = project->findProcess(processId);
-
-    if (!process)
-    {
-        qWarning() << QStringLiteral("ERROR: ") <<
-                   QObject::tr("process not found!") <<
-                   QStringLiteral(" (") << processId << QStringLiteral(")");
-
-        return -1;
-    }
-
-    // execute process
-    gt::currentProcessExecutor().runTask(process);
-
-    if (process->currentState() != GtProcessComponent::FINISHED)
-    {
-        qWarning() << "Calculator run failed!";
-        return -1;
-    }
-
-    qDebug() << "process run successful!";
-
-    if (save)
-    {
-        if (!gtDataModel->saveProject(project))
-        {
-            qWarning() << QStringLiteral("ERROR: ") <<
-                       QObject::tr("project could not be saved!") <<
-                       QStringLiteral(" (") << projectId <<
-                       QStringLiteral(")");
-            return -1;
-        }
-    }
-
-    return 0;
-}
-
-int
-runProcessByFile(const QString& projectFile, const QString& processId,
-                 bool save = false)
-{
-    qDebug() << "process run...";
-
-    if (projectFile.isEmpty())
-    {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("project file is empty!");
-
-        return -1;
-    }
-
-    if (processId.isEmpty())
-    {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("process id is empty!");
-
-        return -1;
-    }
-
-    QFile file(projectFile);
-
-    if (!file.exists())
-    {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("project file")
-                   << projectFile
-                   << QObject::tr("not found!");
-
-        return -1;
-    }
-    //gtDebug() << "  |-> is existing file!";
-
-    GtProjectProvider provider(projectFile);
-    GtProject* project = provider.project();
-
-    if (!project)
-    {
-        gtError() << "Cannot load project";
-        return -1;
-    }
-
-    gtApp->session()->appendChild(project);
-
-    if (!gtDataModel->GtCoreDatamodel::openProject(project))
-    {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("could not open project!")
-                   << QStringLiteral(" (") << projectFile
-                   << QStringLiteral(")");
-
-        return -1;
-    }
-
-    qDebug() << "project opened!";
-
-    // run process
-    GtTask* process = project->findProcess(processId);
-    if (!process)
-    {
-        qWarning() << QStringLiteral("ERROR: ")
-                   << QObject::tr("process not found!")
-                   << QStringLiteral(" (") << processId << QStringLiteral(")");
-
-        return -1;
-    }
-
-    // execute process
-    auto& executor = gt::currentProcessExecutor();
-    executor.setCoreExecutorFlags(gt::DryExecution);
-    executor.runTask(process);
-
-    if (process->currentState() != GtProcessComponent::FINISHED)
-    {
-        qWarning() << "Calculator run failed!";
-        return -1;
-    }
-
-    qDebug() << "process run successful!";
-
-    if (save)
-    {
-        if (!gtDataModel->saveProject(project))
-        {
-            qWarning() << QStringLiteral("ERROR: ")
-                       << QObject::tr("project could not be saved!")
-                       << QStringLiteral(" (") << projectFile
-                       << QStringLiteral(")");
-            return -1;
-        }
-    }
-
-    return 0;
-}
-
-int
 processRunner(QStringList const& args)
 {
     auto port    = gt::process_runner::S_DEFAULT_PORT;
@@ -421,90 +243,6 @@ processRunner(QStringList const& args)
     GtRemoteProcessRunner runner;
 
     return runner.exec(client, port, timeout * 1000);
-}
-
-void
-printRunHelp()
-{
-    std::cout << std::endl;
-    std::cout << "This is the help for the GTlab run function" << std::endl;
-    std::cout << std::endl;
-
-    std::cout << "There are two basic methods to start a process:" << std::endl;
-    std::cout << "\tDefine the project by name from the current session"
-                 "(default option or --name or -n)" << std::endl;
-    std::cout << "\tGTlabConsole.exe run [-n] <fileName> <processname> [-s]  "
-              << std::endl;
-
-    std::cout << std::endl;
-    std::cout << "\tDefine the project by file (use the option --file or -f"
-              << std::endl;
-    std::cout << "\tGTlabConsole.exe run -f <projectName> <processname> [-s] "
-              << std::endl;
-
-    std::cout << std::endl;
-
-    std::cout << "\tAdditionally you can set the option -s or --save"
-              << std::endl;
-    std::cout << "\tWith this option the results of the successfull process are"
-              << " saved in the datamodel" << std::endl;
-
-    std::cout << std::endl;
-}
-
-int
-run(QStringList const& args)
-{
-    GtCommandLineParser p;
-    p.addHelpOption();
-    p.addOption("save", {"save", "s"},
-                "save the process result after successfull run");
-    p.addOption("file", {"file", "f"},
-                "file to gtlab project");
-    p.addOption("name", {"name", "n"},
-                "name of project in current session");
-
-    if (!p.parse(args))
-    {
-        qWarning() << "Run method without arguments is invalid";
-        return -1;
-    }
-
-    if (p.helpOption())
-    {
-        printRunHelp();
-        return 0;
-    }
-
-    bool save = false;
-
-    if (p.option("save"))
-    {
-        save = true;
-        std::cout << "Activate save option" << std::endl;
-    }
-
-    if (p.option("file"))
-    {
-        if (p.positionalArguments().size() != 2)
-        {
-            qWarning() << "Invalid usage of file option";
-            return -1;
-        }
-
-        return runProcessByFile(p.positionalArguments().at(0),
-                p.positionalArguments().at(1), save);
-    }
-
-    // default
-    if (p.positionalArguments().size() != 2)
-    {
-        qWarning() << "Invalid usage of name option";
-        return -1;
-    }
-
-    return runProcess(p.positionalArguments().at(0),
-                      p.positionalArguments().at(1), save);
 }
 
 int
@@ -1003,6 +741,8 @@ initSystemOptions()
                     "Executes given meta process data. "
                     "Results are stored in given output file."
                     "\n\t\t\tUsage; run_meta <input.xml> <output.xml>");
+
+    // run a process
     QList<GtCommandLineOption> runOptions;
     runOptions.append(GtCommandLineOption{
                           {"save", "s"},
@@ -1011,7 +751,10 @@ initSystemOptions()
                           {"name", "n"}, "Define project by name"});
     runOptions.append(GtCommandLineOption{
                           {"file", "f"}, "Define project by file"});
-    initPosArgument("run", run,
+    runOptions.append(GtCommandLineOption{
+                          {"task-group", "t"}, "Define task group to use"});
+
+    initPosArgument("run", gt::console::run,
                     "\tExecutes a process. \n\t\t\t"
                     "To define a project name and a process name is the "
                     "default used option to execute this command."

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -1,6 +1,7 @@
 /* GTlab - Gas Turbine laboratory
- * Source File:
- * copyright 2009-2023 by DLR
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
  *
  *  Created on: 15.04.2024
  *  Author: Jens Schmeink (AT-TWK)

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -1,0 +1,286 @@
+/* GTlab - Gas Turbine laboratory
+ * Source File:
+ * copyright 2009-2023 by DLR
+ *
+ *  Created on: 15.04.2024
+ *  Author: Jens Schmeink (AT-TWK)
+ *  Tel.: +49 2203 601 2191
+ */
+
+#include "gt_consolerunprocess.h"
+#include "gt_commandlineparser.h"
+
+#include "gt_coredatamodel.h"
+#include "gt_project.h"
+#include "gt_projectprovider.h"
+#include "gt_coreapplication.h"
+#include "gt_coreprocessexecutor.h"
+#include "gt_task.h"
+
+#include <QDebug>
+#include <iostream>
+#include <ostream>
+
+int
+gt::console::run(const QStringList &args)
+{
+    GtCommandLineParser p;
+    p.addHelpOption();
+    p.addOption("save", {"save", "s"},
+                "save the process result after successfull run");
+    p.addOption("file", {"file", "f"},
+                "file to gtlab project");
+    p.addOption("name", {"name", "n"},
+                "name of project in current session");
+
+    if (!p.parse(args))
+    {
+        qWarning() << "Run method without arguments is invalid";
+        return -1;
+    }
+
+    if (p.helpOption())
+    {
+        printRunHelp();
+        return 0;
+    }
+
+    bool save = false;
+
+    if (p.option("save"))
+    {
+        save = true;
+        std::cout << "Activate save option" << std::endl;
+    }
+
+    if (p.option("file"))
+    {
+        if (p.positionalArguments().size() != 2)
+        {
+            qWarning() << "Invalid usage of file option";
+            return -1;
+        }
+
+        return runProcessByFile(p.positionalArguments().at(0),
+                p.positionalArguments().at(1), save);
+    }
+
+    // default
+    if (p.positionalArguments().size() != 2)
+    {
+        qWarning() << "Invalid usage of name option";
+        return -1;
+    }
+
+    return runProcess(p.positionalArguments().at(0),
+                      p.positionalArguments().at(1), save);
+}
+
+void
+gt::console::printRunHelp()
+{
+    std::cout << std::endl;
+    std::cout << "This is the help for the GTlab run function" << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "There are two basic methods to start a process:" << std::endl;
+    std::cout << "\tDefine the project by name from the current session"
+                 "(default option or --name or -n)" << std::endl;
+    std::cout << "\tGTlabConsole.exe run [-n] <fileName> <processname> [-s]  "
+              << std::endl;
+
+    std::cout << std::endl;
+    std::cout << "\tDefine the project by file (use the option --file or -f"
+              << std::endl;
+    std::cout << "\tGTlabConsole.exe run -f <projectName> <processname> [-s] "
+              << std::endl;
+
+    std::cout << std::endl;
+
+    std::cout << "\tAdditionally you can set the option -s or --save"
+              << std::endl;
+    std::cout << "\tWith this option the results of the successfull process are"
+              << " saved in the datamodel" << std::endl;
+
+    std::cout << std::endl;
+}
+
+int
+gt::console::runProcess(const QString& projectId,
+                        const QString& processId,
+                        bool save)
+{
+    qDebug() << "process run...";
+
+    if (projectId.isEmpty())
+    {
+        qWarning() << QStringLiteral("ERROR: ") <<
+                   QObject::tr("project id is empty!");
+
+        return -1;
+    }
+
+    if (processId.isEmpty())
+    {
+        qWarning() << QStringLiteral("ERROR: ") <<
+                   QObject::tr("process id is empty!");
+
+        return -1;
+    }
+
+    GtProject* project = gtApp->findProject(projectId);
+
+    if (!project)
+    {
+        qWarning() << QStringLiteral("ERROR: ") <<
+                   QObject::tr("project not found!") <<
+                   QStringLiteral(" (") << projectId << QStringLiteral(")");
+
+        return -1;
+    }
+
+    if (!gtDataModel->GtCoreDatamodel::openProject(project))
+    {
+        qWarning() << QStringLiteral("ERROR: ") <<
+                   QObject::tr("could not open project!") <<
+                   QStringLiteral(" (") << projectId << QStringLiteral(")");
+
+        return -1;
+    }
+
+    qDebug() << "project opened!";
+
+    // run process
+    GtTask* process = project->findProcess(processId);
+
+    if (!process)
+    {
+        qWarning() << QStringLiteral("ERROR: ") <<
+                   QObject::tr("process not found!") <<
+                   QStringLiteral(" (") << processId << QStringLiteral(")");
+
+        return -1;
+    }
+
+    // execute process
+    gt::currentProcessExecutor().runTask(process);
+
+    if (process->currentState() != GtProcessComponent::FINISHED)
+    {
+        qWarning() << "Calculator run failed!";
+        return -1;
+    }
+
+    qDebug() << "process run successful!";
+
+    if (save)
+    {
+        if (!gtDataModel->saveProject(project))
+        {
+            qWarning() << QStringLiteral("ERROR: ") <<
+                       QObject::tr("project could not be saved!") <<
+                       QStringLiteral(" (") << projectId <<
+                       QStringLiteral(")");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int
+gt::console::runProcessByFile(const QString& projectFile,
+                              const QString& processId,
+                              bool save)
+{
+    qDebug() << "process run...";
+
+    if (projectFile.isEmpty())
+    {
+        qWarning() << QStringLiteral("ERROR: ")
+                   << QObject::tr("project file is empty!");
+
+        return -1;
+    }
+
+    if (processId.isEmpty())
+    {
+        qWarning() << QStringLiteral("ERROR: ")
+                   << QObject::tr("process id is empty!");
+
+        return -1;
+    }
+
+    QFile file(projectFile);
+
+    if (!file.exists())
+    {
+        qWarning() << QStringLiteral("ERROR: ")
+                   << QObject::tr("project file")
+                   << projectFile
+                   << QObject::tr("not found!");
+
+        return -1;
+    }
+
+    GtProjectProvider provider(projectFile);
+    GtProject* project = provider.project();
+
+    if (!project)
+    {
+        gtError() << "Cannot load project";
+        return -1;
+    }
+
+    gtApp->session()->appendChild(project);
+
+    if (!gtDataModel->GtCoreDatamodel::openProject(project))
+    {
+        qWarning() << QStringLiteral("ERROR: ")
+                   << QObject::tr("could not open project!")
+                   << QStringLiteral(" (") << projectFile
+                   << QStringLiteral(")");
+
+        return -1;
+    }
+
+    qDebug() << "project opened!";
+
+    // run process
+    GtTask* process = project->findProcess(processId);
+    if (!process)
+    {
+        qWarning() << QStringLiteral("ERROR: ")
+                   << QObject::tr("process not found!")
+                   << QStringLiteral(" (") << processId << QStringLiteral(")");
+
+        return -1;
+    }
+
+    // execute process
+    auto& executor = gt::currentProcessExecutor();
+    executor.setCoreExecutorFlags(gt::DryExecution);
+    executor.runTask(process);
+
+    if (process->currentState() != GtProcessComponent::FINISHED)
+    {
+        qWarning() << "Calculator run failed!";
+        return -1;
+    }
+
+    qDebug() << "process run successful!";
+
+    if (save)
+    {
+        if (!gtDataModel->saveProject(project))
+        {
+            qWarning() << QStringLiteral("ERROR: ")
+                       << QObject::tr("project could not be saved!")
+                       << QStringLiteral(" (") << projectFile
+                       << QStringLiteral(")");
+            return -1;
+        }
+    }
+
+    return 0;
+}

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -51,7 +51,7 @@ gt::console::run(const QStringList &args)
 
     if (!p.parse(args))
     {
-        gtWarning() << QObject::tr("Run method without arguments is invalid");
+        gtError() << QObject::tr("Run method without arguments is invalid");
         return -1;
     }
 
@@ -83,7 +83,7 @@ gt::console::run(const QStringList &args)
         else if (p.positionalArguments().size() < 2 ||
                 p.positionalArguments().size() > 3)
         {
-            gtWarning() << QObject::tr("Invalid usage of file option");
+            gtError() << QObject::tr("Invalid usage of file option");
             return -1;
         }
 
@@ -97,9 +97,9 @@ gt::console::run(const QStringList &args)
         taskGroup = p.positionalArguments().at(2);
     }
     else if (p.positionalArguments().size() < 2 ||
-            p.positionalArguments().size() > 3)
+             p.positionalArguments().size() > 3)
     {
-        gtWarning() << QObject::tr("Invalid usage of file option");
+        gtError() << QObject::tr("Invalid usage of file option");
         return -1;
     }
 
@@ -156,16 +156,14 @@ gt::console::runProcess(const QString& projectId,
 
     if (projectId.isEmpty())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("project id is empty!");
+        gtError() << QObject::tr("Project id is empty!");
 
         return -1;
     }
 
     if (processId.isEmpty())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("process id is empty!");
+        gtError() << QObject::tr("Process id is empty!");
 
         return -1;
     }
@@ -174,40 +172,28 @@ gt::console::runProcess(const QString& projectId,
 
     if (!project)
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("project not found!")
-                    << QStringLiteral(" (") << projectId << QStringLiteral(")");
+        gtError() << QObject::tr("Project not found!")
+                  << QStringLiteral(" (") << projectId << QStringLiteral(")");
 
         return -1;
     }
 
     if (!gtDataModel->GtCoreDatamodel::openProject(project))
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("could not open project!")
-                    << QStringLiteral(" (") << projectId << QStringLiteral(")");
+        gtError() << QObject::tr("could not open project!")
+                  << QStringLiteral(" (") << projectId << QStringLiteral(")");
 
         return -1;
     }
 
     gtDebug() << QObject::tr("project opened!");
 
-    GtTask* process = nullptr;
-
-    if (taskGroupId.isEmpty())
-    {
-        process = project->findProcess(processId);
-    }
-    else
-    {
-        process = getTask(project, taskGroupId, processId);
-    }
+    GtTask* process = getTask(project, processId, taskGroupId);
 
     if (!process)
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("process not found!")
-                    << QStringLiteral(" (") << processId << QStringLiteral(")");
+        gtError() << QObject::tr("Process not found!")
+                  << QStringLiteral(" (") << processId << QStringLiteral(")");
 
         return -1;
     }
@@ -217,7 +203,7 @@ gt::console::runProcess(const QString& projectId,
 
     if (process->currentState() != GtProcessComponent::FINISHED)
     {
-        gtWarning() << QObject::tr("Calculator run failed!");
+        gtError() << QObject::tr("Calculator run failed!");
         return -1;
     }
 
@@ -227,10 +213,9 @@ gt::console::runProcess(const QString& projectId,
     {
         if (!gtDataModel->saveProject(project))
         {
-            gtWarning() << QStringLiteral("ERROR: ")
-                        << QObject::tr("project could not be saved!")
-                        << QStringLiteral(" (") << projectId
-                        << QStringLiteral(")");
+            gtError() << QObject::tr("Project could not be saved!")
+                      << QStringLiteral(" (") << projectId
+                      << QStringLiteral(")");
             return -1;
         }
     }
@@ -248,16 +233,14 @@ gt::console::runProcessByFile(const QString& projectFile,
 
     if (projectFile.isEmpty())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("project file is empty!");
+        gtError() << QObject::tr("Project file is empty!");
 
         return -1;
     }
 
     if (processId.isEmpty())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("process id is empty!");
+        gtError() << QObject::tr("Process id is empty!");
 
         return -1;
     }
@@ -266,10 +249,9 @@ gt::console::runProcessByFile(const QString& projectFile,
 
     if (!file.exists())
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("project file")
-                    << projectFile
-                    << QObject::tr("not found!");
+        gtError() << QObject::tr("project file")
+                  << projectFile
+                  << QObject::tr("not found!");
 
         return -1;
     }
@@ -287,10 +269,9 @@ gt::console::runProcessByFile(const QString& projectFile,
 
     if (!gtDataModel->GtCoreDatamodel::openProject(project))
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("could not open project!")
-                    << QStringLiteral(" (") << projectFile
-                    << QStringLiteral(")");
+        gtError() << QObject::tr("Could not open project!")
+                  << QStringLiteral(" (") << projectFile
+                  << QStringLiteral(")");
 
         return -1;
     }
@@ -301,9 +282,8 @@ gt::console::runProcessByFile(const QString& projectFile,
     GtTask* process = project->findProcess(processId);
     if (!process)
     {
-        gtWarning() << QStringLiteral("ERROR: ")
-                    << QObject::tr("process not found!")
-                    << QStringLiteral(" (") << processId << QStringLiteral(")");
+        gtError() << QObject::tr("Process not found!")
+                  << QStringLiteral(" (") << processId << QStringLiteral(")");
 
         return -1;
     }
@@ -325,10 +305,9 @@ gt::console::runProcessByFile(const QString& projectFile,
     {
         if (!gtDataModel->saveProject(project))
         {
-            gtWarning() << QStringLiteral("ERROR: ")
-                        << QObject::tr("project could not be saved!")
-                        << QStringLiteral(" (") << projectFile
-                        << QStringLiteral(")");
+            gtError() << QObject::tr("project could not be saved!")
+                      << QStringLiteral(" (") << projectFile
+                      << QStringLiteral(")");
             return -1;
         }
     }
@@ -339,17 +318,21 @@ gt::console::runProcessByFile(const QString& projectFile,
 
 
 GtTask*
-gt::console::getTask(GtProject* project, const QString& groupid,
-                     const QString& taskId)
+gt::console::getTask(GtProject* project,
+                     const QString& taskId, const QString& groupid)
 {
     if (!project) return nullptr;
+
+    if (groupid.isEmpty())
+    {
+        return project->findProcess(taskId);
+    }
 
     GtProcessData* processData = project->processData();
 
     if (!processData)
     {
-        gtError() << QStringLiteral("ERROR:")
-                  << QObject::tr("Invalid Process data in project!")
+        gtError() << QObject::tr("Invalid Process data in project!")
                   << QStringLiteral(" (") << project->objectName()
                   << QStringLiteral(")");
         return nullptr;
@@ -361,14 +344,13 @@ gt::console::getTask(GtProject* project, const QString& groupid,
 
     if (!check)
     {
-        processData->switchCurrentTaskGroup(groupid, GtTaskGroup::USER,
-                                            project->path());
+        check = processData->switchCurrentTaskGroup(groupid, GtTaskGroup::USER,
+                                                    project->path());
     }
 
     if (!check)
     {
-        gtError() << QStringLiteral("ERROR:")
-                  << QObject::tr("Cannot switch to grouId '%1'!").arg(groupid);
+        gtError() << QObject::tr("Cannot switch to grouId '%1'!").arg(groupid);
         return nullptr;
     }
 

--- a/src/batch/gt_consolerunprocess.h
+++ b/src/batch/gt_consolerunprocess.h
@@ -30,8 +30,9 @@ int run(QStringList const& args);
 
 void printRunHelp();
 
-GtTask* getTask(GtProject* project, QString const& groupid,
-                QString const& taskId);
+GtTask* getTask(GtProject* project,
+                QString const& taskId,
+                QString const& groupid = "");
 
 /**
  * @brief runProcess

--- a/src/batch/gt_consolerunprocess.h
+++ b/src/batch/gt_consolerunprocess.h
@@ -1,6 +1,7 @@
 /* GTlab - Gas Turbine laboratory
- * Source File:
- * copyright 2009-2023 by DLR
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
  *
  *  Created on: 15.04.2024
  *  Author: Jens Schmeink (AT-TWK)

--- a/src/batch/gt_consolerunprocess.h
+++ b/src/batch/gt_consolerunprocess.h
@@ -1,0 +1,34 @@
+/* GTlab - Gas Turbine laboratory
+ * Source File:
+ * copyright 2009-2023 by DLR
+ *
+ *  Created on: 15.04.2024
+ *  Author: Jens Schmeink (AT-TWK)
+ *  Tel.: +49 2203 601 2191
+ */
+#ifndef GTCONSOLERUNPROCESS_H
+#define GTCONSOLERUNPROCESS_H
+
+#include <QStringList>
+
+namespace gt
+{
+namespace console
+{
+
+int run(QStringList const& args);
+
+void printRunHelp();
+
+int
+runProcess(const QString& projectId, const QString& processId,
+           bool save = false);
+
+int
+runProcessByFile(const QString& projectFile, const QString& processId,
+                 bool save = false);
+
+} // namespace console
+} // namespace gt
+
+#endif // GTCONSOLERUNPROCESS_H

--- a/src/batch/gt_consolerunprocess.h
+++ b/src/batch/gt_consolerunprocess.h
@@ -9,23 +9,53 @@
 #ifndef GTCONSOLERUNPROCESS_H
 #define GTCONSOLERUNPROCESS_H
 
+#include "gt_commandlineparser.h"
 #include <QStringList>
+
+class GtProject;
+class GtTask;
 
 namespace gt
 {
 namespace console
 {
+/**
+ * @brief options
+ * @return list of the command line options
+ */
+QList<GtCommandLineOption> options();
 
 int run(QStringList const& args);
 
 void printRunHelp();
 
+GtTask* getTask(GtProject* project, QString const& groupid,
+                QString const& taskId);
+
+/**
+ * @brief runProcess
+ * @param projectId - id of the project in the given session
+ * @param processId - id of the task to start
+ * @param taskGroupId - if empty string the default task group will be used
+ * @param save
+ * @return
+ */
 int
 runProcess(const QString& projectId, const QString& processId,
+           const QString& taskGroupId = "",
            bool save = false);
 
+/**
+ * @brief runProcessByFile
+ * @param projectFile - project file to run the process from
+ * @param processId - id of the task to start
+ * @param taskGroupId - if empty string the default task group will be used
+ * @param save
+ * @return
+ */
 int
 runProcessByFile(const QString& projectFile, const QString& processId,
+                 const QString& taskGroupId = "",
                  bool save = false);
 
 } // namespace console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

If a task is organized in a task group which might not be the default group (normally the users group) the task cannot be executed in the console application.

This is fixed in this PR.
Call the run function now as following:
GTlabConsole run <PROJECT_ID> <TASK_ID> <TASK_GROUP_ID> (last one is optional)

## Description
If the given <TASK_GROUP_ID> is not empty the task group is switched to the given group and the task is searched and if found executed. 
For a cleanup of the batch the functions related to process execution are extracted to new files in a new namespace.

## How Has This Been Tested?
Manual tests of execution of a task which is part of another task group


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
