### PR TITLE
fix.: disabled switching project to same project while task is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 2.1]
+### Added
+ - New interface methods `GtPackage::readMiscData` and  `GtPackage::saveMiscData` to store package data outside of the package xml structure inside the project directory.
+   Both methods have the project directory as an argument, hence workarounds like currentProject()->path() can be avoided - #617
+
+### Fixed
+ - Fixed alphabetically sorting of Shortcuts in Preference View #482
+
+## [Unreleased]
+### Fixed
+ - Removed a warning, when double clicking on the current project while a task is running - #1282
+
 ## [2.0.10] - 2024-08-29
 ### Fixed
 - Fixed problems in the process dock. The changes from version 2.0.7 have been reverted. It is now again possible to change the order of tasks and calculators - #1270

--- a/src/gui/object_ui/gt_projectui.cpp
+++ b/src/gui/object_ui/gt_projectui.cpp
@@ -349,7 +349,14 @@ GtProjectUI::switchToProject(GtProject& toProject)
 void
 GtProjectUI::openProject(GtObject* obj)
 {
-    if (gt::currentProcessExecutor().taskCurrentlyRunning())
+    auto project = qobject_cast<GtProject*>(obj);
+
+    if (!project)
+    {
+        return;
+    }
+
+    if (gt::currentProcessExecutor().taskCurrentlyRunning() && !project->isOpen())
     {
         QMessageBox mb;
         mb.setIcon(QMessageBox::Information);
@@ -359,13 +366,6 @@ GtProjectUI::openProject(GtObject* obj)
         mb.setStandardButtons(QMessageBox::Ok);
         mb.setDefaultButton(QMessageBox::Ok);
         mb.exec();
-        return;
-    }
-
-    auto project = qobject_cast<GtProject*>(obj);
-
-    if (!project)
-    {
         return;
     }
 


### PR DESCRIPTION
Projects cannot be switched while task is running. This PR removes the possibility to switch to the same project while a task is running/does not show the project switch warning in this case.
