### PR TITLE
Resolve "Renaming objects in the explorer fails sometimes if the new name contains spaces"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed mirco stutters when new messages are appended to the output dock. - #1165
-- Fixed unicode characters not correctly saved to tasks, in particular python tasks and file properties - #1125, #45
+- Fixed unicode characters not beeing correctly saved to tasks, in particular python tasks and file properties - #1125, #45
 - Fixed copying in output dock using keyboard shortcut sometimes not working as expected. - #1136
 - Fixed error "Folder id is empty" when starting GTlab on docker - #1135
+- Fixed restrictive validator when renaming some objects in the explorer - #523
 
 ### Changed
 - Improved performance of the python syntax highlighter - #1139
-- (In-)active filter buttons for the logging level in the output dock are now better distinuishable. - #606 
+- (In-)active filter buttons for the logging level in the output dock are now better distinguishable. - #606 
 - Warning for unknown classes is now only shown in the developer mode of GTlab - #1160
 - Changed call of process execution in console application to enable call of tasks of different task groups- #1144
 

--- a/src/gui/gt_textfilterdelegate.cpp
+++ b/src/gui/gt_textfilterdelegate.cpp
@@ -50,14 +50,14 @@ GtTextFilterDelegate::createEditor(QWidget* parent,
         {
             if (m_validatorflag == uiFilter)
             {
-                GtObjectUI* oui = gtApp->defaultObjectUI(obj);
+                static GtObjectUI fallbackUI;
 
-                if (oui)
+                GtObjectUI* oui = gtApp->defaultObjectUI(obj);
+                if (!oui) oui = &fallbackUI;
+
+                if (oui->hasValidationRegExp())
                 {
-                    if (oui->hasValidationRegExp())
-                    {
-                        regExp = oui->validatorRegExp();
-                    }
+                    regExp = oui->validatorRegExp();
                 }
             }
             else if (m_validatorflag == allowSpaces)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #523. 

Objects that have no dedicated `GtObjectUI` associated, were more restrictive when renaming in the explorer (e.g. no space allowed). This was fixed by using a fallback `GtObjectUI`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
