### PR TITLE
Fixed multiple problems in batch commonad "gtlabconsole run -f ..."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed "GTlabConsole run -f project.gtlab -s" not saving changes to the project - #1254
+- Fixed task group argument ignored in batch command "GTlabConsole run -f project.gtlab" - #1254
+
 ## [2.0.8] - 2024-06-19
 ### Fixed
 - Fixed bug introduced in 2.0.7, that "GTlabConsole run" does not save projects anymore. This change reverts

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -294,53 +294,7 @@ gt::console::runProcessByFile(const QString& projectFile,
     }
 
     gtApp->session()->appendChild(project);
-
-    if (!gtDataModel->GtCoreDatamodel::openProject(project))
-    {
-        gtError() << QObject::tr("Could not open project!")
-                  << QStringLiteral(" (") << projectFile
-                  << QStringLiteral(")");
-
-        return -1;
-    }
-
-    gtDebug() << QObject::tr("project opened!");
-
-    // run process
-    GtTask* process = project->findProcess(processId);
-    if (!process)
-    {
-        gtError() << QObject::tr("Process not found!")
-                  << QStringLiteral(" (") << processId << QStringLiteral(")");
-
-        return -1;
-    }
-
-    // execute process
-    auto& executor = gt::currentProcessExecutor();
-    executor.setCoreExecutorFlags(gt::DryExecution);
-    executor.runTask(process);
-
-    if (process->currentState() != GtProcessComponent::FINISHED)
-    {
-        gtWarning() << QObject::tr("Calculator run failed!");
-        return -1;
-    }
-
-    gtDebug() << QObject::tr("process run successful!");
-
-    if (save)
-    {
-        if (!gtDataModel->saveProject(project))
-        {
-            gtError() << QObject::tr("project could not be saved!")
-                      << QStringLiteral(" (") << projectFile
-                      << QStringLiteral(")");
-            return -1;
-        }
-    }
-
-    return 0;
+    return runProcess(project->objectName(), processId, taskGroupId, save);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Fixed "GTlabConsole run -f project.gtlab -s" not saving changes to the project
2. Fixed task group argument ignored in batch command "GTlabConsole run -f project.gtlab"

The reason for problem 1. was, that the process executor was setup to do a dry run, 
resulting in not merging back the changed memento, allthough the project was technically saved.

The reason for problem 2. was, that the argument "GroupID" was simply not used accidentally.

To avoid these problems in future, I changed the code to reuse the existing function `runProcess`.

## How Has This Been Tested?

Local Changes and in Sketchpad regression tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
