### PR TITLE
added new calculator to export specific data object to hard disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a commit in 2.0.7 that allowed to use the collections from batch mode.
   NOTE: collections will stop working in batch mode again - #1247
 
+### Added
+- Added calculator to export specific objects from the project in form of a memento to hard disk. - #1251
+
 ## [2.0.7] - 2024-06-05
 ### Fixed
 - Fixed mirco stutters when new messages are appended to the output dock. - #1165

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -71,6 +71,7 @@ set(headers
     process_management/process_runner/gt_processrunnerconnectionstrategy.h
     process_management/process_runner/gt_processrunnerglobals.h
     process_management/process_runner/gt_processrunnertcpconnection.h
+    process_management/calculators/gt_exporttomementocalculator.h
     settings/gt_shortcutsettingsdata.h
     states/gt_state.h
     states/gt_stategroup.h
@@ -176,6 +177,7 @@ set(sources
     process_management/process_runner/gt_processrunnerconnectionstrategy.cpp
     process_management/process_runner/gt_processrunnerglobals.cpp
     process_management/process_runner/gt_processrunnertcpconnection.cpp
+    process_management/calculators/gt_exporttomementocalculator.cpp
     settings/gt_shortcutsettingsdata.cpp
     states/gt_state.cpp
     states/gt_stategroup.cpp
@@ -228,6 +230,7 @@ target_include_directories(GTlabCore
     # includes during local build
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/process_management>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/process_management/calculators>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/process_management/process_runner>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/process_management/process_runner/commands>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/provider>

--- a/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
+++ b/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
@@ -1,0 +1,131 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ *
+ *  Created on: 19.06.2024
+ *  Author: Stanislaus Reitenbach (AT-TWK)
+ *  Tel.: +49 2203 601 2907
+ */
+
+#include <QDir>
+#include <QFile>
+#include <QDomDocument>
+
+#include "gt_logging.h"
+#include "gt_coreapplication.h"
+#include "gt_project.h"
+#include <gt_objectmemento.h>
+
+#include "gt_exporttomementocalculator.h"
+
+GtExportToMementoCalculator::GtExportToMementoCalculator() :
+    m_fileMode("fileMode", tr("File Path Mode"), tr("File Path Mode")),
+    m_relativeFileMode(tr("Relative to Working Directory"),
+                       tr("Relative to Working Directory")),
+    m_relativeToProjectFileMode(tr("Relative to Project Directory"),
+                                tr("Relative to Project Directory")),
+    m_absoluteFileMode(tr("Absolute"), tr("Absolut")),
+    m_absoluteFilePath("absPath" ,tr("File Path"), tr("File Path"),
+                       QStringList() << "XML (*.xml)", "memento.xml"),
+    m_relativeFilePath("relPath",tr("File Path"), tr("File Path"),
+                       "memento.xml"),
+    m_targetObject("obj", "Object", "Target object.", this,
+                   QStringList() << GT_CLASSNAME(GtObject), true)
+{
+    setObjectName("Export Object to Memento");
+
+    registerProperty(m_targetObject);
+
+    m_absoluteFileMode.registerSubProperty(m_absoluteFilePath);
+    m_fileMode.registerSubProperty(m_absoluteFileMode);
+
+    m_relativeFileMode.registerSubProperty(m_relativeFilePath);
+    m_relativeToProjectFileMode.registerSubProperty(m_relativeFilePath);
+    m_fileMode.registerSubProperty(m_relativeFileMode);
+    m_fileMode.registerSubProperty(m_relativeToProjectFileMode);
+
+    registerProperty(m_fileMode);
+}
+
+bool
+GtExportToMementoCalculator::run()
+{
+    GtObject* obj = data<GtObject*>(m_targetObject);
+
+    if (!obj)
+    {
+        gtError() << "no object selected!";
+        return false;
+    }
+
+    QString path;
+
+    if (m_fileMode.get() == m_absoluteFileMode.get())
+    {
+        // absolute mode
+        gtInfo() << "absoulte mode";
+        path = m_absoluteFilePath.get();
+    }
+    else
+    {
+        // relative mode
+        if (m_fileMode.get() == m_relativeFileMode.get())
+        {
+            // to working directory
+            gtInfo() << "relative to working directory mode";
+            path = m_relativeFilePath;
+        }
+        else
+        {
+            // to project directory
+            gtInfo() << "relative to project directory mode";
+            if (gtApp->currentProject())
+            {
+                path = gtApp->currentProject()->path() + QDir::separator() +
+                       m_relativeFilePath;
+            }
+        }
+    }
+
+    if (path.isEmpty())
+    {
+        gtError() << "path is empty";
+        return false;
+    }
+
+    QFileInfo fileInfo(path);
+    QString directory = fileInfo.absolutePath();
+
+    QDir dir;
+    if (!dir.mkpath(directory))
+    {
+        gtError() << "Could not create directory!" << directory;
+        return false;
+    }
+
+    QFile file(path);
+
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+    {
+        gtError() << tr("Could not open file!") << file.fileName();
+        return false;
+    }
+
+
+
+    QTextStream out(&file);
+
+    QDomDocument doc;
+    doc.setContent(obj->toMemento(false).toByteArray());
+
+    out << doc.toString();
+
+    file.close();
+
+    gtInfo() << "object (" << obj->objectName()
+             << ") successfully exported to " << path;
+
+    return true;
+}
+

--- a/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
+++ b/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
@@ -55,7 +55,7 @@ GtExportToMementoCalculator::run()
 
     if (!obj)
     {
-        gtError() << "GtExportToMementoCalculator: no object selected!";
+        gtError() << QObject::tr("GtExportToMementoCalculator: no object selected!");
         return false;
     }
 
@@ -90,7 +90,7 @@ GtExportToMementoCalculator::run()
 
     if (path.isEmpty())
     {
-        gtError() << "GtExportToMementoCalculator: Path is empty";
+        gtError() << QObject::tr("GtExportToMementoCalculator: Path is empty");
         return false;
     }
 
@@ -100,8 +100,8 @@ GtExportToMementoCalculator::run()
     QDir dir;
     if (!dir.mkpath(directory))
     {
-        gtError() << "GtExportToMementoCalculator: Could not create directory!"
-                  << directory;
+        gtError() << QObject::tr("GtExportToMementoCalculator: Could not create directory '%1'")
+                         .arg(directory);
         return false;
     }
 
@@ -109,8 +109,8 @@ GtExportToMementoCalculator::run()
 
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
     {
-        gtError() << "GtExportToMementoCalculator: Could not open file!"
-                  << file.fileName();
+        gtError() << QObject::tr("GtExportToMementoCalculator: Could not open file '%1'")
+                         .arg(file.fileName());
         return false;
     }
 
@@ -125,8 +125,8 @@ GtExportToMementoCalculator::run()
 
     file.close();
 
-    gtDebug() << "object (" << obj->objectName()
-              << ") successfully exported to " << path;
+    gtInfo() << QObject::tr("Object '%1' successfully exported to '%2'")
+                    .arg(obj->objectName(), path);
 
     return true;
 }

--- a/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
+++ b/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
@@ -55,7 +55,7 @@ GtExportToMementoCalculator::run()
 
     if (!obj)
     {
-        gtError() << "no object selected!";
+        gtError() << "GtExportToMementoCalculator: no object selected!";
         return false;
     }
 
@@ -64,7 +64,7 @@ GtExportToMementoCalculator::run()
     if (m_fileMode.get() == m_absoluteFileMode.get())
     {
         // absolute mode
-        gtInfo() << "absoulte mode";
+        gtDebug() << "absolute mode";
         path = m_absoluteFilePath.get();
     }
     else
@@ -73,13 +73,13 @@ GtExportToMementoCalculator::run()
         if (m_fileMode.get() == m_relativeFileMode.get())
         {
             // to working directory
-            gtInfo() << "relative to working directory mode";
+            gtDebug() << "relative to working directory mode";
             path = m_relativeFilePath;
         }
         else
         {
             // to project directory
-            gtInfo() << "relative to project directory mode";
+            gtDebug() << "relative to project directory mode";
             if (gtApp->currentProject())
             {
                 path = gtApp->currentProject()->path() + QDir::separator() +
@@ -90,7 +90,7 @@ GtExportToMementoCalculator::run()
 
     if (path.isEmpty())
     {
-        gtError() << "path is empty";
+        gtError() << "GtExportToMementoCalculator: Path is empty";
         return false;
     }
 
@@ -100,7 +100,8 @@ GtExportToMementoCalculator::run()
     QDir dir;
     if (!dir.mkpath(directory))
     {
-        gtError() << "Could not create directory!" << directory;
+        gtError() << "GtExportToMementoCalculator: Could not create directory!"
+                  << directory;
         return false;
     }
 
@@ -108,7 +109,8 @@ GtExportToMementoCalculator::run()
 
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
     {
-        gtError() << tr("Could not open file!") << file.fileName();
+        gtError() << "GtExportToMementoCalculator: Could not open file!"
+                  << file.fileName();
         return false;
     }
 
@@ -123,9 +125,19 @@ GtExportToMementoCalculator::run()
 
     file.close();
 
-    gtInfo() << "object (" << obj->objectName()
-             << ") successfully exported to " << path;
+    gtDebug() << "object (" << obj->objectName()
+              << ") successfully exported to " << path;
 
     return true;
+}
+
+GtCalculatorData
+GtExportToMementoCalculator::calculatorData()
+{
+    GtCalculatorData exportMemento = GT_CALC_DATA(GtExportToMementoCalculator);
+    exportMemento->id = QStringLiteral("Export Object to Memento");
+    exportMemento->version = GtVersionNumber(1,0);
+    exportMemento->status = GtCalculatorDataImpl::RELEASE;
+    return exportMemento;
 }
 

--- a/src/core/process_management/calculators/gt_exporttomementocalculator.h
+++ b/src/core/process_management/calculators/gt_exporttomementocalculator.h
@@ -1,0 +1,55 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ *
+ *  Created on: 19.06.2024
+ *  Author: Stanislaus Reitenbach (AT-TWK)
+ *  Tel.: +49 2203 601 2907
+ */
+
+#ifndef GTEXPORTTOMEMENTOCALCULATOR_H
+#define GTEXPORTTOMEMENTOCALCULATOR_H
+
+#include "gt_core_exports.h"
+
+#include "gt_calculator.h"
+#include "gt_modeproperty.h"
+#include "gt_modetypeproperty.h"
+#include "gt_stringproperty.h"
+#include "gt_savefilenameproperty.h"
+#include "gt_objectlinkproperty.h"
+
+class GT_CORE_EXPORT GtExportToMementoCalculator : public GtCalculator
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE GtExportToMementoCalculator();
+
+    /**
+     * @brief Main run method of the calculator.
+     * @return Whether run process was successful or not.
+     */
+    bool run() override;
+
+private:
+    /// file mode
+    GtModeProperty m_fileMode;
+
+    /// file mode types
+    GtModeTypeProperty m_relativeFileMode, m_relativeToProjectFileMode,
+        m_absoluteFileMode;
+
+    /// Filepath absolute
+    GtSaveFileNameProperty m_absoluteFilePath;
+
+    /// Filepath relative
+    GtStringProperty m_relativeFilePath;
+
+    /// target object
+    GtObjectLinkProperty m_targetObject;
+
+};
+
+#endif // GTEXPORTTOMEMENTOCALCULATOR_H

--- a/src/core/process_management/calculators/gt_exporttomementocalculator.h
+++ b/src/core/process_management/calculators/gt_exporttomementocalculator.h
@@ -33,6 +33,8 @@ public:
      */
     bool run() override;
 
+    static GtCalculatorData calculatorData();
+
 private:
     /// file mode
     GtModeProperty m_fileMode;

--- a/src/core/process_management/gt_calculatorfactory.cpp
+++ b/src/core/process_management/gt_calculatorfactory.cpp
@@ -23,11 +23,8 @@ GtCalculatorFactory::GtCalculatorFactory(QObject* parent) : QObject(parent)
     registerClass(GT_METADATA(GtTaskLink));
 
     // Default calculators
-    GtCalculatorData exportMemento = GT_CALC_DATA(GtExportToMementoCalculator);
-    exportMemento->id = QStringLiteral("Export Object to Memento");
-    exportMemento->version = GtVersionNumber(1,0);
-    exportMemento->status = GtCalculatorDataImpl::RELEASE;
-    GtCalculatorFactory::registerCalculatorData(exportMemento);
+    GtCalculatorFactory::registerCalculatorData(
+        GtExportToMementoCalculator::calculatorData());
 }
 
 GtCalculatorFactory*

--- a/src/core/process_management/gt_calculatorfactory.cpp
+++ b/src/core/process_management/gt_calculatorfactory.cpp
@@ -15,9 +15,19 @@
 #include "gt_tasklink.h"
 #include "gt_calculatordata.h"
 
+#include "gt_exporttomementocalculator.h"
+
 GtCalculatorFactory::GtCalculatorFactory(QObject* parent) : QObject(parent)
 {
+    // TODO: task link should be deleted
     registerClass(GT_METADATA(GtTaskLink));
+
+    // Default calculators
+    GtCalculatorData exportMemento = GT_CALC_DATA(GtExportToMementoCalculator);
+    exportMemento->id = QStringLiteral("Export Object to Memento");
+    exportMemento->version = GtVersionNumber(1,0);
+    exportMemento->status = GtCalculatorDataImpl::RELEASE;
+    GtCalculatorFactory::registerCalculatorData(exportMemento);
 }
 
 GtCalculatorFactory*


### PR DESCRIPTION
Added a new calculator to be able to export user selected data objects from current project.
The objects are exported in Memento-Format (XML).
Users can select whether the object is exported to an absolute or relative file path .
The relative file path can be related to the project directory or the working directory.
Missing subdirectories are created automatically.

## Description
The calculator is currently required specifically for regression tests.
It fixes issue #1251

## How Has This Been Tested?
The calculator was tested manually in all three modes.

## Checklist:
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
