### PR TITLE
Remove duble registration of tasks

### DIFF
--- a/src/core/process_management/gt_processmoduleloader.cpp
+++ b/src/core/process_management/gt_processmoduleloader.cpp
@@ -143,8 +143,8 @@ GtProcessModuleLoader::insert(GtModuleInterface* plugin)
 
         for (GtTaskData const& taskData : taskDataList)
         {
+            // includes registration in objectFactory
             gtTaskFactory->registerTaskData(taskData);
-            gtObjectFactory->registerClass(taskData->metaData());
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As mentioned in the issue description the tasks of the modules were registered twice as seen by a warning in the logging.

This double registration was caused by a doubled execution of the registerClass function of the objectFactory
This was removed

## Description
I removed the second call of the registration

## How Has This Been Tested?
I started GTlab. My processes worked fine while the warning in the logging system did not appear anymore


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
