### PR TITLE
[CRITICAL] Fixed bug: Save project via "GTlabConsole run" does not work anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed bug introduced in 2.0.7, that "GTlabConsole run" does not save projects anymore. This change reverts
+  a commit in 2.0.7 that allowed to use the collections from batch mode.
+  NOTE: collections will stop working in batch mode again - #1247
+
 ## [2.0.7] - 2024-06-05
 ### Fixed
 - Fixed mirco stutters when new messages are appended to the output dock. - #1165

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -22,7 +22,7 @@
 #include "batchremote.h"
 #include "gt_consolerunprocess.h"
 
-#include "gt_application.h"
+#include "gt_coreapplication.h"
 #include "gt_coreprocessexecutor.h"
 
 //#include "gt_coreapplication.h"
@@ -863,7 +863,7 @@ int main(int argc, char* argv[])
     initSystemOptions();
 
     // application initialization
-    GtApplication app(qApp, true, GtCoreApplication::AppMode::Batch);
+    GtCoreApplication app(qApp, GtCoreApplication::AppMode::Batch);
 
     // version option
     if (parser.option("version"))
@@ -897,7 +897,6 @@ int main(int argc, char* argv[])
     }
 
     // load GTlab modules
-    app.initMdiLauncher();
     app.loadModules();
 
     // calculator initialization

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -875,11 +875,6 @@ int main(int argc, char* argv[])
 
     app.init();
 
-    // avoid runing tasks in threads, only the GUI can do this
-    // due to the event loop
-    gt::processExecutorManager().clearAllExecutors();
-    gt::registerExecutorType<GtCoreProcessExecutor>();
-
 
     // save to system environment (temporary)
     app.saveSystemEnvironment();

--- a/src/core/gt_session.cpp
+++ b/src/core/gt_session.cpp
@@ -89,7 +89,7 @@ GtSession::saveProjectData(GtProject* project)
 
     project->acceptChangesRecursively();
 
-    gtInfo() << project->objectName() << tr("saved!");
+    gtInfo() << tr("Project '%1' saved to %2").arg(project->objectName(), project->path());
 
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed bug introduced in 2.0.7, that "GTlabConsole run" does not save projects anymore. This change reverts
a commit in 2.0.7 that allowed to use the collections from batch mode.

__NOTE: collections will stop working in batch mode again__

Closes #1247

## How Has This Been Tested?

On the console. We will need to create regression tests to check this in future.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
