### PR TITLE
Add some basic colors for plotting for splines and schedules

### DIFF
--- a/src/gui/gt_colors.cpp
+++ b/src/gui/gt_colors.cpp
@@ -523,3 +523,61 @@ gt::gui::color::connection_editor::connectionHighlight()
     }
     return Qt::red;
 }
+
+QColor
+gt::gui::color::plots::activeLine()
+{
+    if (gtApp->inDarkMode())
+    {
+        return QColor(Qt::blue).lighter();
+    }
+    return Qt::blue;
+}
+
+QColor
+gt::gui::color::plots::inactiveLine()
+{
+    return Qt::gray;
+}
+
+QColor
+gt::gui::color::plots::helpingLine()
+{
+    if (gtApp->inDarkMode())
+    {
+        return QColor(Qt::red).lighter();
+    }
+    return Qt::red;
+}
+
+QColor
+gt::gui::color::plots::marker()
+{
+    if (gtApp->inDarkMode())
+    {
+        return QColor(Qt::red).lighter();
+    }
+    return Qt::red;
+}
+
+QColor
+gt::gui::color::plots::selectedMarker()
+{
+    return Qt::white;
+}
+
+QColor
+gt::gui::color::plots::markerBoarder()
+{
+    if (gtApp->inDarkMode())
+    {
+        return Qt::gray;
+    }
+    return Qt::black;
+}
+
+QColor
+gt::gui::color::plots::inactiveMarker()
+{
+    return Qt::darkGray;
+}

--- a/src/gui/gt_colors.cpp
+++ b/src/gui/gt_colors.cpp
@@ -567,7 +567,7 @@ gt::gui::color::plots::selectedMarker()
 }
 
 QColor
-gt::gui::color::plots::markerBoarder()
+gt::gui::color::plots::markerBorder()
 {
     if (gtApp->inDarkMode())
     {

--- a/src/gui/gt_colors.h
+++ b/src/gui/gt_colors.h
@@ -267,10 +267,12 @@ GT_GUI_EXPORT QColor marker();
 namespace plots {
 GT_GUI_EXPORT QColor activeLine();
 GT_GUI_EXPORT QColor inactiveLine();
-// function for e.g.control polygon
+// helpingLine:
+// function for e.g.control polygon of a spline or other additional lines of the
+// main plot
 GT_GUI_EXPORT QColor helpingLine();
 GT_GUI_EXPORT QColor marker();
-GT_GUI_EXPORT QColor markerBoarder();
+GT_GUI_EXPORT QColor markerBorder();
 GT_GUI_EXPORT QColor selectedMarker();
 GT_GUI_EXPORT QColor inactiveMarker();
 }

--- a/src/gui/gt_colors.h
+++ b/src/gui/gt_colors.h
@@ -264,6 +264,17 @@ GT_GUI_EXPORT QColor builtIn();
 GT_GUI_EXPORT QColor marker();
 } // namespace js_highlight
 
+namespace plots {
+GT_GUI_EXPORT QColor activeLine();
+GT_GUI_EXPORT QColor inactiveLine();
+// function for e.g.control polygon
+GT_GUI_EXPORT QColor helpingLine();
+GT_GUI_EXPORT QColor marker();
+GT_GUI_EXPORT QColor markerBoarder();
+GT_GUI_EXPORT QColor selectedMarker();
+GT_GUI_EXPORT QColor inactiveMarker();
+}
+
 /// Deprecated functions
 [[deprecated("Use gridLine instead")]]
 GT_GUI_EXPORT QColor gridLineColor();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To improve the ability for a single look in GTlab some colors for schedules and splines are added to the colors namespace

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
