### PR TITLE
feat.: Enable Sorting for QLineEdits in Preference View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - New interface methods `GtPackage::readMiscData` and  `GtPackage::saveMiscData` to store package data outside of the package xml structure inside the project directory.
    Both methods have the project directory as an argument, hence workarounds like currentProject()->path() can be avoided - #617
 
+### Fixed
+ - Fixed alphabetically sorting of Shortcuts in Preference View #482
+
 ## [2.0.8] - 2024-06-19
 ### Fixed
 - Fixed bug introduced in 2.0.7, that "GTlabConsole run" does not save projects anymore. This change reverts

--- a/src/app/preferences/pages/gt_preferencesshortcuts.cpp
+++ b/src/app/preferences/pages/gt_preferencesshortcuts.cpp
@@ -94,10 +94,11 @@ GtPreferencesShortCuts::GtPreferencesShortCuts() :
         if (!editable)
         {
             edit->setEnabled(false);
-            edit->setToolTip(tr("Not editable"));
+            edit->GtLineEdit::setToolTip(tr("Not editable"));
         }
 
         m_tab->setItem(i, 0, idItem);
+        m_tab->setItem(i, 1, edit);
         m_tab->setItem(i, 2, catItem);
         ++i;
     }

--- a/src/gui/widgets/gt_shortcutedit.cpp
+++ b/src/gui/widgets/gt_shortcutedit.cpp
@@ -14,7 +14,6 @@
 
 #include <QKeyEvent>
 
-
 GtShortCutEdit::GtShortCutEdit(const QKeySequence& shortcut,
                                const QString& shortcutID,
                                QWidget* parent) :
@@ -52,7 +51,7 @@ void
 GtShortCutEdit::setKeySequence(const QKeySequence& seq)
 {
     m_keySequence = seq;
-    this->setText(seq.toString());
+    this->GtLineEdit::setText(seq.toString());
 }
 
 void
@@ -64,7 +63,7 @@ GtShortCutEdit::keyPressEvent(QKeyEvent* event)
     if (event->key() == Qt::Key_Escape)
     {
         // clear input if nothing was set
-        if (this->text().isEmpty())
+        if (this->GtLineEdit::text().isEmpty())
         {
             this->clear();
         }
@@ -111,7 +110,7 @@ GtShortCutEdit::keyPressEvent(QKeyEvent* event)
 
         if (!text.isEmpty())
         {
-            this->setText(text + QStringLiteral("..."));
+            this->GtLineEdit::setText(text + QStringLiteral("..."));
         }
         return;
     }
@@ -124,14 +123,14 @@ GtShortCutEdit::keyPressEvent(QKeyEvent* event)
         // dont allow simple keys (eg. chars and numbers)
         if (text.length() == 1)
         {
-            this->setText(QStringLiteral("...") + text);
+            this->GtLineEdit::setText(QStringLiteral("...") + text);
             return;
         }
     }
 
     // valid key combination
     m_lastKey = key;
-    this->setText(QKeySequence(key | modifiers).toString());
+    this->GtLineEdit::setText(QKeySequence(key | modifiers).toString());
 }
 
 void
@@ -161,14 +160,14 @@ GtShortCutEdit::onFocusOut()
     setPlaceholderText(QStringLiteral(""));
 
     // incomplete keysequence (only modifiers)
-    if (this->text().contains(QStringLiteral("...")))
+    if (this->GtLineEdit::text().contains(QStringLiteral("...")))
     {
         //restore old keysequence
         setKeySequence(m_keySequence);
         return;
     }
 
-    setKeySequence(this->text());
+    setKeySequence(this->GtLineEdit::text());
 }
 
 void

--- a/src/gui/widgets/gt_shortcutedit.h
+++ b/src/gui/widgets/gt_shortcutedit.h
@@ -16,18 +16,34 @@
 
 #include "gt_lineedit.h"
 #include <QKeySequence>
+#include <QTableWidgetItem>
 
 /**
  * @brief The GtShortCutEdit class
  * Used to input a keysequence for a short cut (single key + multiple modifers).
  */
-class GT_GUI_EXPORT GtShortCutEdit : public GtLineEdit
+class GT_GUI_EXPORT GtShortCutEdit : public GtLineEdit, public QTableWidgetItem
 {
     Q_OBJECT
 
     Q_PROPERTY(QKeySequence keySequence READ keySequence WRITE setKeySequence)
 
 public:
+
+    bool operator <(const QTableWidgetItem& other) const
+    {
+        if(other.column() == 0 /* numeric cell */) {
+             return QTableWidgetItem::text().toInt() < other.text().toInt();
+        }
+        else if(other.column() == 1 /* progress bar */) {
+            const GtLineEdit *p = dynamic_cast<const GtLineEdit *>(&other);
+            if(p != 0) {
+                if(this->GtLineEdit::text() < p->text())
+                    return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * @brief GtShortCutEdit constructor

--- a/src/gui/widgets/gt_shortcutedit.h
+++ b/src/gui/widgets/gt_shortcutedit.h
@@ -41,10 +41,7 @@ public:
         {
             const GtLineEdit *p = dynamic_cast<const GtLineEdit *>(&other);
 
-            if (p)
-            {
-                if (this->GtLineEdit::text() < p->text()) return true;
-            }
+            if (p && this->GtLineEdit::text() < p->text()) return true;
         }
 
         return false;

--- a/src/gui/widgets/gt_shortcutedit.h
+++ b/src/gui/widgets/gt_shortcutedit.h
@@ -30,18 +30,23 @@ class GT_GUI_EXPORT GtShortCutEdit : public GtLineEdit, public QTableWidgetItem
 
 public:
 
+    /**
+     * @brief operator < for sorting GtLineEdits
+     * @param other
+     * @return
+     */
     bool operator <(const QTableWidgetItem& other) const
     {
-        if(other.column() == 0 /* numeric cell */) {
-             return QTableWidgetItem::text().toInt() < other.text().toInt();
-        }
-        else if(other.column() == 1 /* progress bar */) {
+        if (other.column() == 1)
+        {
             const GtLineEdit *p = dynamic_cast<const GtLineEdit *>(&other);
-            if(p != 0) {
-                if(this->GtLineEdit::text() < p->text())
-                    return true;
+
+            if (p)
+            {
+                if (this->GtLineEdit::text() < p->text()) return true;
             }
         }
+
         return false;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding GtShortCutEdit as an Item to The Table and Implemented a special comparison method for sorting the entries according to the ShortCut-String.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/dlr-gtlab/gtlab-core/issues/482

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Worked in local GTlab instance.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [x] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [x] The number of code quality warnings is not increasing.
