### PR TITLE
Reset scope for undo_redo commands in process dock

### DIFF
--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1456,7 +1456,7 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
             }
         }
 
-        auto moveCmd = gtApp->makeCommand(gtApp->currentProject(),
+        auto moveCmd = gtApp->makeCommand(m_taskGroup,
                                           tr("move tasks element"));
         for (auto o : objectsToMove)
         {
@@ -1693,7 +1693,7 @@ GtProcessDock::cutElement(const QModelIndex& index)
     toDelete.append(pComp);
 
     auto command =
-        gtApp->makeCommand(gtApp->currentProject(),
+        gtApp->makeCommand(m_taskGroup,
                            tr("Cut Process Element") +
                            QStringLiteral(" (") + obj->objectName() +
                            QStringLiteral(")"));
@@ -1773,7 +1773,7 @@ GtProcessDock::deleteProcessElements(const QList<QModelIndex>& indexList)
         {
             gtDataModel->reduceToParents(objects);
 
-            auto cmd = gtApp->makeCommand(gtApp->currentProject(),
+            auto cmd = gtApp->makeCommand(m_taskGroup,
                                           tr("Delete Process Elements"));
             Q_UNUSED(cmd)
 
@@ -1863,7 +1863,7 @@ GtProcessDock::pasteElement(GtObject* obj, GtObject* parent)
 
     m_view->setFocus();
 
-    auto pasteCmd = gtApp->makeCommand(gtApp->currentProject(),
+    auto pasteCmd = gtApp->makeCommand(m_taskGroup,
                                        tr("Paste process element"));
 
     auto const propCons = obj->findChildren<GtPropertyConnection*>();
@@ -1943,7 +1943,7 @@ GtProcessDock::skipComponent(const QModelIndex& index, bool skip)
     QString msg = tr("%1 selected Process Elements")
                   .arg(skip ? tr("Skip") : tr("Unskip"));
 
-    auto cmd = gtApp->makeCommand(gtApp->currentProject(), msg);
+    auto cmd = gtApp->makeCommand(m_taskGroup, msg);
     Q_UNUSED(cmd)
 
     skipComponent(componentByModelIndex(index), skip);
@@ -1969,7 +1969,7 @@ GtProcessDock::skipComponent(const QList<QModelIndex>& indexList, bool skip)
     QString msg = tr("%1 selected Process Elements")
                   .arg(skip ? tr("Skip") : tr("Unskip"));
 
-    auto cmd = gtApp->makeCommand(gtApp->currentProject(), msg);
+    auto cmd = gtApp->makeCommand(m_taskGroup, msg);
     Q_UNUSED(cmd)
 
     for (GtProcessComponent* pc : qAsConst(pcs))
@@ -2178,7 +2178,9 @@ GtProcessDock::openConnectionEditor(const QModelIndex& index)
 void
 GtProcessDock::onRowsAboutToBeMoved()
 {
-    m_command = gtApp->startCommand(gtApp->currentProject(),
+    assert(m_taskGroup);
+
+    m_command = gtApp->startCommand(m_taskGroup,
                                     tr("Process elements moved"));
 }
 

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1476,7 +1476,7 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
     if (!targetComp) return;
 
 
-    auto* commonParent = gt::find_lowest_ancestor(objectsToMove,
+    auto* commonParent = gt::find_lowest_ancestor(objectsToMove << targetComp,
                                                   gt::get_parent_object);
     assert(commonParent);
 
@@ -1923,10 +1923,13 @@ GtProcessDock::skipComponent(const QModelIndex& index, bool skip)
     QString msg = tr("%1 selected Process Elements")
                   .arg(skip ? tr("Skip") : tr("Unskip"));
 
-    auto cmd = gtApp->makeCommand(m_taskGroup, msg);
-    Q_UNUSED(cmd)
-
-    skipComponent(componentByModelIndex(index), skip);
+    auto* comp = componentByModelIndex(index);
+    if (!comp) return;
+    
+    auto cmd = gtApp->makeCommand(comp, msg);
+    Q_UNUSED(cmd);
+    
+    skipComponent(comp, skip);
 }
 
 void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The scope for the change commands in the process dock are changed to not use the whole currentProject but 

## Description
The commands to determine the changes to keep in the undo/redo system got a more specific scope: the current selected task group

## How Has This Been Tested?
I startet GTlab with a project with multiple task groups and tasks in it. I did several actions like moving, copy, paste, ... and no problem occured but undo was possible.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
