### PR TITLE
Resolve "fix GtEventLoop running indefintely if timeout was set to 0"

### DIFF
--- a/src/dataprocessor/gt_eventloop.cpp
+++ b/src/dataprocessor/gt_eventloop.cpp
@@ -56,7 +56,7 @@ GtEventLoop::exec()
 {
     // trigger eventloop and timeout
     QTimer timer;
-    if (m_mstimeout > 0)
+    if (m_mstimeout >= 0)
     {
         timer.setSingleShot(true);
         connectFailed(&timer, &QTimer::timeout);

--- a/tests/unittests/datamodel/test_gt_eventloop.cpp
+++ b/tests/unittests/datamodel/test_gt_eventloop.cpp
@@ -15,7 +15,7 @@
 #include <QTimer>
 
 static const int timeout = 1 * 1000;
-static const int no_timeout = 0 * 1000;
+static const int no_timeout = 0;
 
 class TestGtEventLoop :
         public ::testing::TestWithParam<int>

--- a/tests/unittests/datamodel/test_gt_eventloop.cpp
+++ b/tests/unittests/datamodel/test_gt_eventloop.cpp
@@ -11,55 +11,64 @@
 #include "gtest/gtest.h"
 
 #include "gt_eventloop.h"
-#include "gt_object.h"
 
 #include <QTimer>
 
 static const int timeout = 1 * 1000;
+static const int no_timeout = 0 * 1000;
 
-class TestGtEventLoop : public testing::Test {};
+class TestGtEventLoop :
+        public ::testing::TestWithParam<int>
+{ };
 
-TEST_F(TestGtEventLoop, timeout)
+
+INSTANTIATE_TEST_SUITE_P(
+    TestGtEventLoop,
+    TestGtEventLoop,
+    ::testing::Values(timeout, no_timeout));
+
+
+TEST_P(TestGtEventLoop, timeout)
 {
-    GtEventLoop future{timeout};
+    GtEventLoop future{GetParam()};
 
     // future is not connected -> timeout
     EXPECT_TRUE(future.exec() == GtEventLoop::Failed);
 }
 
-TEST_F(TestGtEventLoop, success)
+TEST_P(TestGtEventLoop, success)
 {
     QTimer timer;
-    GtEventLoop loop{2 * timeout};
+    GtEventLoop loop{2 * (GetParam()+1)};
 
     loop.connectSuccess(&timer, &QTimer::timeout);
 
-    timer.start(timeout);
+    timer.start(GetParam());
 
     // future should wait until signal is emitted
     EXPECT_TRUE(loop.exec() == GtEventLoop::Success);
 }
 
-TEST_F(TestGtEventLoop, preliminaryState)
+TEST_P(TestGtEventLoop, preliminaryState)
 {
-    GtEventLoop loop{timeout};
+    GtEventLoop loop{GetParam()};
 
     // emitted before even loop
     emit loop.success();
 
-    // future should finish righ away
+    // future should finish right away
     EXPECT_TRUE(loop.exec() == GtEventLoop::Success);
 }
 
-TEST_F(TestGtEventLoop, multiplePreliminaryState)
+TEST_P(TestGtEventLoop, multiplePreliminaryState)
 {
-    GtEventLoop loop{timeout};
+    GtEventLoop loop{GetParam()};
 
     // emitted before even loop
     emit loop.abort();
     emit loop.success();
 
-    // future should finish righ away
+    // future should finish right away
     EXPECT_TRUE(loop.exec() == GtEventLoop::Success);
     // now loop will run into timeout
     EXPECT_TRUE(loop.exec() == GtEventLoop::Failed);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1154 

Fixed `GtEventLoop` not returning if timeout was set to 0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Checked usages of `GtEventLoop`
- Added Unittests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
