### PR TITLE
Resolve "Allowed mdi items to be closed using middle mouse click"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warning for unknown classes is now only shown in the developer mode of GTlab - #1160
 - Changed call of process execution in console application to enable call of tasks of different task groups- #1144
 
+### Added
+- MDI Items can now be closed using middle mouse click (similarly to most common browsers). - #603
+
 ### Removed
 - Removed the error message dialog. - #611
 

--- a/src/app/ui/gt_mainwin.ui
+++ b/src/app/ui/gt_mainwin.ui
@@ -41,7 +41,7 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="QTabWidget" name="mdiArea">
+     <widget class="GtTabWidget" name="mdiArea">
       <property name="tabShape">
        <enum>QTabWidget::Rounded</enum>
       </property>
@@ -411,8 +411,15 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>GtTabWidget</class>
+   <extends>QTabWidget</extends>
+   <header>gt_tabwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
-  <include location="../../resources/icons/icons.qrc"/>
   <include location="../../resources/icons/icons.qrc"/>
  </resources>
  <connections>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -41,6 +41,7 @@ set(headers
     tools/gt_switchprojectmessagebox.h
     tools/gt_textedit.h
     widgets/gt_shortcutedit.h
+    widgets/gt_tabwidget.h
     widgets/gt_preferencespage.h
     gt_processexecutor.h
     gt_datamodel.h
@@ -216,6 +217,7 @@ set(sources
     tools/gt_switchprojectmessagebox.cpp
     tools/gt_textedit.cpp
     widgets/gt_shortcutedit.cpp
+    widgets/gt_tabwidget.cpp
     widgets/gt_preferencespage.cpp
     gt_guimoduleloader.cpp
     gt_dockwidget.cpp

--- a/src/gui/widgets/gt_tabwidget.cpp
+++ b/src/gui/widgets/gt_tabwidget.cpp
@@ -1,0 +1,60 @@
+/* GTlab - Gas Turbine laboratory
+ * copyright 2009-2024 by DLR
+ *
+ *  Created on: 25.4.2024
+ *  Author: Marius Bröcker (AT-TWK)
+ *  E-Mail: marius.broecker@dlr.de
+ */
+
+
+#include "gt_tabwidget.h"
+
+#include <gt_finally.h>
+
+#include <QMouseEvent>
+#include <QTabBar>
+
+GtTabWidget::GtTabWidget(QWidget* parent) :
+    QTabWidget(parent)
+{
+
+}
+
+void
+GtTabWidget::mousePressEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::MiddleButton && tabsClosable())
+    {
+        m_tabClickedIdx = tabBar()->tabAt(event->pos());
+        if (m_tabClickedIdx >= 0)
+        {
+            event->accept();
+            return;
+        }
+    }
+
+    return QTabWidget::mousePressEvent(event);
+}
+
+void
+GtTabWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (m_tabClickedIdx >= 0)
+    {
+        auto cleanup = gt::finally([this](){
+            m_tabClickedIdx = -1;
+        });
+
+        // only remove tab if cursor is on the same tab
+        int idx = tabBar()->tabAt(event->pos());
+        if (idx == m_tabClickedIdx)
+        {
+            event->accept();
+            emit tabCloseRequested(m_tabClickedIdx);
+            return;
+        }
+    }
+
+    return QTabWidget::mouseReleaseEvent(event);
+}
+

--- a/src/gui/widgets/gt_tabwidget.cpp
+++ b/src/gui/widgets/gt_tabwidget.cpp
@@ -1,5 +1,7 @@
 /* GTlab - Gas Turbine laboratory
- * copyright 2009-2024 by DLR
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
  *
  *  Created on: 25.4.2024
  *  Author: Marius Bröcker (AT-TWK)

--- a/src/gui/widgets/gt_tabwidget.h
+++ b/src/gui/widgets/gt_tabwidget.h
@@ -1,5 +1,7 @@
 /* GTlab - Gas Turbine laboratory
- * copyright 2009-2024 by DLR
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
  *
  *  Created on: 25.4.2024
  *  Author: Marius Bröcker (AT-TWK)

--- a/src/gui/widgets/gt_tabwidget.h
+++ b/src/gui/widgets/gt_tabwidget.h
@@ -1,0 +1,41 @@
+/* GTlab - Gas Turbine laboratory
+ * copyright 2009-2024 by DLR
+ *
+ *  Created on: 25.4.2024
+ *  Author: Marius Bröcker (AT-TWK)
+ *  E-Mail: marius.broecker@dlr.de
+ */
+
+
+#ifndef GTTABWIDGET_H
+#define GTTABWIDGET_H
+
+#include <QTabWidget>
+#include <gt_gui_exports.h>
+
+/**
+ * @brief The GtTabWidget class.
+ * Specialized QTabWidget. Will emit tabCloseRequested when tab was middle
+ * clicked (only emitted if cursor is on the same tab on release).
+ */
+class GT_GUI_EXPORT GtTabWidget : public QTabWidget
+{
+    Q_OBJECT
+
+public:
+
+    GtTabWidget(QWidget* parent = nullptr);
+
+protected:
+
+    void mousePressEvent(QMouseEvent* event) override;
+
+    void mouseReleaseEvent(QMouseEvent* event) override;
+
+private:
+
+    /// stores the tab that was right clicked
+    int m_tabClickedIdx = -1;
+};
+
+#endif // GTTABWIDGET_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allowed mdi items to be closed using middle mouse click. Closes #603

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
