### PR TITLE
Hide button to detach mdi widget in non dev mode

### DIFF
--- a/src/gui/gt_mdilauncher.cpp
+++ b/src/gui/gt_mdilauncher.cpp
@@ -53,6 +53,11 @@ QWidget* makeTabButtons(QPointer<GtTabWidget> tabWidget,
     undockBtn->setIcon(gt::gui::icon::dock());
     undockBtn->setFlat(true);
 
+    if (!gtApp->devMode())
+    {
+        undockBtn->hide();
+    }
+
     auto* buttonLay = new QHBoxLayout;
     buttonLay->setContentsMargins(0, 0, 0, 0);
     buttonLay->addWidget(undockBtn);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
