### PR TITLE
Resolve "Add app setting to change logging level at runtime"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed copying in output dock using keyboard shortcut sometimes not working as expected. - #1136
 
 ### Added
-- Added app setting to change logging level at runtime. - #1086
+- Added setting to the output dock to change logging level at runtime. - #1086
 
 ### Changed
 - Improved performance of the python syntax highlighter - #1139

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unicode characters not correctly saved to tasks, in particular python tasks and file properties - #1125, #45
 - Fixed copying in output dock using keyboard shortcut sometimes not working as expected. - #1136
 
+### Added
+- Added app setting to change logging level at runtime. - #1086
+
 ### Changed
 - Improved performance of the python syntax highlighter - #1139
 - (In-)active filter buttons for the logging level in the output dock are now better distinuishable. - #606 

--- a/src/app/dock_widgets/output/gt_outputdock.cpp
+++ b/src/app/dock_widgets/output/gt_outputdock.cpp
@@ -295,15 +295,6 @@ GtOutputDock::GtOutputDock()
 
     defaultLayout->addLayout(filterLayout);
 
-    if (loggingLevel > gt::log::TraceLevel)
-    {
-        m_traceButton->hide();
-    }
-    if (loggingLevel > gt::log::DebugLevel)
-    {
-        m_debugButton->hide();
-    }
-
     layout->addWidget(tab);
 
     widget->setLayout(layout);

--- a/src/app/preferences/pages/gt_preferencesapp.cpp
+++ b/src/app/preferences/pages/gt_preferencesapp.cpp
@@ -33,23 +33,10 @@ struct LoggingVerbosity
     QString name;
 };
 
-struct LoggingLevel
-{
-    gt::log::Level level;
-    QString name;
-};
-
 std::array<LoggingVerbosity, 3> const s_verbosityLevels{
     LoggingVerbosity{gt::log::Silent    , QStringLiteral("Silent")},
     LoggingVerbosity{gt::log::Medium    , QStringLiteral("Medium")},
     LoggingVerbosity{gt::log::Everything, QStringLiteral("High")  }
-};
-
-std::array<LoggingLevel, 4> const s_loggingLevels{
-    LoggingLevel{gt::log::TraceLevel,   QStringLiteral("Trace-Level")},
-    LoggingLevel{gt::log::DebugLevel,   QStringLiteral("Debug-Level")},
-    LoggingLevel{gt::log::InfoLevel,    QStringLiteral("User-Level")},
-    LoggingLevel{gt::log::WarningLevel, QStringLiteral("Warnings only")}
 };
 
 GtPreferencesApp::GtPreferencesApp() :
@@ -95,15 +82,6 @@ GtPreferencesApp::GtPreferencesApp() :
     m_verbositySelection = new QComboBox;
     m_verbositySelection->addItems(verbosityLevels);
     formLay->addRow(tr("Logging verbosity:"), m_verbositySelection);
-
-    // order verbosity levels depending on their value
-    QStringList loggingLevels;
-    std::transform(std::begin(s_loggingLevels), std::end(s_loggingLevels),
-                   std::back_inserter(loggingLevels), [](auto const& entry){
-        return entry.name;
-    });
-    m_loggingLevelSelection = new QComboBox;
-    m_loggingLevelSelection->addItems(loggingLevels);
     formLay->addRow(tr("Logging level:"), m_loggingLevelSelection);
 
     m_themeSelection = new QComboBox(this);
@@ -176,24 +154,6 @@ GtPreferencesApp::GtPreferencesApp() :
         }
     }
 
-    // logging level
-    {
-        // not using logging level setting here to get actual logging level
-        gt::log::Level loggingLevel = gt::log::Logger::instance().loggingLevel();
-
-        // set verbosity text
-        auto iter = std::find_if(std::begin(s_loggingLevels),
-                                 std::end(s_loggingLevels),
-                                 [=](auto const& entry){
-            return loggingLevel <= entry.level;
-        });
-
-        if (iter != std::end(s_loggingLevels))
-        {
-            m_loggingLevelSelection->setCurrentText(iter->name);
-        }
-    }
-
     // theme selection
     QString themeMode = settings->themeMode();
     if (themeMode == "bright")
@@ -239,26 +199,6 @@ GtPreferencesApp::saveSettings(GtSettings& settings) const
 
         settings.setLoggingVerbosity(verbosity);
         gt::log::Logger::instance().setVerbosity(verbosity);
-    }
-
-    // logging level
-    {
-        auto loggingLevelText = m_loggingLevelSelection->currentText();
-        auto loggingLevel = gt::log::Logger::instance().loggingLevel();
-
-        auto iter = std::find_if(std::begin(s_loggingLevels),
-                                 std::end(s_loggingLevels),
-                                 [&](auto const& entry){
-            return loggingLevelText == entry.name;
-        });
-
-        if (iter != std::end(s_loggingLevels))
-        {
-            loggingLevel = iter->level;
-        }
-
-        settings.setLoggingLevel(loggingLevel);
-        gt::log::Logger::instance().setLoggingLevel(loggingLevel);
     }
 
     // process executor

--- a/src/app/preferences/pages/gt_preferencesapp.cpp
+++ b/src/app/preferences/pages/gt_preferencesapp.cpp
@@ -82,7 +82,6 @@ GtPreferencesApp::GtPreferencesApp() :
     m_verbositySelection = new QComboBox;
     m_verbositySelection->addItems(verbosityLevels);
     formLay->addRow(tr("Logging verbosity:"), m_verbositySelection);
-    formLay->addRow(tr("Logging level:"), m_loggingLevelSelection);
 
     m_themeSelection = new QComboBox(this);
     m_themeSelection->addItem(tr("System selection"));

--- a/src/app/preferences/pages/gt_preferencesapp.h
+++ b/src/app/preferences/pages/gt_preferencesapp.h
@@ -62,9 +62,6 @@ private:
     /// Select the logging verbosity
     QComboBox* m_verbositySelection;
 
-    /// Select the logging level
-    QComboBox* m_loggingLevelSelection;
-
     /// Select the theme to use (by system, dark, bright)
     QComboBox* m_themeSelection;
 

--- a/src/app/preferences/pages/gt_preferencesapp.h
+++ b/src/app/preferences/pages/gt_preferencesapp.h
@@ -62,6 +62,9 @@ private:
     /// Select the logging verbosity
     QComboBox* m_verbositySelection;
 
+    /// Select the logging level
+    QComboBox* m_loggingLevelSelection;
+
     /// Select the theme to use (by system, dark, bright)
     QComboBox* m_themeSelection;
 
@@ -70,7 +73,7 @@ private slots:
      * @brief onAutoSaveTriggered
      * @param val
      */
-    void onAutoSaveTriggered(bool val);
+    [[deprecated]] void onAutoSaveTriggered(bool val);
 
 };
 

--- a/src/core/gt_coreapplication.cpp
+++ b/src/core/gt_coreapplication.cpp
@@ -333,7 +333,7 @@ GtCoreApplication::initLogging()
     }
     else
     {
-        logger.setLoggingLevel(gt::log::InfoLevel);
+        logger.setLoggingLevel(gt::log::levelFromInt(m_settings->loggingLevel()));
     }
 
     // TODO: Remove this if block in GTlab 2.1 (see !294)

--- a/src/core/settings/gt_settings.cpp
+++ b/src/core/settings/gt_settings.cpp
@@ -10,13 +10,13 @@
 
 #include "gt_settings.h"
 #include "gt_settingsitem.h"
+#include "gt_loglevel.h"
 
 #include <QDir>
 #include <QSettings>
 #include <QMap>
 #include <QKeySequence>
 #include <QString>
-
 
 struct GtSettings::Impl
 {
@@ -56,6 +56,8 @@ struct GtSettings::Impl
 
     ///
     GtSettingsItem* loggingVerbosity;
+
+    GtSettingsItem* loggingLevel;
 
     ///
     GtSettingsItem* lastProcessElements;
@@ -115,6 +117,9 @@ GtSettings::GtSettings()
     pimpl->loggingVerbosity = registerSetting(
                          QStringLiteral("application/general/loggingVerbosity"),
                          (int) 0);
+    pimpl->loggingLevel = registerSetting(
+                         QStringLiteral("application/general/loggingLevel"),
+                         (int)gt::log::InfoLevel);
     pimpl->lastProcessElements =
             registerSetting(
                 QStringLiteral("application/process/lastelements"),
@@ -486,6 +491,18 @@ int
 GtSettings::loggingVerbosity() const
 {
     return pimpl->loggingVerbosity->getValue().toInt();
+}
+
+void
+GtSettings::setLoggingLevel(int value)
+{
+    pimpl->loggingLevel->setValue(value);
+}
+
+int
+GtSettings::loggingLevel() const
+{
+    return pimpl->loggingLevel->getValue().toInt();
 }
 
 void

--- a/src/core/settings/gt_settings.h
+++ b/src/core/settings/gt_settings.h
@@ -275,6 +275,18 @@ public:
     int loggingVerbosity() const;
 
     /**
+     * @brief Setter for the logging level (see gt::log::Level)
+     * @param value
+     */
+    void setLoggingLevel(int value);
+
+    /**
+     * @brief Getter for the logging level (see gt::log::Level)
+     * @return Logging Level
+     */
+    int loggingLevel() const;
+
+    /**
      * @brief Sets last used process elements.
      * @param list List of last used process element class names.
      */

--- a/src/gui/style/gt_palette.cpp
+++ b/src/gui/style/gt_palette.cpp
@@ -58,16 +58,18 @@ generateTheme(ColorConfig const& config)
 
     // tones
     /// QPalette::Dark: Apperantly affects the lower part of a raised frame
+    /// the bottom part of sunken frame
     palette.setColor(QPalette::Dark,
                      gt::gui::color::darken(config.main, 40));
 
-    /// QPalette::Mid:
+    /// QPalette::Mid: ???
     palette.setColor(QPalette::Mid,
                      gt::gui::color::darken(config.main, 20));
 
     /// QPalette::Midlight: ???
 
-    /// QPalette::Light: Apperantly affects the top part of a raised frame
+    /// QPalette::Light: Apperantly affects the top part of a raised frame and
+    /// the lower part of sunken frame
     palette.setColor(QPalette::Light,
                      gt::gui::color::lighten(
                          gt::gui::color::desaturate(config.main, 0.5), 20));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1086.

Added setting to change logging level at runtime. Will remember selection, however, arguments like `--debug` or `--dev` will override this setting but only for the duration of the session. If the logging level is overridden and the preferences dialog is opened and saved the logging level is changed permanently to the overridden logging level.

![grafik](https://github.com/dlr-gtlab/gtlab-core/assets/52258575/fda32ea4-916f-4ef9-927e-55835a423275)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
