### PR TITLE
Draft: Resolve "Allow to detach MDI Tabs to make them their own standalone widget"

### DIFF
--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -397,6 +397,9 @@ GtMainWin::closeEvent(QCloseEvent* event)
         m_undoView->close();
     }
 
+    assert(GtMdiLauncher::instance());
+    GtMdiLauncher::instance()->close();
+
     QMainWindow::closeEvent(event);
 }
 

--- a/src/gui/gt_mdiitem.cpp
+++ b/src/gui/gt_mdiitem.cpp
@@ -28,7 +28,7 @@ GtMdiItem::GtMdiItem() : m_frame(new QFrame), m_d(nullptr),
     m_frame->setFrameStyle(QFrame::NoFrame);
 
     connect(m_frame, &QObject::destroyed, [w=(void*)m_frame.data()](){
-        gtError() << "DELETED" << w;
+        gtError() << "DELETED MDI WIDGET" << w;
     });
 
     connect(gtApp, SIGNAL(currentProjectChanged(GtProject*)),
@@ -59,7 +59,7 @@ GtMdiItem::setData(GtObject* /*obj*/)
 
 GtMdiItem::~GtMdiItem()
 {
-    gtError() << "HERE DELETE" << objectName() << m_frame;
+    gtError() << "DELETED MDI ITEM" << objectName() << m_frame;
 
     qDeleteAll(m_eventQueue);
 }

--- a/src/gui/gt_mdiitem.cpp
+++ b/src/gui/gt_mdiitem.cpp
@@ -11,8 +11,6 @@
 #include <QFrame>
 #include <QIcon>
 #include <QMessageBox>
-#include <QApplication>
-#include <QSettings>
 
 #include "gt_mdiitem.h"
 #include "gt_application.h"
@@ -21,10 +19,17 @@
 #include "gt_objectchangedevent.h"
 #include "gt_statehandler.h"
 
+
+#include <gt_logging.h>
+
 GtMdiItem::GtMdiItem() : m_frame(new QFrame), m_d(nullptr),
     m_subWin(nullptr), m_queueEvents(false)
 {
     m_frame->setFrameStyle(QFrame::NoFrame);
+
+    connect(m_frame, &QObject::destroyed, [w=(void*)m_frame.data()](){
+        gtError() << "DELETED" << w;
+    });
 
     connect(gtApp, SIGNAL(currentProjectChanged(GtProject*)),
             SLOT(onProjectChanged(GtProject*)));
@@ -37,7 +42,7 @@ GtMdiItem::GtMdiItem() : m_frame(new QFrame), m_d(nullptr),
 QWidget*
 GtMdiItem::widget()
 {
-    return m_frame;
+    return static_cast<QWidget*>(m_frame.data());
 }
 
 QIcon
@@ -54,11 +59,7 @@ GtMdiItem::setData(GtObject* /*obj*/)
 
 GtMdiItem::~GtMdiItem()
 {
-//    gtError() << "MDI ITEM DESTROYED!";
-    if (m_frame && !m_frame->parent())
-    {
-        delete m_frame;
-    }
+    gtError() << "HERE DELETE" << objectName() << m_frame;
 
     qDeleteAll(m_eventQueue);
 }

--- a/src/gui/gt_mdilauncher.cpp
+++ b/src/gui/gt_mdilauncher.cpp
@@ -155,7 +155,6 @@ GtMdiLauncher::close()
     {
         assert(item);
         assert(item->widget());
-        gtError() << "HERE BEFORE" << item->objectName() << item->widget();
         item->widget()->deleteLater();
     }
     m_openItems.clear();
@@ -201,10 +200,6 @@ GtMdiLauncher::instance()
         retval = new GtMdiLauncher(qApp);
     }
     return retval;
-}
-
-GtMdiLauncher::~GtMdiLauncher()
-{
 }
 
 void

--- a/src/gui/gt_mdilauncher.h
+++ b/src/gui/gt_mdilauncher.h
@@ -34,6 +34,7 @@ class GT_GUI_EXPORT GtMdiLauncher : public QObject,
         public GtAbstractObjectFactory
 {
     friend class GtGuiModuleLoader;
+    friend class GtMainWin;
 
     Q_OBJECT
 
@@ -43,6 +44,7 @@ public:
      * @return
      */
     static GtMdiLauncher* instance();
+    ~GtMdiLauncher();
 
     /**
      * @brief setMdiArea
@@ -211,6 +213,11 @@ private:
      * @param mdiId
      */
     void setFocus(const QString& mdiId);
+
+    /**
+     * @brief Closes all active MDI items.
+     */
+    void close();
 
 private slots:
     /**

--- a/src/gui/gt_mdilauncher.h
+++ b/src/gui/gt_mdilauncher.h
@@ -44,7 +44,6 @@ public:
      * @return
      */
     static GtMdiLauncher* instance();
-    ~GtMdiLauncher();
 
     /**
      * @brief setMdiArea


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I have looked into how we could implement the detach behavior of MDI Items. I successfully added a "detach" button, that does exactly that. 

*However, I could not resolve the ownership of the MDI Items and their widgets. And every solution feels hacky. I think we'll have to wait for #1199. I really would like to have this implemented, but I'll could not get this to work in the few hours I have spent and I dont want to spent anymore time on this for now. **If anybody else is interested, go for it**. Still, I wanted to save the little progress I have made.*

*Another issue I have faced is how we allow the widget to "redock" with the main area. Maybe a drag-and-drop system might work? But this might be difficult to implement. Since it's not easily possible to add a button to the window-bar we might have to implement our own window-bar like with the dock widgets. Or we might be able to intercept the "minimize/close" event (when the user minimizes/closes the window) to reattach it to the dock area.*

Before undocking (notice the fancy button)

![grafik](https://github.com/dlr-gtlab/gtlab-core/assets/52258575/5e746e48-e2b4-417f-8a52-cb1175501eb9)

After widget was undocked it became its standalone window (how do we "redock" it?)

![grafik](https://github.com/dlr-gtlab/gtlab-core/assets/52258575/86d898b0-0457-4d2a-8e71-bb1452612397)


Closes #604

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
