### PR TITLE
Added project dir to package read/save api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 2.1]
+### Changed
+ - GtPackage and all derived classes now use an additional project directory as its first argument in `GtPackage::read` and `GtPackage::save`. This will impact module code! - #617
+
 ## [2.0.8] - 2024-06-19
 ### Fixed
 - Fixed bug introduced in 2.0.7, that "GTlabConsole run" does not save projects anymore. This change reverts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased 2.1]
-### Changed
- - GtPackage and all derived classes now use an additional project directory as its first argument in `GtPackage::read` and `GtPackage::save`. This will impact module code! - #617
+### Added
+ - New interface methods `GtPackage::readMiscData` and  `GtPackage::saveMiscData` to store package data outside of the package xml structure inside the project directory.
+   Both methods have the project directory as an argument, workarounds like currentProject()->path() can be hence avoided - #617
 
 ## [2.0.8] - 2024-06-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased 2.1]
 ### Added
  - New interface methods `GtPackage::readMiscData` and  `GtPackage::saveMiscData` to store package data outside of the package xml structure inside the project directory.
-   Both methods have the project directory as an argument, workarounds like currentProject()->path() can be hence avoided - #617
+   Both methods have the project directory as an argument, hence workarounds like currentProject()->path() can be avoided - #617
 
 ## [2.0.8] - 2024-06-19
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT DEFINED CMAKE_BUILD_TYPE)
     "MinSizeRel" "RelWithDebInfo")
 endif()
 
-project(GTlab-Core VERSION 2.0.8)
+project(GTlab-Core VERSION 2.1.0)
 
 option(BUILD_WITH_HDF5 "Build with hdf5 support" ON)
 option(BUILD_UNITTESTS "Build the unit tests" OFF)

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.45.0"
 
 class GTlabCore(ConanFile):
     name = "gtlab-core"
-    version = "2.0.8"
+    version = "2.1.0-dev"
     license = "GTlab license"
     author = "Martin Siggel <martin.siggel@dlr.de>"
     url = "https://gitlab.dlr.de/gtlab-coredev/gtlab"

--- a/src/core/gt_coreapplication.cpp
+++ b/src/core/gt_coreapplication.cpp
@@ -336,17 +336,8 @@ GtCoreApplication::initLogging()
         logger.setLoggingLevel(gt::log::levelFromInt(m_settings->loggingLevel()));
     }
 
-    // TODO: Remove this if block in GTlab 2.1 (see !294)
-    if (args.contains(QStringLiteral("-dev")))
-    {
-        static_assert(GT_VERSION < GT_VERSION_CHECK(2, 1, 0),
-                      "DEPRECATED: Remove me! (see MR !294)");
-        enableDevMode();
-        gtWarning() << tr("DEPRECATED: Enable dev-mode using '--dev' "
-                          "option instead");
-    }
     // dev mode
-    else if (args.contains(QStringLiteral("--dev")))
+    if (args.contains(QStringLiteral("--dev")))
     {
         enableDevMode();
     }

--- a/src/core/gt_project.cpp
+++ b/src/core/gt_project.cpp
@@ -615,7 +615,7 @@ GtProject::readModuleData()
 
         package->setUuid(uuid);
 
-        if (!package->readData(root) && !package->readMiscData(QDir(m_path)))
+        if (!package->readData(root) || !package->readMiscData(QDir(m_path)))
         {
             gtWarning() << objectName() << ": "
                         << tr("Failed to read module data!")
@@ -676,7 +676,7 @@ GtProject::saveModuleData()
 
         document.appendChild(rootElement);
 
-        if (!package->saveData(rootElement, document) && !package->saveMiscData(QDir(m_path)))
+        if (!package->saveData(rootElement, document) || !package->saveMiscData(QDir(m_path)))
         {
             gtWarning().noquote()
                     << tr("Failed to save module data!")

--- a/src/core/gt_project.cpp
+++ b/src/core/gt_project.cpp
@@ -615,7 +615,7 @@ GtProject::readModuleData()
 
         package->setUuid(uuid);
 
-        if (!package->readData(QDir(m_path), root))
+        if (!package->readData(root) && !package->readMiscData(QDir(m_path)))
         {
             gtWarning() << objectName() << ": "
                         << tr("Failed to read module data!")
@@ -676,7 +676,7 @@ GtProject::saveModuleData()
 
         document.appendChild(rootElement);
 
-        if (!package->saveData(QDir(m_path), rootElement, document))
+        if (!package->saveData(rootElement, document) && !package->saveMiscData(QDir(m_path)))
         {
             gtWarning().noquote()
                     << tr("Failed to save module data!")

--- a/src/core/gt_project.cpp
+++ b/src/core/gt_project.cpp
@@ -528,16 +528,6 @@ GtProject::readLabelData(const GtObjectList& moduleData)
 GtObjectList
 GtProject::readModuleData()
 {
-    // set current project, so that packages can load data from disk (issue #267)
-    // emitting projectChanged signal to early may cause problems, therefore
-    // blocking gtApp temporarily is a crude workaround
-    QSignalBlocker block(gtApp);
-    gtApp->setCurrentProject(this);
-
-    auto cleanup = gt::finally([](){
-        gtApp->setCurrentProject(nullptr);
-    });
-
     GtObjectList retval;
 
     foreach (const QString& mid, m_moduleIds)
@@ -625,7 +615,7 @@ GtProject::readModuleData()
 
         package->setUuid(uuid);
 
-        if (!package->readData(root))
+        if (!package->readData(QDir(m_path), root))
         {
             gtWarning() << objectName() << ": "
                         << tr("Failed to read module data!")
@@ -686,7 +676,7 @@ GtProject::saveModuleData()
 
         document.appendChild(rootElement);
 
-        if (!package->saveData(rootElement, document))
+        if (!package->saveData(QDir(m_path), rootElement, document))
         {
             gtWarning().noquote()
                     << tr("Failed to save module data!")

--- a/src/dataprocessor/gt_package.cpp
+++ b/src/dataprocessor/gt_package.cpp
@@ -19,7 +19,7 @@ GtPackage::GtPackage()
 }
 
 bool
-GtPackage::readData(const QDomElement& root)
+GtPackage::readData(const QDir&, const QDomElement& root)
 {
     QDomElement oe = root.firstChildElement("object");
     while (!oe.isNull())
@@ -62,7 +62,7 @@ GtPackage::readData(const QDomElement& root)
 }
 
 bool
-GtPackage::saveData(QDomElement& root, QDomDocument& /*doc*/)
+GtPackage::saveData(const QDir& /*unused */, QDomElement& root, QDomDocument& /*doc*/)
 {
     foreach (GtObject* obj, findDirectChildren<GtObject*>())
     {

--- a/src/dataprocessor/gt_package.cpp
+++ b/src/dataprocessor/gt_package.cpp
@@ -19,7 +19,7 @@ GtPackage::GtPackage()
 }
 
 bool
-GtPackage::readData(const QDir&, const QDomElement& root)
+GtPackage::readData(const QDomElement& root)
 {
     QDomElement oe = root.firstChildElement("object");
     while (!oe.isNull())
@@ -61,8 +61,13 @@ GtPackage::readData(const QDir&, const QDomElement& root)
     return true;
 }
 
+bool GtPackage::readMiscData(const QDir &projectDir)
+{
+    return true;
+}
+
 bool
-GtPackage::saveData(const QDir& /*unused */, QDomElement& root, QDomDocument& /*doc*/)
+GtPackage::saveData(QDomElement& root, QDomDocument& /*doc*/)
 {
     foreach (GtObject* obj, findDirectChildren<GtObject*>())
     {
@@ -70,5 +75,10 @@ GtPackage::saveData(const QDir& /*unused */, QDomElement& root, QDomDocument& /*
         root.appendChild(memento.documentElement());
     }
 
+    return true;
+}
+
+bool GtPackage::saveMiscData(const QDir &projectDir)
+{
     return true;
 }

--- a/src/dataprocessor/gt_package.h
+++ b/src/dataprocessor/gt_package.h
@@ -17,6 +17,7 @@
 
 class QDomElement;
 class QDomDocument;
+class QDir;
 
 /**
  * @brief The GtPackage class
@@ -28,17 +29,17 @@ class GT_DATAMODEL_EXPORT GtPackage : public GtObject
 public:
     /**
      * @brief Module specific data read method.
-     * @param Root data.
+     *
      * @return Returns true if data was successfully read.
      */
-    virtual bool readData(const QDomElement& root);
+    virtual bool readData(const QDir& projectDir, const QDomElement& root);
 
     /**
      * @brief Module specific data save method.
-     * @param Root data.
+     *
      * @return Returns true if data was successfully read.
      */
-    virtual bool saveData(QDomElement& root, QDomDocument& doc);
+    virtual bool saveData(const QDir& projectDir, QDomElement& root, QDomDocument& doc);
 
 protected:
     /**

--- a/src/dataprocessor/gt_package.h
+++ b/src/dataprocessor/gt_package.h
@@ -30,16 +30,34 @@ public:
     /**
      * @brief Module specific data read method.
      *
+     * Reads in package data from an xml node provided by GTlab
+     *
      * @return Returns true if data was successfully read.
      */
-    virtual bool readData(const QDir& projectDir, const QDomElement& root);
+    virtual bool readData(const QDomElement& root);
+
+    /**
+     * @brief Reads additional package data that are stored in the project dir
+     * @param projectDir Directory of the project
+     *
+     * @return Returns true if data was successfully read.
+     */
+    virtual bool readMiscData(const QDir& projectDir);
 
     /**
      * @brief Module specific data save method.
      *
      * @return Returns true if data was successfully read.
      */
-    virtual bool saveData(const QDir& projectDir, QDomElement& root, QDomDocument& doc);
+    virtual bool saveData(QDomElement& root, QDomDocument& doc);
+
+    /**
+     * @brief Saves additional package data that are stored in the project dir
+     * @param projectDir Directory of the project
+     *
+     * @return Returns true if data was successfully read.
+     */
+    virtual bool saveMiscData(const QDir& projectDir);
 
 protected:
     /**

--- a/src/dataprocessor/gt_version.h
+++ b/src/dataprocessor/gt_version.h
@@ -12,9 +12,9 @@
 #define GT_VERSION_H
 
 #define GT_VERSION_MAJOR 2
-#define GT_VERSION_MINOR 0
-#define GT_VERSION_PATCH 8
-#define GT_VERSION_PRE_RELEASE ""
+#define GT_VERSION_MINOR 1
+#define GT_VERSION_PATCH 0
+#define GT_VERSION_PRE_RELEASE "dev"
 #define GT_VERSION_BUILD ""
 
 /*


### PR DESCRIPTION
Closes #617

<!--- Provide a general summary of your changes in the Title above -->

## Description

__ ABI CHANGE__

- Added new package read/write functions to store miscelleneous data, like intelligraphs etc.
- The new functions are directly executed after calling the xml-based ones.
- Using the new APi, the currentProject()->path workaround can be avoided, which is error prone.
- Modules, that don't exploit this functionality require only a recompile
- Other modules (like intelligraph) should be adapted to use this new API

@mariusalexander I quickly adapted locally the intelligraph package to test this. Seems to be working.
Please still have a look!

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Locally, with an adapted intelligraph.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
