### PR TITLE
Fix "Move rows failed" error message

### DIFF
--- a/src/gui/dock_widgets/process/gt_processcomponentmodel.cpp
+++ b/src/gui/dock_widgets/process/gt_processcomponentmodel.cpp
@@ -616,10 +616,7 @@ GtProcessComponentModel::dropMimeData(const QMimeData* mimeData,
         if (!moveRow(droppedObjectParentIndex, droppedObjectSrcRow,
                      destinationIndex, row))
         {
-            if (gtApp->devMode())
-            {
-                gtFatal() << "move rows failed!";
-            }
+            gtDebug() << tr("Move rows failed!");
 
             return false;
         }
@@ -636,12 +633,7 @@ GtProcessComponentModel::dropMimeData(const QMimeData* mimeData,
         if (!moveRow(droppedObjectParentIndex, droppedObjectSrcRow,
                      destinationIndex, destinationRowCount))
         {
-            if (gtApp->devMode())
-            {
-                // more checks in canDropMimeData function to prevent moveRow
-                // function return false.
-                gtFatal() << "move rows failed!";
-            }
+            gtDebug() << tr("Move rows failed!");
 
             return false;
         }


### PR DESCRIPTION
## Description
There is an error message implemented (currently not apperaing anymore, which logged some fatal lines but only in devmode.

This is now changed to logging also in non-dev-mode but only with gtDebug as it is a message for debugging.

## How Has This Been Tested?
Cannot reproduce occurance so cannot test


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
