### PR TITLE
Add functionality to test module interface versions

### DIFF
--- a/src/core/gt_datamodelinterface.h
+++ b/src/core/gt_datamodelinterface.h
@@ -13,6 +13,8 @@
 
 #include "gt_core_exports.h"
 
+#include "gt_globals.h"
+
 #include <QtPlugin>
 
 /**
@@ -51,8 +53,11 @@ public:
 
 QT_BEGIN_NAMESPACE
 Q_DECLARE_INTERFACE(GtDatamodelInterface,
-                    "de.dlr.gtlab.GtDatamodelInterface/0.1")
+                    "de.dlr.gtlab.GtDatamodelInterface/2.1")
 QT_END_NAMESPACE
+
+GT_OLD_INTERFACES(GtDatamodelInterface,
+                  "de.dlr.gtlab.GtDatamodelInterface/0.1")
 
 #endif // GT_DATAMODELINTERFACE_H
 

--- a/src/core/gt_globals.h
+++ b/src/core/gt_globals.h
@@ -14,6 +14,8 @@
 
 #include "gt_version.h"
 
+#include <QStringList>
+
 #define GT_MAINTENANCETOOL "MaintenanceTool"
 
 #ifndef GT_MODULE_ID
@@ -27,5 +29,23 @@ Please define the macro using -DGT_MODULE_ID =<module_id>
 #define deprecated_from(major, minor, message)                             \
 [[deprecated("Will be removed in GTlab " \
     #major "." #minor ". " message)]] \
+
+template <typename InterfaceType>
+inline QStringList gtGetOutdatedItfVersions()
+{
+    return {};
+}
+
+/**
+ * Defines previous interface versions for error tracking
+ *
+ * Usage:
+ *
+ * GT_OLD_INTERFACES(GtModuleInterface,
+ *                  "de.dlr.gtlab.GtModuleInterface/1.7",
+ *                  "de.dlr.gtlab.GtModuleInterface/2.0")
+ */
+#define GT_OLD_INTERFACES(TYPE, ...) template <> \
+inline QStringList gtGetOutdatedItfVersions<TYPE>() {return {__VA_ARGS__};}
 
 #endif // GT_GLOBALS_H

--- a/src/core/gt_moduleinterface.h
+++ b/src/core/gt_moduleinterface.h
@@ -218,4 +218,8 @@ Q_DECLARE_INTERFACE(GtModuleInterface,
                     "de.dlr.gtlab.GtModuleInterface/2.0")
 QT_END_NAMESPACE
 
+
+GT_OLD_INTERFACES(GtModuleInterface,
+                  "de.dlr.gtlab.GtModuleInterface/1.7")
+
 #endif // GT_MODULEINTERFACE_H

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -732,7 +732,7 @@ GtModuleLoader::insert(GtModuleInterface* plugin)
         gt::commandline::registerFunction(commandLineFunction);
     }
 
-    GtDatamodelInterface* dmp = dynamic_cast<GtDatamodelInterface*>(plugin);
+    GtDatamodelInterface* dmp = checkInterface<GtDatamodelInterface>(plugin->ident(), plugin);
 
     // contains dynamic linked datamodel classes
     if (dmp)

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -611,16 +611,14 @@ GtModuleLoader::moduleLicence(const QString& id) const
 
 QString
 GtModuleLoader::getSupportedInterfaceByModule(QObject *pluginObj,
-                                              const QStringList &listOfInterfaces)
+                                              const QStringList &lOfItfs)
 {
-    QStringList supportedInterfaces;
-    for (const QString& interfaceName : listOfInterfaces)
-    {
-        if (pluginObj->qt_metacast(interfaceName.toUtf8().constData()))
-            return interfaceName;
-    }
+    auto found = std::find_if(std::begin(lOfItfs), std::end(lOfItfs),
+                 [&pluginObj](const QString& itfName) {
+        return pluginObj->qt_metacast(itfName.toUtf8().constData()) != nullptr;
+    });
 
-    return "unknown";
+    return found != lOfItfs.end() ? *found : "unknown";
 }
 
 QString

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -871,8 +871,9 @@ GtModuleLoader::Impl::performLoading(GtModuleLoader& moduleLoader,
                 << QObject::tr("loading ") << moduleMeta.location() << "...";
 
         // check that plugin is a GTlab module
-        checkInterface<GtModuleInterface>(moduleMeta.location(), plugin.get());
-        auto module = gt::unique_qobject_cast<GtModuleInterface>(std::move(plugin));
+        auto module = gt::transfer_unique(std::move(plugin),[&](QObject* o) {
+            return checkInterface<GtModuleInterface>(moduleMeta.location(), o);
+        });
 
         if (module && moduleLoader.check(module.get()))
         {

--- a/src/core/gt_moduleloader.h
+++ b/src/core/gt_moduleloader.h
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include <gt_logging.h>
+#include <gt_globals.h>
 
 class QStringList;
 class QJsonObject;

--- a/src/core/gt_moduleloader.h
+++ b/src/core/gt_moduleloader.h
@@ -208,7 +208,7 @@ inline InterfaceType* checkInterface(const QString& soName, Plugin* plugin)
         auto oldItf = GtModuleLoader::getSupportedInterfaceByModule(
             obj, gtGetOutdatedItfVersions<InterfaceType>());
 
-        gtError() << QObject::tr("Version mismatch of module '%1' "
+        gtLogOnce(Error) << QObject::tr("Version mismatch of module '%1' "
                                  "with GTlab interface '%2'. "
                                  "It was compiled against '%3'")
                          .arg(soName,

--- a/src/core/process_management/gt_processmoduleloader.cpp
+++ b/src/core/process_management/gt_processmoduleloader.cpp
@@ -34,16 +34,18 @@ GtProcessModuleLoader::GtProcessModuleLoader()
 bool
 GtProcessModuleLoader::check(GtModuleInterface* plugin) const
 {
-    const auto errorString = [=](){
-        return QObject::tr("Loading module '%1' failed:").arg(plugin->ident());
-    };
 
     if (!GtModuleLoader::check(plugin))
     {
         return false;
     }
 
-    GtProcessInterface* proi = dynamic_cast<GtProcessInterface*>(plugin);
+    const auto errorString = [=](){
+        return QObject::tr("Loading module '%1' failed:").arg(plugin->ident());
+    };
+
+    GtProcessInterface* proi = checkInterface<GtProcessInterface>(
+        plugin->ident(), plugin);
 
     if (proi)
     {
@@ -85,8 +87,8 @@ GtProcessModuleLoader::check(GtModuleInterface* plugin) const
         }
     }
 
-    GtCalculatorExecInterface* cexecp =
-            dynamic_cast<GtCalculatorExecInterface*>(plugin);
+    GtCalculatorExecInterface* cexecp = checkInterface<GtCalculatorExecInterface>(
+        plugin->ident(), plugin);
 
     // contains dynamic linked calculator execution classes
     if (cexecp)
@@ -94,7 +96,8 @@ GtProcessModuleLoader::check(GtModuleInterface* plugin) const
         // check for GtAbstractCalculatorExecutor class
     }
 
-    GtNetworkInterface* neti = dynamic_cast<GtNetworkInterface*>(plugin);
+    GtNetworkInterface* neti = checkInterface<GtNetworkInterface>(
+        plugin->ident(), plugin);
 
     if (neti)
     {

--- a/src/core/process_management/gt_processmoduleloader.cpp
+++ b/src/core/process_management/gt_processmoduleloader.cpp
@@ -129,7 +129,8 @@ GtProcessModuleLoader::insert(GtModuleInterface* plugin)
 {
     GtModuleLoader::insert(plugin);
 
-    GtProcessInterface* proi = dynamic_cast<GtProcessInterface*>(plugin);
+    GtProcessInterface* proi = checkInterface<GtProcessInterface>(plugin->ident(),
+                                                                  plugin);
 
     if (proi)
     {
@@ -152,7 +153,7 @@ GtProcessModuleLoader::insert(GtModuleInterface* plugin)
     }
 
     GtCalculatorExecInterface* cexecp =
-            dynamic_cast<GtCalculatorExecInterface*>(plugin);
+            checkInterface<GtCalculatorExecInterface>(plugin->ident(), plugin);
 
     // contains dynamic linked calculator execution classes
     if (cexecp)
@@ -169,7 +170,8 @@ GtProcessModuleLoader::insert(GtModuleInterface* plugin)
         gtCalcExecList->addExecutor(cexecp);
     }
 
-    GtNetworkInterface* neti = dynamic_cast<GtNetworkInterface*>(plugin);
+    GtNetworkInterface* neti = checkInterface<GtNetworkInterface>(plugin->ident(),
+                                                                  plugin);
 
     if (neti)
     {

--- a/src/dataprocessor/gt_qtutilities.h
+++ b/src/dataprocessor/gt_qtutilities.h
@@ -82,15 +82,19 @@ inline auto container_const_cast(Vec<T...>&& contianer)
  * @return
  */
 template <typename Base, typename TransferFunction>
-inline auto transfer_unique(std::unique_ptr<Base>&& basePtr,
-                            TransferFunction&& castFunc) noexcept
+inline auto
+transfer_unique(std::unique_ptr<Base>&& basePtr,
+                TransferFunction&& transferFunc) noexcept
+
     -> std::unique_ptr<std::remove_pointer_t<
-        typename std::result_of<decltype(castFunc)(Base*)>::type>>
+        typename std::result_of_t<decltype(transferFunc)(Base*)>>>
+
 {
     using TransferredType = std::remove_pointer_t<
-        typename std::result_of<decltype(castFunc)(Base*)>::type>;
+        typename std::result_of_t<decltype(transferFunc)(Base*)>>;
 
-    auto derivedPtr = std::unique_ptr<TransferredType>(castFunc(basePtr.get()));
+    auto derivedPtr = std::unique_ptr<TransferredType>(
+        transferFunc(basePtr.get()));
 
     if (derivedPtr)
     {

--- a/src/gui/gt_guimoduleloader.cpp
+++ b/src/gui/gt_guimoduleloader.cpp
@@ -129,7 +129,8 @@ GtGuiModuleLoader::check(GtModuleInterface* plugin) const
         return true;
     }
 
-    GtMdiInterface* mdip = dynamic_cast<GtMdiInterface*>(plugin);
+    GtMdiInterface* mdip = checkInterface<GtMdiInterface>(
+        plugin->ident(), plugin);
 
     // contains dynamic linked mdi classes
     if (mdip)
@@ -180,7 +181,8 @@ GtGuiModuleLoader::check(GtModuleInterface* plugin) const
     }
 
     // importer interface
-    GtImporterInterface* impp = dynamic_cast<GtImporterInterface*>(plugin);
+    GtImporterInterface* impp = checkInterface<GtImporterInterface>(
+        plugin->ident(), plugin);
 
     if (impp)
     {
@@ -200,7 +202,8 @@ GtGuiModuleLoader::check(GtModuleInterface* plugin) const
     }
 
     // exporter interface
-    GtExporterInterface* expp = dynamic_cast<GtExporterInterface*>(plugin);
+    GtExporterInterface* expp = checkInterface<GtExporterInterface>(
+        plugin->ident(), plugin);
 
     if (expp)
     {
@@ -220,7 +223,8 @@ GtGuiModuleLoader::check(GtModuleInterface* plugin) const
     }
 
     // property interface
-    GtPropertyInterface* prop = dynamic_cast<GtPropertyInterface*>(plugin);
+    GtPropertyInterface* prop = checkInterface<GtPropertyInterface>(
+        plugin->ident(), plugin);
 
     if (prop)
     {
@@ -242,8 +246,8 @@ GtGuiModuleLoader::check(GtModuleInterface* plugin) const
     }
 
     // collection interface
-    GtCollectionInterface* coll =
-            dynamic_cast<GtCollectionInterface*>(plugin);
+    GtCollectionInterface* coll = checkInterface<GtCollectionInterface>(
+        plugin->ident(), plugin);
 
     if (coll)
     {

--- a/src/gui/gt_guimoduleloader.cpp
+++ b/src/gui/gt_guimoduleloader.cpp
@@ -269,10 +269,13 @@ GtGuiModuleLoader::check(GtModuleInterface* plugin) const
 void
 GtGuiModuleLoader::insert(GtModuleInterface* plugin)
 {
+    if (!plugin) return;
+
     QApplication::processEvents();
     GtCoreModuleLoader::insert(plugin);
 
-    GtMdiInterface* mdip = dynamic_cast<GtMdiInterface*>(plugin);
+    GtMdiInterface* mdip = checkInterface<GtMdiInterface>(plugin->ident(),
+                                                          plugin);
 
     // contains dynamic linked mdi classes
     if (mdip && !gtApp->batchMode())
@@ -294,7 +297,8 @@ GtGuiModuleLoader::insert(GtModuleInterface* plugin)
     }
 
     // importer interface
-    GtImporterInterface* impp = dynamic_cast<GtImporterInterface*>(plugin);
+    GtImporterInterface* impp =
+        checkInterface<GtImporterInterface>(plugin->ident(), plugin);
 
     if (impp)
     {
@@ -302,7 +306,8 @@ GtGuiModuleLoader::insert(GtModuleInterface* plugin)
     }
 
     // exporter interface
-    GtExporterInterface* expp = dynamic_cast<GtExporterInterface*>(plugin);
+    GtExporterInterface* expp =
+        checkInterface<GtExporterInterface>(plugin->ident(), plugin);
 
     if (expp)
     {
@@ -310,7 +315,8 @@ GtGuiModuleLoader::insert(GtModuleInterface* plugin)
     }
 
     // property interface
-    GtPropertyInterface* prop = dynamic_cast<GtPropertyInterface*>(plugin);
+    GtPropertyInterface* prop =
+        checkInterface<GtPropertyInterface>(plugin->ident(), plugin);
 
     if (prop)
     {
@@ -319,7 +325,7 @@ GtGuiModuleLoader::insert(GtModuleInterface* plugin)
 
     // collection interface
     GtCollectionInterface* coll =
-            dynamic_cast<GtCollectionInterface*>(plugin);
+            checkInterface<GtCollectionInterface>(plugin->ident(), plugin);
 
     if (coll)
     {


### PR DESCRIPTION
This PR also increases the datamodel interface version, as the GtPackage ABI was changed in a previous PR.

Closes #1273

<!--- Provide a general summary of your changes in the Title above -->

## Description

- added function `checkInterface`  to test interface compatibility
- added macro `GT_OLD_INTERFACES` to define previous interface versions that are used to test a module against

## How Has This Been Tested?
I tried to load e.g. basictools, which is now denied. When though building basictools from scratch against this version, it will load.

Here's an example, when GTlab does not load the TestDMI module, as it was compiled against 2.0:

![image](https://github.com/user-attachments/assets/a1ccfbe4-c88e-40ce-a6e2-daeddca70146)



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
