### PR TITLE
Fix sort for collection items without additional parameters

### DIFF
--- a/src/gui/mdi_items/collection_env/gt_localcollectionmodel.cpp
+++ b/src/gui/mdi_items/collection_env/gt_localcollectionmodel.cpp
@@ -240,11 +240,6 @@ GtLocalCollectionModel::propIds() const
 void
 GtLocalCollectionModel::sort(int column, Qt::SortOrder order)
 {
-    if (m_propIds.empty())
-    {
-        return;
-    }
-
     using T = GtCollectionItem;
     std::function<bool(T const&, T const&)> function;
 
@@ -266,6 +261,8 @@ GtLocalCollectionModel::sort(int column, Qt::SortOrder order)
         };
         break;
     default:
+        if (m_propIds.empty()) return;
+
         if (column > 2 && column - 3 < m_propIds.size())
         {
             QString const& prop = m_propIds.at(column - 3);


### PR DESCRIPTION
The check for additional parameters to use for sorting is moved to the relevant section and not done default.

## How Has This Been Tested?
Manual as sorting is now possible by name for material collection as it was not before


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
