### PR TITLE
Remove all connections at once by button

### DIFF
--- a/src/app/dock_widgets/process/gt_processconnectioneditor.cpp
+++ b/src/app/dock_widgets/process/gt_processconnectioneditor.cpp
@@ -66,15 +66,20 @@ GtProcessConnectionEditor::GtProcessConnectionEditor(GtTask* task,
 
     lay->addLayout(mainLay);
 
-    QPushButton* saveButton = new QPushButton(tr("Ok"));
+    auto* removeAllButton =
+            new QPushButton(tr("Remove all connections"));
+    removeAllButton->setIcon(gt::gui::icon::delete_());
+    auto* saveButton = new QPushButton(tr("Ok"));
     saveButton->setIcon(gt::gui::icon::check());
-    QPushButton* closeButton = new QPushButton(tr("Cancel"));
+    auto* closeButton = new QPushButton(tr("Cancel"));
     closeButton->setIcon(gt::gui::icon::cancel());
 
     connect(closeButton, SIGNAL(clicked()), SLOT(reject()));
     connect(saveButton, SIGNAL(clicked()), SLOT(accept()));
+    connect(removeAllButton, SIGNAL(clicked()), SLOT(deleteAllConnections()));
 
     QHBoxLayout* buttonsLayout = new QHBoxLayout;
+    buttonsLayout->addWidget(removeAllButton);
     buttonsLayout->setContentsMargins(4, 4, 4, 4);
     buttonsLayout->addStretch(1);
     buttonsLayout->addWidget(saveButton);
@@ -116,6 +121,12 @@ GtProcessConnectionEditor::connectionData()
     }
 
     return GtObjectMemento();
+}
+
+void
+GtProcessConnectionEditor::deleteAllConnections()
+{
+    m_connectionView->removeAllConnections();
 }
 
 void

--- a/src/app/dock_widgets/process/gt_processconnectioneditor.cpp
+++ b/src/app/dock_widgets/process/gt_processconnectioneditor.cpp
@@ -126,6 +126,8 @@ GtProcessConnectionEditor::connectionData()
 void
 GtProcessConnectionEditor::deleteAllConnections()
 {
+    if (!m_connectionView->root()) return;
+
     m_connectionView->removeAllConnections(m_connectionView->root()->uuid());
 }
 

--- a/src/app/dock_widgets/process/gt_processconnectioneditor.cpp
+++ b/src/app/dock_widgets/process/gt_processconnectioneditor.cpp
@@ -126,17 +126,14 @@ GtProcessConnectionEditor::connectionData()
 void
 GtProcessConnectionEditor::deleteAllConnections()
 {
-    m_connectionView->removeAllConnections();
+    m_connectionView->removeAllConnections(m_connectionView->root()->uuid());
 }
 
 void
 GtProcessConnectionEditor::fillData()
 {
     // check task
-    if (!m_task)
-    {
-        return;
-    }
+    if (!m_task) return;
 
     // fill output model and expand view
     m_outputModel->setRoot(m_task);

--- a/src/app/dock_widgets/process/gt_processconnectioneditor.h
+++ b/src/app/dock_widgets/process/gt_processconnectioneditor.h
@@ -28,6 +28,7 @@ class GtObjectMemento;
  */
 class GtProcessConnectionEditor : public GtDialog
 {
+    Q_OBJECT
 public:
     /**
      * @brief Constructor.
@@ -46,6 +47,15 @@ public:
      * @return Connection data.
      */
     GtObjectMemento connectionData();
+
+private slots:
+
+    /**
+     * @brief deleteAllConnections
+     * function to remove all connections currently part of the editor
+    */
+    void deleteAllConnections();
+
 
 private:
     /// Root task

--- a/src/app/mdi_items/process_env/entities/gt_processconnectionview.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processconnectionview.cpp
@@ -11,7 +11,12 @@
 
 #include <QPainter>
 #include <QApplication>
+#include <QMenu>
 
+#include <gt_logging.h>
+#include "gt_icons.h"
+#include "gt_guiutilities.h"
+#include "gt_objectuiaction.h"
 #include "gt_processconnectionmodel.h"
 #include "gt_processconnectiongraphicsview.h"
 
@@ -22,6 +27,12 @@ GtProcessConnectionView::GtProcessConnectionView(QWidget* parent) :
     m_graphicsView(nullptr)
 {
     setIconSize({16, 16});
+    setContextMenuPolicy(Qt::CustomContextMenu);
+
+    connect(this, SIGNAL(customContextMenuRequested(QPoint)),
+            SLOT(customContextMenu(QPoint)));
+
+
 }
 
 void
@@ -29,6 +40,8 @@ GtProcessConnectionView::setGraphicsView(
         GtProcessConnectionGraphicsView* graphicsView)
 {
     m_graphicsView = graphicsView;
+    connect(this, SIGNAL(triggerDeleteConnections(QString const&, bool)),
+            m_graphicsView, SLOT(removeAllConnections(QString const&, bool)));
 }
 
 QModelIndex
@@ -160,9 +173,10 @@ GtProcessConnectionView::itemById(const QString& uuid, const QString& propId)
     return connModel->itemById(uuid, propId);
 }
 
-void GtProcessConnectionView::drawRow(QPainter* painter,
-                                      const QStyleOptionViewItem& option,
-                                      const QModelIndex& index) const
+void
+GtProcessConnectionView::drawRow(QPainter* painter,
+                                 const QStyleOptionViewItem& option,
+                                 const QModelIndex& index) const
 {
     QStyleOptionViewItem opt = option;
 
@@ -193,4 +207,36 @@ GtProcessConnectionView::paintEvent(QPaintEvent* event)
     }
 
     GtTreeView::paintEvent(event);
+}
+
+void
+GtProcessConnectionView::customContextMenu(QPoint const& p)
+{
+    QModelIndex index = indexAt(p);
+
+    if (!index.isValid()) return;
+
+    GtProcessConnectionModel* connModel = connectionModel();
+
+    if (!connModel) return;
+
+    GtProcessConnectionItem* i = connModel->itemFromIndex(index);
+
+    if (!i) return;
+
+    if (i->itemType() != GtProcessConnectionItem::PROCESS_COMPONENT) return;
+
+    QMenu menu(this);
+
+    bool inPortIndicator =
+            connModel->mode() == GtProcessConnectionModel::READ_WRITE;
+
+    auto disconnection = gt::gui::makeAction(tr("Disconnect"), [=](GtObject*){
+            triggerDeleteConnections(i->componentUuid(), inPortIndicator);
+        })
+        .setIcon(gt::gui::icon::delete_());
+
+    gt::gui::addToMenu({disconnection}, menu, nullptr);
+
+    menu.exec(QCursor::pos());
 }

--- a/src/app/mdi_items/process_env/entities/gt_processconnectionview.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processconnectionview.cpp
@@ -220,11 +220,9 @@ GtProcessConnectionView::customContextMenu(QPoint const& p)
 
     if (!connModel) return;
 
-    GtProcessConnectionItem* i = connModel->itemFromIndex(index);
+    GtProcessConnectionItem* item = connModel->itemFromIndex(index);
 
-    if (!i) return;
-
-    if (i->itemType() != GtProcessConnectionItem::PROCESS_COMPONENT) return;
+    if (!item || item->itemType() != GtProcessConnectionItem::PROCESS_COMPONENT) return;
 
     QMenu menu(this);
 
@@ -232,7 +230,7 @@ GtProcessConnectionView::customContextMenu(QPoint const& p)
             connModel->mode() == GtProcessConnectionModel::READ_WRITE;
 
     auto disconnection = gt::gui::makeAction(tr("Disconnect"), [=](GtObject*){
-            triggerDeleteConnections(i->componentUuid(), inPortIndicator);
+            triggerDeleteConnections(item->componentUuid(), inPortIndicator);
         })
         .setIcon(gt::gui::icon::delete_());
 

--- a/src/app/mdi_items/process_env/entities/gt_processconnectionview.h
+++ b/src/app/mdi_items/process_env/entities/gt_processconnectionview.h
@@ -100,6 +100,18 @@ private:
     /// Pointer to graphics view widget.
     QPointer<GtProcessConnectionGraphicsView> m_graphicsView;
 
+private slots:
+    void customContextMenu(const QPoint& p);
+
+signals:
+    /**
+     * @brief triggerDeleteConnections
+     * @param uuid of the processcomponent to delete all connections of
+     * @param inPorts - indicator if the trigger is set for inport (true) or
+     * outports (false)
+     */
+    void triggerDeleteConnections(QString const& uuid, bool inPorts);
+
 };
 
 #endif // GTPROCESSCONNECTIONVIEW_H

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
@@ -172,28 +172,27 @@ GtProcessPropertyConnectionEntity::connection()
 void
 GtProcessPropertyConnectionEntity::removeConnection()
 {
-    if (m_connection)
+    if (!m_connection) return;
+
+    if (m_startPort)
     {
-        if (m_startPort)
-        {
-            m_startPort->disconnectPort(this);
-        }
-
-        if (m_endPort)
-        {
-            m_endPort->disconnectPort(this);
-        }
-
-        delete m_connection;
-        m_connection = nullptr;
-
-        deleteLater();
+        m_startPort->disconnectPort(this);
     }
+
+    if (m_endPort)
+    {
+        m_endPort->disconnectPort(this);
+    }
+
+    delete m_connection;
+    m_connection = nullptr;
+
+    deleteLater();
 }
 
 bool
 GtProcessPropertyConnectionEntity::connectedToProcessComponent(
-        const QString& uuid, bool inPort)
+        const QString& uuid, bool inPort) const
 {
     if (!m_connection) return false;
 

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
@@ -169,6 +169,28 @@ GtProcessPropertyConnectionEntity::connection()
 }
 
 void
+GtProcessPropertyConnectionEntity::removeConnection()
+{
+    if (m_connection)
+    {
+        if (m_startPort)
+        {
+            m_startPort->disconnectPort(this);
+        }
+
+        if (m_endPort)
+        {
+            m_endPort->disconnectPort(this);
+        }
+
+        delete m_connection;
+        m_connection = nullptr;
+
+        deleteLater();
+    }
+}
+
+void
 GtProcessPropertyConnectionEntity::hoverEnterEvent(
         QGraphicsSceneHoverEvent* event)
 {
@@ -210,23 +232,7 @@ GtProcessPropertyConnectionEntity::contextMenuEvent(
 
     if (a == actdelete)
     {
-        if (m_connection)
-        {
-            if (m_startPort)
-            {
-                m_startPort->disconnectPort(this);
-            }
-
-            if (m_endPort)
-            {
-                m_endPort->disconnectPort(this);
-            }
-
-            delete m_connection;
-            m_connection = nullptr;
-
-            deleteLater();
-        }
+        removeConnection();
     }
 
     GtGraphicsAnimatedPathItem::contextMenuEvent(event);

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
@@ -195,14 +195,16 @@ bool
 GtProcessPropertyConnectionEntity::connectedToProcessComponent(
         const QString& uuid, bool inPort)
 {
-    if (inPort && m_startPort)
+    if (!m_connection) return false;
+
+    if (inPort)
     {
-        if (m_startPort->parentComponentUuid() == uuid) return true;
+        if (m_connection->sourceUuid() == uuid) return true;
     }
 
-    if (!inPort && m_endPort)
+    if (!inPort)
     {
-        if (m_endPort->parentComponentUuid() == uuid) return true;
+        if (m_connection->targetUuid() == uuid) return true;
     }
 
     return false;

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
@@ -191,6 +191,23 @@ GtProcessPropertyConnectionEntity::removeConnection()
     }
 }
 
+bool
+GtProcessPropertyConnectionEntity::connectedToProcessComponent(
+        const QString& uuid, bool inPort)
+{
+    if (inPort && m_startPort)
+    {
+        if (m_startPort->parentComponentUuid() == uuid) return true;
+    }
+
+    if (!inPort && m_endPort)
+    {
+        if (m_endPort->parentComponentUuid() == uuid) return true;
+    }
+
+    return false;
+}
+
 void
 GtProcessPropertyConnectionEntity::hoverEnterEvent(
         QGraphicsSceneHoverEvent* event)

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.cpp
@@ -16,6 +16,7 @@
 
 #include "gt_processpropertyportentity.h"
 #include "gt_icons.h"
+#include "gt_colors.h"
 #include "gt_propertyconnection.h"
 
 #include "gt_processpropertyconnectionentity.h"
@@ -195,7 +196,7 @@ GtProcessPropertyConnectionEntity::hoverEnterEvent(
         QGraphicsSceneHoverEvent* event)
 {
     QPen p = pen();
-    p.setColor(Qt::red);
+    p.setColor(gt::gui::color::connection_editor::connectionHighlight());
     p.setWidth(2);
     setPen(p);
 
@@ -243,7 +244,7 @@ GtProcessPropertyConnectionEntity::currentColor()
 {
     if (m_startPort && m_endPort)
     {
-        return QColor(Qt::black);
+        return gt::gui::color::connection_editor::connection();
     }
 
     return QColor(Qt::gray);

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.h
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.h
@@ -118,6 +118,14 @@ public:
      */
     void removeConnection();
 
+    /**
+     * @brief connectedToProcessComponent
+     * @param uuid of process component to check
+     * @return true if the connection is connected to the process component
+     * given by the uuid
+     */
+    bool connectedToProcessComponent(QString const& uuid, bool inPort);
+
 protected:
     /**
      * @brief hoverEnterEvent

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.h
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.h
@@ -112,6 +112,12 @@ public:
      */
     GtPropertyConnection* connection();
 
+    /**
+     * @brief removeConnection
+     * Remove the connection and the connection entity
+     */
+    void removeConnection();
+
 protected:
     /**
      * @brief hoverEnterEvent

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.h
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyconnectionentity.h
@@ -124,7 +124,7 @@ public:
      * @return true if the connection is connected to the process component
      * given by the uuid
      */
-    bool connectedToProcessComponent(QString const& uuid, bool inPort);
+    bool connectedToProcessComponent(QString const& uuid, bool inPort) const;
 
 protected:
     /**

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -22,7 +22,6 @@
 
 #include "gt_application.h"
 #include "gt_colors.h"
-#include "gt_logging.h"
 
 GtProcessPropertyPortEntity::GtProcessPropertyPortEntity(
         double x, double y, double width, double height, PortTypes typ,
@@ -32,7 +31,7 @@ GtProcessPropertyPortEntity::GtProcessPropertyPortEntity(
     m_type(typ),
     m_item(item)
 {
-    setBrush(QBrush(Qt::darkGray));
+    setBrush(QBrush(gt::gui::color::connection_editor::portBrush()));
     setFlags(QGraphicsItem::ItemIsSelectable);
     setAcceptHoverEvents(true);
 }
@@ -257,14 +256,7 @@ GtProcessPropertyPortEntity::propertyId()
 void
 GtProcessPropertyPortEntity::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
-    if (!gtApp->inDarkMode())
-    {
-        setBrush(QBrush(Qt::white));
-    }
-    else
-    {
-        setBrush(QBrush(gt::gui::color::basicDark()));
-    }
+    setBrush(QBrush(gt::gui::color::connection_editor::portHoverEnter()));
 
     QApplication::restoreOverrideCursor();
     QApplication::setOverrideCursor(Qt::OpenHandCursor);
@@ -276,7 +268,7 @@ GtProcessPropertyPortEntity::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 void
 GtProcessPropertyPortEntity::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
-    setBrush(QBrush(Qt::darkGray));
+    setBrush(QBrush(gt::gui::color::connection_editor::portBrush()));
     QApplication::restoreOverrideCursor();
     runAnimation(false);
     QGraphicsEllipseItem::hoverLeaveEvent(event);

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -31,7 +31,7 @@ GtProcessPropertyPortEntity::GtProcessPropertyPortEntity(
     m_type(typ),
     m_item(item)
 {
-    setBrush(QBrush(gt::gui::color::connection_editor::portBrush()));
+    setBrush(QBrush(gt::gui::color::connection_editor::portBackground()));
     setFlags(QGraphicsItem::ItemIsSelectable);
     setAcceptHoverEvents(true);
 }
@@ -256,7 +256,7 @@ GtProcessPropertyPortEntity::propertyId()
 void
 GtProcessPropertyPortEntity::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
-    setBrush(QBrush(gt::gui::color::connection_editor::portHoverEnter()));
+    setBrush(QBrush(gt::gui::color::connection_editor::portHover()));
 
     QApplication::restoreOverrideCursor();
     QApplication::setOverrideCursor(Qt::OpenHandCursor);
@@ -268,7 +268,7 @@ GtProcessPropertyPortEntity::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 void
 GtProcessPropertyPortEntity::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
-    setBrush(QBrush(gt::gui::color::connection_editor::portBrush()));
+    setBrush(QBrush(gt::gui::color::connection_editor::portBackground()));
     QApplication::restoreOverrideCursor();
     runAnimation(false);
     QGraphicsEllipseItem::hoverLeaveEvent(event);

--- a/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
@@ -392,10 +392,12 @@ GtProcessConnectionGraphicsView::removeAllConnections(
 
     QList<QGraphicsItem*> allItems = items();
 
-    for (auto i : qAsConst(allItems))
+    for (auto item : qAsConst(allItems))
     {
-        if (auto e = dynamic_cast<GtProcessPropertyConnectionEntity*>(i))
-        {
+        auto e = dynamic_cast<GtProcessPropertyConnectionEntity*>(item)
+
+        if (!e) continue;
+
             for (auto const& u : allUuids)
             {
                 if (e->connectedToProcessComponent(u, inPorts))
@@ -404,7 +406,7 @@ GtProcessConnectionGraphicsView::removeAllConnections(
                     break;
                 }
             }
-        }
+
     }
 }
 

--- a/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
@@ -365,7 +365,21 @@ GtProcessConnectionGraphicsView::updateConnections()
 //        }
 
 
-//    }
+    //    }
+}
+
+void
+GtProcessConnectionGraphicsView::removeAllConnections()
+{
+    QList<QGraphicsItem*> allItems = items();
+
+    for (auto i : qAsConst(allItems))
+    {
+        if (auto e = dynamic_cast<GtProcessPropertyConnectionEntity*>(i))
+        {
+            e->removeConnection();
+        }
+    }
 }
 
 void

--- a/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
@@ -387,6 +387,9 @@ GtProcessConnectionGraphicsView::removeAllConnections(
         allUuids.append(c->uuid());
     }
 
+    // make sure to avoid double checks
+    allUuids.removeDuplicates();
+
     QList<QGraphicsItem*> allItems = items();
 
     for (auto i : qAsConst(allItems))
@@ -394,10 +397,12 @@ GtProcessConnectionGraphicsView::removeAllConnections(
         if (auto e = dynamic_cast<GtProcessPropertyConnectionEntity*>(i))
         {
             for (auto const& u : allUuids)
-
-            if (e->connectedToProcessComponent(u, inPorts))
             {
-                e->removeConnection();
+                if (e->connectedToProcessComponent(u, inPorts))
+                {
+                    e->removeConnection();
+                    break;
+                }
             }
         }
     }

--- a/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
@@ -394,19 +394,20 @@ GtProcessConnectionGraphicsView::removeAllConnections(
 
     for (auto item : qAsConst(allItems))
     {
-        auto e = dynamic_cast<GtProcessPropertyConnectionEntity*>(item)
+        auto e = dynamic_cast<GtProcessPropertyConnectionEntity*>(item);
 
         if (!e) continue;
 
-            for (auto const& u : allUuids)
-            {
-                if (e->connectedToProcessComponent(u, inPorts))
-                {
-                    e->removeConnection();
-                    break;
-                }
-            }
+        auto iter = std::find_if(allUuids.begin(),
+                                 allUuids.end(),
+                                 [&](QString const& uuid){
+            return e->connectedToProcessComponent(uuid, inPorts);
+        });
 
+        if (iter != allUuids.end())
+        {
+            e->removeConnection();
+        }
     }
 }
 

--- a/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.cpp
@@ -369,15 +369,36 @@ GtProcessConnectionGraphicsView::updateConnections()
 }
 
 void
-GtProcessConnectionGraphicsView::removeAllConnections()
+GtProcessConnectionGraphicsView::removeAllConnections(
+        const QString& uuid, bool inPorts)
 {
+    QStringList allUuids = {uuid};
+
+    // get component with given uuid and all uuids of child process components
+    GtObject* deletionRoot = m_root->getObjectByUuid(uuid);
+
+    if (!deletionRoot) return;
+
+    QList<GtProcessComponent*> children
+            = deletionRoot->findChildren<GtProcessComponent*>();
+
+    for (auto c : qAsConst(children))
+    {
+        allUuids.append(c->uuid());
+    }
+
     QList<QGraphicsItem*> allItems = items();
 
     for (auto i : qAsConst(allItems))
     {
         if (auto e = dynamic_cast<GtProcessPropertyConnectionEntity*>(i))
         {
-            e->removeConnection();
+            for (auto const& u : allUuids)
+
+            if (e->connectedToProcessComponent(u, inPorts))
+            {
+                e->removeConnection();
+            }
         }
     }
 }

--- a/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.h
+++ b/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.h
@@ -89,6 +89,13 @@ public:
      */
     void updateConnections();
 
+    /**
+     * @brief removeAllConnections
+     * Remove all graphics entities of connections in the view and their related
+     * connection objects
+     */
+    void removeAllConnections();
+
 protected:
     /**
      * @brief resizeEvent

--- a/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.h
+++ b/src/app/mdi_items/process_env/gt_processconnectiongraphicsview.h
@@ -89,12 +89,14 @@ public:
      */
     void updateConnections();
 
+public slots:
     /**
      * @brief removeAllConnections
+     * @param uuid of component to delete the connections
      * Remove all graphics entities of connections in the view and their related
      * connection objects
      */
-    void removeAllConnections();
+    void removeAllConnections(QString const& uuid, bool inPorts = true);
 
 protected:
     /**

--- a/src/app/mdi_items/process_env/gt_processconnectionmodel.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectionmodel.cpp
@@ -76,6 +76,12 @@ GtProcessConnectionModel::setMode(GtProcessConnectionModel::Modes mode)
     }
 }
 
+GtProcessConnectionModel::Modes
+GtProcessConnectionModel::mode() const
+{
+    return m_mode;
+}
+
 int
 GtProcessConnectionModel::rowCount(const QModelIndex& parent) const
 {

--- a/src/app/mdi_items/process_env/gt_processconnectionmodel.h
+++ b/src/app/mdi_items/process_env/gt_processconnectionmodel.h
@@ -60,6 +60,8 @@ public:
      */
     void setMode(GtProcessConnectionModel::Modes mode);
 
+    GtProcessConnectionModel::Modes mode() const;
+
     /**
      * @brief rowCount
      * @param parent
@@ -132,7 +134,6 @@ public:
      */
     GtProcessConnectionItem* itemById(const QString& uuid,
                                       const QString& propId);
-
 private:
     /// Root item
     GtProcessConnectionItem* m_root;

--- a/src/app/mdi_items/process_env/gt_processconnectionscene.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectionscene.cpp
@@ -22,6 +22,7 @@
 #include "gt_processconnectiongraphicsview.h"
 #include "gt_propertyconnection.h"
 #include "gt_task.h"
+#include "gt_colors.h"
 
 #include "gt_processconnectionscene.h"
 
@@ -175,7 +176,7 @@ GtProcessConnectionScene::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
             {
                 m_tempConnection = new GtProcessPropertyConnectionEntity();
                 QPen pen = m_tempConnection->pen();
-                pen.setColor(Qt::blue);
+                pen.setColor(gt::gui::color::connection_editor::connectionDraft());
                 m_tempConnection->setPen(pen);
                 m_tempConnection->setZValue(-0.5);
 

--- a/src/gui/gt_colors.cpp
+++ b/src/gui/gt_colors.cpp
@@ -474,5 +474,52 @@ gt::gui::color::js_highlight::marker()
     return QColor(255, 255, 0);
 }
 
+QColor
+gt::gui::color::connection_editor::connection()
+{
+    if (gtApp->inDarkMode())
+    {
+        return Qt::lightGray;
+    }
+    return Qt::black;
+}
 
+QColor
+gt::gui::color::connection_editor::connectionDraft()
+{
+    if (gtApp->inDarkMode())
+    {
+        return QColor(98, 182, 230);
+    }
+    return Qt::blue;
+}
 
+QColor
+gt::gui::color::connection_editor::portBrush()
+{
+    if (gtApp->inDarkMode())
+    {
+        return QColor(69, 130, 162);
+    }
+    return Qt::darkGray;
+}
+
+QColor
+gt::gui::color::connection_editor::portHoverEnter()
+{
+    if (gtApp->inDarkMode())
+    {
+        return Qt::lightGray;
+    }
+    return Qt::white;
+}
+
+QColor
+gt::gui::color::connection_editor::connectionHighlight()
+{
+    if (gtApp->inDarkMode())
+    {
+        return Qt::red;
+    }
+    return Qt::red;
+}

--- a/src/gui/gt_colors.cpp
+++ b/src/gui/gt_colors.cpp
@@ -495,7 +495,7 @@ gt::gui::color::connection_editor::connectionDraft()
 }
 
 QColor
-gt::gui::color::connection_editor::portBrush()
+gt::gui::color::connection_editor::portBackground()
 {
     if (gtApp->inDarkMode())
     {
@@ -505,7 +505,7 @@ gt::gui::color::connection_editor::portBrush()
 }
 
 QColor
-gt::gui::color::connection_editor::portHoverEnter()
+gt::gui::color::connection_editor::portHover()
 {
     if (gtApp->inDarkMode())
     {

--- a/src/gui/gt_colors.h
+++ b/src/gui/gt_colors.h
@@ -234,8 +234,8 @@ namespace connection_editor
 GT_GUI_EXPORT QColor connection();
 GT_GUI_EXPORT QColor connectionDraft();
 GT_GUI_EXPORT QColor connectionHighlight();
-GT_GUI_EXPORT QColor portBrush();
-GT_GUI_EXPORT QColor portHoverEnter();
+GT_GUI_EXPORT QColor portBackground();
+GT_GUI_EXPORT QColor portHover();
 } // connection_editor
 
 namespace code_editor {

--- a/src/gui/gt_colors.h
+++ b/src/gui/gt_colors.h
@@ -229,6 +229,15 @@ GT_GUI_EXPORT QColor gridPoint();
 
 GT_GUI_EXPORT QColor gridAxis();
 
+namespace connection_editor
+{
+GT_GUI_EXPORT QColor connection();
+GT_GUI_EXPORT QColor connectionDraft();
+GT_GUI_EXPORT QColor connectionHighlight();
+GT_GUI_EXPORT QColor portBrush();
+GT_GUI_EXPORT QColor portHoverEnter();
+} // connection_editor
+
 namespace code_editor {
 GT_GUI_EXPORT QColor highlightLine();
 } // namespace code_editor
@@ -254,7 +263,6 @@ GT_GUI_EXPORT QColor keyword();
 GT_GUI_EXPORT QColor builtIn();
 GT_GUI_EXPORT QColor marker();
 } // namespace js_highlight
-
 
 /// Deprecated functions
 [[deprecated("Use gridLine instead")]]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The new button removes all graphics entities for the connections and the related connection objects.


![grafik](https://github.com/dlr-gtlab/gtlab-core/assets/148551711/f86969f5-86ca-4278-b875-a47deeff7f8f)

## How Has This Been Tested?
Manual

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
