### PR TITLE
Deprecate unused run function of GtTask

### DIFF
--- a/src/core/gt_globals.h
+++ b/src/core/gt_globals.h
@@ -23,4 +23,9 @@ Please define the macro using -DGT_MODULE_ID =<module_id>
 
 #define GT_MODULENAME() GT_MODULE_ID
 
+// Macro to mark a function as deprecated for removal in a specific version
+#define deprecated_from(major, minor, message)                             \
+[[deprecated("Will be removed in GTlab " \
+    #major "." #minor ". " message)]] \
+
 #endif // GT_GLOBALS_H

--- a/src/core/process_management/gt_task.cpp
+++ b/src/core/process_management/gt_task.cpp
@@ -186,42 +186,42 @@ GtTask::exec()
     return true;
 }
 
-void
-GtTask::run(GtAbstractRunnable* r)
-{
-    if (!r)
-    {
-        setState(GtProcessComponent::FAILED);
-        gtError() << tr("%1: Failed to run task, invalid runnable!")
-                         .arg(objectName());
-        return;
-    }
-
-    setState(GtTask::RUNNING);
-    pimpl->dataToMerge.clear();
-
-    setRunnable(r);
-
-    QThreadPool* tp = QThreadPool::globalInstance();
-
-    if (!tp)
-    {
-        return;
-    }
-
-    runnable()->setAutoDelete(false);
-
-    connect(runnable().data(), &GtAbstractRunnable::runnableFinished,
-            this, &GtTask::handleRunnableFinished);
-
-    tp->start(runnable());
-
-    qDebug() << "#### exec event loop...";
-
-    pimpl->eventLoop.exec();
-
-    qDebug() << "#### exec finished";
-}
+//void
+//GtTask::run(GtAbstractRunnable* r)
+//{
+//    if (!r)
+//    {
+//        setState(GtProcessComponent::FAILED);
+//        gtError() << tr("%1: Failed to run task, invalid runnable!")
+//                         .arg(objectName());
+//        return;
+//    }
+//
+//    setState(GtTask::RUNNING);
+//    pimpl->dataToMerge.clear();
+//
+//    setRunnable(r);
+//
+//    QThreadPool* tp = QThreadPool::globalInstance();
+//
+//    if (!tp)
+//    {
+//        return;
+//    }
+//
+//    runnable()->setAutoDelete(false);
+//
+//    connect(runnable().data(), &GtAbstractRunnable::runnableFinished,
+//            this, &GtTask::handleRunnableFinished);
+//
+//    tp->start(runnable());
+//
+//    qDebug() << "#### exec event loop...";
+//
+//    pimpl->eventLoop.exec();
+//
+//    qDebug() << "#### exec finished";
+//}
 
 QList<GtCalculator*>
 GtTask::calculators()

--- a/src/core/process_management/gt_task.cpp
+++ b/src/core/process_management/gt_task.cpp
@@ -186,42 +186,6 @@ GtTask::exec()
     return true;
 }
 
-//void
-//GtTask::run(GtAbstractRunnable* r)
-//{
-//    if (!r)
-//    {
-//        setState(GtProcessComponent::FAILED);
-//        gtError() << tr("%1: Failed to run task, invalid runnable!")
-//                         .arg(objectName());
-//        return;
-//    }
-//
-//    setState(GtTask::RUNNING);
-//    pimpl->dataToMerge.clear();
-//
-//    setRunnable(r);
-//
-//    QThreadPool* tp = QThreadPool::globalInstance();
-//
-//    if (!tp)
-//    {
-//        return;
-//    }
-//
-//    runnable()->setAutoDelete(false);
-//
-//    connect(runnable().data(), &GtAbstractRunnable::runnableFinished,
-//            this, &GtTask::handleRunnableFinished);
-//
-//    tp->start(runnable());
-//
-//    qDebug() << "#### exec event loop...";
-//
-//    pimpl->eventLoop.exec();
-//
-//    qDebug() << "#### exec finished";
-//}
 
 QList<GtCalculator*>
 GtTask::calculators()

--- a/src/core/process_management/gt_task.cpp
+++ b/src/core/process_management/gt_task.cpp
@@ -186,6 +186,42 @@ GtTask::exec()
     return true;
 }
 
+void
+GtTask::run(GtAbstractRunnable* r)
+{
+    if (!r)
+    {
+        setState(GtProcessComponent::FAILED);
+        gtError() << tr("%1: Failed to run task, invalid runnable!")
+                         .arg(objectName());
+        return;
+    }
+
+    setState(GtTask::RUNNING);
+    pimpl->dataToMerge.clear();
+
+    setRunnable(r);
+
+    QThreadPool* tp = QThreadPool::globalInstance();
+
+    if (!tp)
+    {
+        return;
+    }
+
+    runnable()->setAutoDelete(false);
+
+    connect(runnable().data(), &GtAbstractRunnable::runnableFinished,
+            this, &GtTask::handleRunnableFinished);
+
+    tp->start(runnable());
+
+    qDebug() << "#### exec event loop...";
+
+    pimpl->eventLoop.exec();
+
+    qDebug() << "#### exec finished";
+}
 
 QList<GtCalculator*>
 GtTask::calculators()

--- a/src/core/process_management/gt_task.h
+++ b/src/core/process_management/gt_task.h
@@ -61,7 +61,7 @@ public:
      */
     void run(GtAbstractRunnable* runnable);
 
-     /**
+    /**
      * @brief calculators
      * @return
      */

--- a/src/core/process_management/gt_task.h
+++ b/src/core/process_management/gt_task.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include <gt_globals.h>
 #include "gt_processcomponent.h"
 #include "gt_objectmemento.h"
 #include "gt_intmonitoringproperty.h"
@@ -54,11 +55,10 @@ public:
      */
     bool exec() override;
 
-    [[deprecated("This function is not part of the supported process management and therefore not 
-                          maintained and updated")]]
     /**
      * @brief run
      */
+    deprecated_from(3, 0, "This function not maintained and updated anymore.")
     void run(GtAbstractRunnable* runnable);
 
     /**

--- a/src/core/process_management/gt_task.h
+++ b/src/core/process_management/gt_task.h
@@ -55,11 +55,6 @@ public:
     bool exec() override;
 
     /**
-     * @brief run
-     */
-    void run(GtAbstractRunnable* runnable);
-
-    /**
      * @brief calculators
      * @return
      */

--- a/src/core/process_management/gt_task.h
+++ b/src/core/process_management/gt_task.h
@@ -54,7 +54,14 @@ public:
      */
     bool exec() override;
 
+    [[deprecated("This function is not part of the supported process management and therefore not 
+                          maintained and updated")]]
     /**
+     * @brief run
+     */
+    void run(GtAbstractRunnable* runnable);
+
+     /**
      * @brief calculators
      * @return
      */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The function was not used and therefore could be removed

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
