### PR TITLE
fix.: remove warnings for creation of multiple commands. These are recorded in the command stack

### DIFF
--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -508,10 +508,6 @@ GtApplication::startCommand(GtObject* root, const QString& commandId)
 
     if (!m_d->m_commandId.isEmpty())
     {
-        gtDebug().medium() << tr("already recording command")
-                           << QStringLiteral("...");
-        gtDebug().medium() << QStringLiteral("    |-> ") << m_d->m_commandId;
-        gtDebug().medium() << QStringLiteral("    |-> vs") << commandId;
         return GtCommand();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

remove warnings for creation of multiple commands. These are recorded in the command stack.
Thus the warnings are unneccessary. 