### PR TITLE
Fixed empty task bug on console app

### DIFF
--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -23,6 +23,7 @@
 #include "gt_consolerunprocess.h"
 
 #include "gt_application.h"
+#include "gt_coreprocessexecutor.h"
 
 //#include "gt_coreapplication.h"
 #include "gt_coredatamodel.h"
@@ -873,6 +874,12 @@ int main(int argc, char* argv[])
     }
 
     app.init();
+
+    // avoid runing tasks in threads, only the GUI can do this
+    // due to the event loop
+    gt::processExecutorManager().clearAllExecutors();
+    gt::registerExecutorType<GtCoreProcessExecutor>();
+
 
     // save to system environment (temporary)
     app.saveSystemEnvironment();

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -469,7 +469,7 @@ GtCoreProcessExecutor::setupTaskRunner()
 void
 GtCoreProcessExecutor::onTaskRunnerFinished()
 {
-    qDebug() << __FUNCTION__;
+    gtTrace() << __FUNCTION__;
 
     // create timer
     QElapsedTimer timer;

--- a/src/core/gt_processexecutormanager.cpp
+++ b/src/core/gt_processexecutormanager.cpp
@@ -109,7 +109,11 @@ GtProcessExecutorManager::setCurrentExecutor(std::string const& id)
         return false;
     }
 
+    // Only print this in debug builds. Note: right now, this is printed
+    // before the logging level has been set correctly, hence it would always be printed
+#ifndef NDEBUG
     gtDebugId(GT_EXEC_ID) << tr("Now using Executor '%1'").arg(id.c_str());
+#endif
 
     // switch executor
     s_currentExecutorId = id;
@@ -135,7 +139,9 @@ GtProcessExecutorManager::registerExecutor(std::string id,
         return false;
     }
 
-    qDebug().noquote() << tr("#### Registered executor '%1'").arg(id.c_str());
+#ifndef NDEBUG
+    gtDebug().noquote() << tr("#### Registered executor '%1'").arg(id.c_str());
+#endif
 
     s_executors.push_back(ExecutorEntry{std::move(exec), std::move(id)});
 

--- a/src/core/process_management/gt_taskrunner.cpp
+++ b/src/core/process_management/gt_taskrunner.cpp
@@ -30,7 +30,7 @@ GtTaskRunner::GtTaskRunner(GtTask* task) : m_task(task), m_runnable(nullptr),
 
 GtTaskRunner::~GtTaskRunner()
 {
-    qDebug() << "task runner deleted!";
+    gtTrace() << "task runner deleted!";
 }
 
 bool
@@ -261,7 +261,7 @@ GtTaskRunner::setupElements(GtProcessComponent* orig,
 void
 GtTaskRunner::handleRunnableFinished()
 {
-    qDebug() << "GtTaskRunner::handleRunnableFinished()";
+    gtTrace() << "GtTaskRunner::handleRunnableFinished()";
 
     // check runnable
     if (!m_runnable)
@@ -279,7 +279,7 @@ GtTaskRunner::handleRunnableFinished()
 
     if (m_task)
     {
-        qDebug() << "monitoring data table size = " <<
+        gtDebug() << "monitoring data table size = " <<
                  m_task->monitoringDataSize();
     }
 

--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -623,14 +623,7 @@ GtApplication::getShortCutSequence(const QString& id,
         return {};
     }
 
-    QKeySequence retVal = s->getKey(id, category);
-
-    if (retVal.isEmpty())
-    {
-        gtWarning() << tr("No shortcut registered for") << id;
-    }
-
-    return retVal;
+    return s->getKey(id, category);
 }
 
 bool

--- a/src/gui/gt_shortcuts.cpp
+++ b/src/gui/gt_shortcuts.cpp
@@ -113,7 +113,9 @@ GtShortCuts::getKey(const QString& id, const QString& category) const
 
     if (list.isEmpty())
     {
+#ifndef NDEBUG
         gtWarning() << tr("No shortcuts registered!");
+#endif
         return {};
     }
 
@@ -137,6 +139,9 @@ GtShortCuts::getKey(const QString& id, const QString& category) const
 
     if (iter == std::end(list))
     {
+#ifndef NDEBUG
+        gtWarning() << tr("No shortcut registered for") << id;
+#endif
         return {};
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This commit switches back the executor to the coreexecutor. This change is required, since the batch app has no event loop and thus cannot handle running tasks in threads correctly.

Thanks at @real-ct-ac for digging into it in depth.

Fixed #1233 

Note: In a second commit, I removed many annoying warnings (or  changed the logging level).

## How Has This Been Tested?

This bug first revealed on  python calculators, which crashed or failed to run. 

I tested these changes with
 - Empty tasks
 - Tasks with Python calculators
 - On Windows and Linux

This change seems to restore the old functionality.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
