### PR TITLE
Reduced scope of the import menu command

### DIFF
--- a/src/gui/importer/gt_importmenu.cpp
+++ b/src/gui/importer/gt_importmenu.cpp
@@ -135,7 +135,7 @@ GtImportMenu::onActionTrigger(QObject* obj)
                              QStringLiteral(" ") +
                              m_obj->objectName();
 
-            auto command = gtApp->makeCommand(project, msg);
+            auto command = gtApp->makeCommand(m_obj, msg);
             Q_UNUSED(command)
 
             m_obj->applyDiff(diff);


### PR DESCRIPTION
Closes #1188

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

 - I first checked, that the command is actually used by commenting it out: Undo was not available, great!
 - Then you changed the code to use the enclosing object, Undo is working again 😄 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
