### PR TITLE
fix.: add task as dummy object to taskgroup if the task-module did no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - New interface methods `GtPackage::readMiscData` and  `GtPackage::saveMiscData` to store package data outside of the package xml structure inside the project directory.
    Both methods have the project directory as an argument, hence workarounds like currentProject()->path() can be avoided - #617
+ - Unknown tasks (corrseponding module did not load) are now displayed as Dummy Objects in the `GtTaskGroup` - #612
 
 ### Fixed
  - Fixed alphabetically sorting of Shortcuts in Preference View #482

--- a/src/core/process_management/gt_taskgroup.cpp
+++ b/src/core/process_management/gt_taskgroup.cpp
@@ -495,17 +495,7 @@ GtTaskGroup::Impl::createTaskFromFile(const QString& filePath) const
 
     auto obj = memento.restore(gtProcessFactory);
 
-    if (obj)
-    {
-        retval = qobject_cast<GtObject*>(obj);
-        if (!retval)
-        {
-            gtError() << QObject::tr("Invalid task file (%1)").arg(filePath);
-            delete obj;
-        }
-    }
-
-    return std::unique_ptr<GtObject>(retval);
+    return std::unique_ptr<GtObject>(obj);
 }
 
 bool

--- a/src/core/process_management/gt_taskgroup.cpp
+++ b/src/core/process_management/gt_taskgroup.cpp
@@ -134,10 +134,10 @@ GtTaskGroup::read(const QString& projectPath,
             gtDebug().medium().nospace() << "dummy task created ("
                                          << newTask->uuid() << ")";
         }
+
         else
         {
-            GtTask* gtTask = dynamic_cast<GtTask*>(newTask.get());
-            assert(gtTask != nullptr && "newTask must be of type GtTask.");
+            assert(qobject_cast<GtTask*>(newTask.get()) && "newTask must be of type GtTask.");
 
             // Safe to use gtTask here
             gtDebug().medium().nospace() << "new task created ("
@@ -460,8 +460,6 @@ std::unique_ptr<GtObject>
 GtTaskGroup::Impl::createTaskFromFile(const QString& filePath) const
 {
     QFile taskFile(filePath);
-
-    GtObject* retval = nullptr;
 
     if (!taskFile.exists())
     {

--- a/src/core/process_management/gt_taskgroup.cpp
+++ b/src/core/process_management/gt_taskgroup.cpp
@@ -120,18 +120,18 @@ GtTaskGroup::read(const QString& projectPath,
     for (const auto& e : qAsConst(activeTasks))
     {
         auto newTask = m_pimpl->createTaskFromFile(
-                    dir.absoluteFilePath(e.toString() + S_TASK_FILE_EXT));
+            dir.absoluteFilePath(e.toString() + S_TASK_FILE_EXT));
 
+        if (newTask)
+        {
+            if (newTask->isDummy())
+            {
+                gtDebug().medium().nospace() << "dummy task created ("
+                                             << newTask->uuid() << ")";
+                appendChild(newTask);
+                continue;
+            }
 
-        if (newTask->isDummy())
-        {
-            gtDebug().medium().nospace() << "new task created ("
-                                         << newTask->uuid() << ")";
-            appendChild(newTask);
-            continue;
-        }
-        else if (newTask)
-        {
             auto retval = qobject_cast<GtTask*>(newTask);
 
             if (!retval)


### PR DESCRIPTION
…t load

<!--- Provide a general summary of your changes in the Title above -->

GtTasks recognized as dummy are now added to the datamodel.

In `GtTaskGroup` 

## Description
<!--- Describe your changes in detail -->

In `GtTaskGroup` task-objects read from momento are now additionaly checked if they are dummy objects and then added to the datamodel as background objects with the recognizable red color of dummy objects.

<!--- Why is this change required? What problem does it solve? -->

Previously a wrong error message was printed that the task file is invalid. This happened because the GtDummy-object could not be parsed to GtTask.

<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/dlr-gtlab/gtlab-core/issues/612

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [x] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [x] The number of code quality warnings is not increasing.
