### PR TITLE
Enable skip/unsik hotkey for multiple elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-###
+### Fixed
 - Fixed crash when deleting multiple calculators or task via the context menu - #1266
+
+### Added
+- Added option to skip/unskip multiple process elements at once - #1226
 
 ## [2.0.9] - 2024-06-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed crash when deleting multiple calculators or task via the context menu - #1266
 
 ### Added
-- Added option to skip/unskip multiple process elements at once - #1226
+- Added option to skip/unskip multiple process elements at once via keyboard shortcut - #1226
 
 ## [2.0.9] - 2024-06-20
 ### Fixed

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -187,7 +187,7 @@ GtProcessDock::GtProcessDock() :
             SLOT(pasteElement(QModelIndex)));
     connect(m_view, SIGNAL(runTaskElement(QModelIndex)),
             SLOT(runProcess()));
-    connect(m_view, SIGNAL(skipCalcultorElement(const QList<QModelIndex>&,bool)),
+    connect(m_view, SIGNAL(skipCalculatorElements(const QList<QModelIndex>&,bool)),
             SLOT(skipComponents(const QList<QModelIndex>&,bool)));
     connect(m_view, SIGNAL(renameProcessElement(QModelIndex)),
             SLOT(renameElement()));
@@ -2052,12 +2052,9 @@ GtProcessDock::skipComponents(const QList<QModelIndex>& indexList, bool skip)
 
         if (!pc) continue;
 
-        if (!pcs.contains(pc))
+        if (!pcs.contains(pc) && pc->isSkipped() != skip)
         {
-            if (pc->isSkipped() != skip)
-            {
-                pcs.append(pc);
-            }
+            pcs.append(pc);
         }
     }
 

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1220,7 +1220,6 @@ GtProcessDock::processContextMenu(GtProcessComponent& obj,
 void
 GtProcessDock::multiSelectionContextMenu(QList<QModelIndex> const& indexList)
 {
-//    if (indexList.isEmpty()) return;
 
     QMenu menu(this);
 

--- a/src/app/dock_widgets/process/gt_processdock.h
+++ b/src/app/dock_widgets/process/gt_processdock.h
@@ -127,7 +127,7 @@ public slots:
      * @brief sets skip status to components at indexes
      * @param indexlist
      */
-    void skipComponent(const QList<QModelIndex>& indexList, bool skip = true);
+    void skipComponents(const QList<QModelIndex>& indexList, bool skip = true);
 
     /**
      * @brief sets skip status to component

--- a/src/app/dock_widgets/process/gt_processview.cpp
+++ b/src/app/dock_widgets/process/gt_processview.cpp
@@ -113,14 +113,14 @@ GtProcessView::keyPressEvent(QKeyEvent* event)
 
         if (gtApp->compareKeyEvent(event, "skipProcess", "GtProcessDock"))
         {
-            emit skipCalcultorElement(indexes, true);
+            emit skipCalculatorElements(indexes, true);
             event->accept();
             return;
         }
 
         if (gtApp->compareKeyEvent(event, "unskipProcess", "GtProcessDock"))
         {
-            emit skipCalcultorElement(indexes, false);
+            emit skipCalculatorElements(indexes, false);
             event->accept();
             return;
         }

--- a/src/app/dock_widgets/process/gt_processview.cpp
+++ b/src/app/dock_widgets/process/gt_processview.cpp
@@ -13,7 +13,6 @@
 
 #include "gt_application.h"
 #include "gt_icons.h"
-#include "gt_logging.h"
 #include "gt_processview.h"
 
 GtProcessView::GtProcessView(QWidget* parent) : GtTreeView(parent)
@@ -95,26 +94,6 @@ GtProcessView::keyPressEvent(QKeyEvent* event)
                 }
             }
 
-            if (gtApp->compareKeyEvent(event, "skipProcess", "GtProcessDock"))
-            {
-                if (index.isValid())
-                {
-                    emit skipCalcultorElement(index, true);
-                    event->accept();
-                    return;
-                }
-            }
-
-            if (gtApp->compareKeyEvent(event, "unskipProcess", "GtProcessDock"))
-            {
-                if (index.isValid())
-                {
-                    emit skipCalcultorElement(index, false);
-                    event->accept();
-                    return;
-                }
-            }
-
             if (gtApp->compareKeyEvent(event, "rename", "Core"))
             {
                 if (index.isValid())
@@ -131,6 +110,20 @@ GtProcessView::keyPressEvent(QKeyEvent* event)
             emit deleteProcessElements(indexes);
             return;
         }
+
+        if (gtApp->compareKeyEvent(event, "skipProcess", "GtProcessDock"))
+        {
+            emit skipCalcultorElement(indexes, true);
+            event->accept();
+            return;
+        }
+
+        if (gtApp->compareKeyEvent(event, "unskipProcess", "GtProcessDock"))
+        {
+            emit skipCalcultorElement(indexes, false);
+            event->accept();
+            return;
+        }
     }
 
     GtTreeView::keyPressEvent(event);
@@ -145,10 +138,7 @@ GtProcessView::mousePressEvent(QMouseEvent* event)
 
     if (!index.isValid())
     {
-        if (!gtApp->currentProject())
-        {
-            return;
-        }
+        if (!gtApp->currentProject()) return;
 
         assert(selectionModel());
 

--- a/src/app/dock_widgets/process/gt_processview.h
+++ b/src/app/dock_widgets/process/gt_processview.h
@@ -96,11 +96,11 @@ signals:
     void runTaskElement(const QModelIndex& index);
 
     /**
-     * @brief skipCalcultorElement
+     * @brief skipCalculatorElements
      * @param index - modelindex for which the signal is emited
      * @param skip - bool as flag to skip or unskip
      */
-    void skipCalcultorElement(const QList<QModelIndex>& index, bool skip);
+    void skipCalculatorElements(const QList<QModelIndex>& index, bool skip);
 
     /**
      * @brief renameProcessElement

--- a/src/app/dock_widgets/process/gt_processview.h
+++ b/src/app/dock_widgets/process/gt_processview.h
@@ -100,7 +100,7 @@ signals:
      * @param index - modelindex for which the signal is emited
      * @param skip - bool as flag to skip or unskip
      */
-    void skipCalcultorElement(const QModelIndex& index, bool skip);
+    void skipCalcultorElement(const QList<QModelIndex>& index, bool skip);
 
     /**
      * @brief renameProcessElement


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The function to skip or unskip elements via a shortcuts is extended to be used for selection of more of one element.  
  
There is added a very small cleanup to reduce code. 

## How Has This Been Tested?
Manual tests


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
