### PR TITLE
Major performance improvement of objectlink object selection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Major performance improvement of the objectlink selection dialog - #1206
 - Fixed crash when deleting multiple calculators or task via the context menu - #1266
 
 ### Added

--- a/src/core/gt_objectfiltermodel.cpp
+++ b/src/core/gt_objectfiltermodel.cpp
@@ -30,41 +30,10 @@ bool
 GtObjectFilterModel::filterAcceptsRow(int source_row,
                                       const QModelIndex& source_parent) const
 {
-    if (!source_parent.isValid())
-    {
-        return true;
-    }
-
-    bool retval = GtTreeFilterModel::filterAcceptsRow(source_row,
-                  source_parent);
-
-    if (!retval)
-    {
-        return false;
-    }
-
-    QModelIndex source_index = sourceModel()->index(source_row,
-                               this->filterKeyColumn(),
-                               source_parent);
-
-    if (source_index.isValid())
-    {
-        int i, nb = sourceModel()->rowCount(source_index) ;
-
-        for (i = 0; i < nb; ++i)
-        {
-            if (filterAcceptsRow(i, source_index))
-            {
-                return true ;
-            }
-        }
-
-        GtObject* obj = static_cast<GtObject*>(source_index.internalPointer());
-
-        return acceptsRow(obj->metaObject()->className());
-    }
-
-    return false;
+    return GtTreeFilterModel::filterAcceptsRow(source_row, source_parent,
+        [this](const GtObject* obj) {
+          return acceptsRow(obj->metaObject()->className());
+    });
 }
 
 Qt::ItemFlags

--- a/src/core/gt_treefiltermodel.cpp
+++ b/src/core/gt_treefiltermodel.cpp
@@ -27,30 +27,13 @@ bool
 GtTreeFilterModel::filterAcceptsRow(int source_row,
                                     const QModelIndex& source_parent) const
 {
-    if (!filterRegExp().isEmpty())
+    if (filterRegExp().isEmpty())
     {
-        QModelIndex source_index =
-                sourceModel()->index(source_row,
-                                     this->filterKeyColumn(),
-                                     source_parent);
-
-        if (source_index.isValid())
-        {
-            int i, nb = sourceModel()->rowCount(source_index) ;
-            for (i = 0; i < nb; ++i)
-            {
-                if (filterAcceptsRow(i, source_index))
-                {
-                    return true ;
-                }
-            }
-            QString key = sourceModel()->data(source_index,
-                                              filterRole()).toString();
-
-            return key.contains(filterRegExp()) ;
-        }
+        return QSortFilterProxyModel::filterAcceptsRow(source_row, source_parent);
     }
 
-    return QSortFilterProxyModel::filterAcceptsRow(source_row,
-                                                   source_parent);
+    return filterAcceptsRow(source_row, source_parent, [](const GtObject*)
+    {
+        return true;
+    });
 }

--- a/src/core/gt_treefiltermodel.h
+++ b/src/core/gt_treefiltermodel.h
@@ -82,7 +82,7 @@ protected:
         // otherwise test childs
         for (int i = 0; i < sourceModel()->rowCount(source_index); ++i)
         {
-            if (filterAcceptsRow(i, source_index, pred)) return true ;
+            if (filterAcceptsRow(i, source_index, pred)) return true;
         }
 
         return false;

--- a/src/core/gt_treefiltermodel.h
+++ b/src/core/gt_treefiltermodel.h
@@ -14,6 +14,7 @@
 #include "gt_core_exports.h"
 
 #include <QSortFilterProxyModel>
+#include <gt_object.h>
 
 /**
  * @brief The GtTreeFilterModel class
@@ -43,6 +44,49 @@ protected:
      */
     bool filterAcceptsRow(int source_row,
                           const QModelIndex& source_parent) const override;
+
+    /**
+     * @brief Same as filterAcceptsRow, but also checks the predicate pred(obj)
+     *        weather to accept this object or not in addition
+     *
+     * @param source_row
+     * @param source_parent
+     * @param pred Function(GtObject* obj). Returns true,
+     *             if obj should be accepted
+     * @return
+     */
+    template <typename Func>
+    bool filterAcceptsRow(int source_row,
+                          const QModelIndex& source_parent,
+                          Func&& pred) const
+    {
+        QModelIndex source_index =
+            sourceModel()->index(source_row,
+                                 this->filterKeyColumn(),
+                                 source_parent);
+
+        if (!source_index.isValid()) return false;
+
+        GtObject* obj = static_cast<GtObject*>(source_index.internalPointer());
+        assert(obj);
+
+        QString key = sourceModel()->data(source_index,
+                                          filterRole()).toString();
+
+        // check if this object is accepted
+        if (pred(obj) && key.contains(filterRegExp()))
+        {
+            return true;
+        }
+
+        // otherwise test childs
+        for (int i = 0; i < sourceModel()->rowCount(source_index); ++i)
+        {
+            if (filterAcceptsRow(i, source_index)) return true ;
+        }
+
+        return false;
+    }
 
 };
 

--- a/src/core/gt_treefiltermodel.h
+++ b/src/core/gt_treefiltermodel.h
@@ -82,7 +82,7 @@ protected:
         // otherwise test childs
         for (int i = 0; i < sourceModel()->rowCount(source_index); ++i)
         {
-            if (filterAcceptsRow(i, source_index)) return true ;
+            if (filterAcceptsRow(i, source_index, pred)) return true ;
         }
 
         return false;

--- a/src/gui/dock_widgets/process/gt_processfiltermodel.cpp
+++ b/src/gui/dock_widgets/process/gt_processfiltermodel.cpp
@@ -25,41 +25,10 @@ bool
 GtProcessFilterModel::filterAcceptsRow(int source_row,
                                        const QModelIndex& source_parent) const
 {
-    bool retval = GtTreeFilterModel::filterAcceptsRow(source_row,
-                  source_parent);
-
-    if (!retval)
+    return GtTreeFilterModel::filterAcceptsRow(source_row, source_parent,
+                                               [](GtObject* obj)
     {
-        return false;
-    }
-
-    QModelIndex source_index = sourceModel()->index(source_row,
-                               this->filterKeyColumn(),
-                               source_parent);
-
-    if (source_index.isValid())
-    {
-        int i, nb = sourceModel()->rowCount(source_index) ;
-
-        for (i = 0; i < nb; ++i)
-        {
-            if (filterAcceptsRow(i, source_index))
-            {
-                return true ;
-            }
-        }
-
-        GtObject* obj = static_cast<GtObject*>(source_index.internalPointer());
-
-        if (qobject_cast<GtTask*>(obj) || qobject_cast<GtCalculator*>(obj) ||
-                qobject_cast<GtTaskGroup*>(obj) ||
-                obj->isDummy())
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    return false;
+        return qobject_cast<GtTask*>(obj) || qobject_cast<GtCalculator*>(obj) ||
+               qobject_cast<GtTaskGroup*>(obj) || obj->isDummy();
+    });
 }

--- a/src/gui/gt_styledmodel.cpp
+++ b/src/gui/gt_styledmodel.cpp
@@ -38,7 +38,7 @@ GtStyledModel::data(const QModelIndex& index, int role) const
 
     if (item)
     {
-        GtObjectUI* oui = gtApp->defaultObjectUI(item);
+        GtObjectUI* oui = gtApp ? gtApp->defaultObjectUI(item) : nullptr;
 
         if (oui)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This improves the performance of the object link selection (`GtObjectFilterModel`).

The reason for the slow performance was a ping-pong of virtual calls between the `GtObjectFilterModel`and `GtTreeFilterModel`.
As a result, childs were unnecessary often traversed, resulting in an exponential decay in runtime.

The solution was to write the traversing logic in a function that also accept another predicate function checking, if an object is accepted. This avoids ping-ponging and excessive child traversal.

As a result, the implementation of `GtObjectFilterModel`and `GtProcessFilterModel` is now very short.

Closes #1206 

## How Has This Been Tested?

Local tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
