### PR TITLE
Fix deletion of environment variables when trying to edit it via settings dialig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed crash when deleting multiple calculators or task via the context menu - #1266
+- Fixed deletion of environment variable value, when trying to edit it via gtlab settings - #1268
 
 ### Added
 - Added option to skip/unskip multiple process elements at once via keyboard shortcut - #1226

--- a/src/gui/tools/gt_environmentmodel.cpp
+++ b/src/gui/tools/gt_environmentmodel.cpp
@@ -75,7 +75,7 @@ GtEnvironmentModel::data(const QModelIndex& index, int role) const
     switch (role)
     {
     case Qt::EditRole:
-        break;
+        retVal = valId;
 
     case Qt::DisplayRole:
         if (col == 0)


### PR DESCRIPTION
## Description
- Return String for QLineEdit in displayCase for the QTableView
- Existing text can now be selected
