### PR TITLE
Fix cppcheck warnings / errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,6 +340,7 @@ package-linux:
 cppcheck:
   stage: codequality
   extends: .cppCheckTemplate
+  allow_failure: false
   variables:
     GIT_SUBMODULE_STRATEGY: "none"
    

--- a/src/app/dock_widgets/output/gt_outputdock.cpp
+++ b/src/app/dock_widgets/output/gt_outputdock.cpp
@@ -141,12 +141,12 @@ static QPushButton* setupToggleButton(QLayout* layout,
 static QString const& currentLoggingLevel()
 {
     // not using logging level setting here to get actual logging level
-    gt::log::Level loggingLevel = gt::log::Logger::instance().loggingLevel();
+    gt::log::Level loggingLevelValue = gt::log::Logger::instance().loggingLevel();
 
     auto iter = std::find_if(std::begin(s_loggingLevels),
                              std::end(s_loggingLevels),
                              [=](auto const& entry){
-        return loggingLevel <= entry.level;
+        return loggingLevelValue <= entry.level;
     });
 
     if (iter != std::end(s_loggingLevels))

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -531,8 +531,6 @@ GtProcessDock::addTaskToParent(GtObject* parentObj)
 
     if (!wizard.exec()) return;
 
-    if (!parentObj) return;
-
     GtObjectMemento memento = provider.componentData();
 
     if (memento.isNull()) return;
@@ -1457,8 +1455,8 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
             }
         }
 
-        auto moveCmd = gtApp->makeCommand(m_taskGroup,
-                                          tr("move tasks element"));
+        auto _ = gtApp->makeCommand(m_taskGroup, tr("move tasks element"));
+
         for (auto o : objectsToMove)
         {
             gtDataModel->appendChild(o, m_taskGroup);
@@ -1481,8 +1479,7 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
     assert(commonParent);
 
 
-    auto moveCmd = gtApp->makeCommand(commonParent,
-                                      tr("move process element"));
+    auto _ = gtApp->makeCommand(commonParent, tr("move process element"));
 
     if (auto taskParent = qobject_cast<GtTask*>(targetComp))
     {

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1456,6 +1456,7 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
         }
 
         auto _ = gtApp->makeCommand(m_taskGroup, tr("move tasks element"));
+        Q_UNUSED(_);
 
         for (auto o : objectsToMove)
         {
@@ -1480,6 +1481,7 @@ GtProcessDock::moveElements(const QList<QModelIndex>& source,
 
 
     auto _ = gtApp->makeCommand(commonParent, tr("move process element"));
+    Q_UNUSED(_);
 
     if (auto taskParent = qobject_cast<GtTask*>(targetComp))
     {

--- a/src/app/preferences/pages/gt_preferencesapp.cpp
+++ b/src/app/preferences/pages/gt_preferencesapp.cpp
@@ -46,12 +46,12 @@ namespace
 QString const& currentVerbosityName()
 {
     // not using verbosity setting here to get actual logging verbosity
-    int verbosityLevel = gt::log::Logger::instance().verbosity();
+    int verbosityLevelValue = gt::log::Logger::instance().verbosity();
 
     auto iter = std::find_if(std::begin(s_verbosityLevels),
                              std::end(s_verbosityLevels),
                              [=](auto const& entry){
-        return verbosityLevel <= entry.verbosity;
+        return verbosityLevelValue <= entry.verbosity;
     });
 
     if (iter != std::end(s_verbosityLevels))

--- a/src/gui/dialogs/project_settings/gt_projectsettingsgeneraltab.h
+++ b/src/gui/dialogs/project_settings/gt_projectsettingsgeneraltab.h
@@ -30,8 +30,8 @@ public:
      * @param project pointer to valid project
      * @param parent parent widget
      */
-    GtProjectSettingsGeneralTab(GtProject* project,
-                                QWidget* parent = {});
+    explicit GtProjectSettingsGeneralTab(GtProject* project,
+                                         QWidget* parent = {});
 
     /**
      * @brief method called when dialog was accepted


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes all code problems discovered by cppcheck.

In addition:
 - Adjusted the pipeline that the cppcheck job fails, if new errors occur (note, that this is a change in our ci templates)
 - Don't allow failure of the job anymore

## How Has This Been Tested?
- See commit history

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
