### PR TITLE
Fix crashes when two tasks / calculators are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+###
+- Fixed crash when deleting multiple calculators or task via the context menu - #1266
+
 ## [2.0.9] - 2024-06-20
 ### Fixed
 - Fixed "GTlabConsole run -f project.gtlab -s" not saving changes to the project - #1254

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -967,6 +967,7 @@ GtProcessDock::customContextMenu(const QModelIndex& srcIndex)
     if (m_view->selectionModel()->selectedRows(0).size() > 1)
     {
         multiSelectionContextMenu(m_view->selectionModel()->selectedIndexes());
+        return;
     }
 
     // single selection


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes the regression from 2.0.5, that deleting multiple process elements results in a crash.

The regression came from commit https://github.com/dlr-gtlab/gtlab-core/commit/37383d9c2e3b042d76ce645731d48bd6f54def0d, which had a incorrect refactoring in the end.

The change makes sure, that the single selection is not processed, when the multi-selection is handled.

## How Has This Been Tested?

1. Create two calculators
2. Delete them via context menu. 
3. Without the change, the app crashed (in debug mode at least). Now, everything is fine again.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
