### PR TITLE
Operators for double int and string propeties

### DIFF
--- a/src/dataprocessor/property/gt_doubleproperty.cpp
+++ b/src/dataprocessor/property/gt_doubleproperty.cpp
@@ -137,6 +137,35 @@ GtDoubleProperty::GtDoubleProperty(const QString& ident,
     }
 }
 
+void
+GtDoubleProperty::operator+=(const double& b)
+{
+    double newVal = getVal() + b;
+    setVal(newVal);
+}
+
+void
+GtDoubleProperty::operator-=(const double& b)
+{
+    double newVal = getVal() - b;
+    setVal(newVal);
+}
+
+void
+GtDoubleProperty::operator*=(const double& b)
+{
+    double newVal = getVal() * b;
+    setVal(newVal);
+}
+
+void
+GtDoubleProperty::operator/=(const double& b)
+{
+    assert(a != 0.0);
+    double newVal = getVal() / b;
+    setVal(newVal);
+}
+
 QVariant
 GtDoubleProperty::valueToVariant(const QString& unit,
                                  bool* success) const

--- a/src/dataprocessor/property/gt_doubleproperty.h
+++ b/src/dataprocessor/property/gt_doubleproperty.h
@@ -100,10 +100,10 @@ public:
                      const double& value = 0.0);
 
     // operator overloads
-    inline void operator+=(double const& b);
-    inline void operator-=(double const& b);
-    inline void operator*=(double const& b);
-    inline void operator/=(double const& b);
+    void operator+=(double const& b);
+    void operator-=(double const& b);
+    void operator*=(double const& b);
+    void operator/=(double const& b);
 
 
     /**

--- a/src/dataprocessor/property/gt_doubleproperty.h
+++ b/src/dataprocessor/property/gt_doubleproperty.h
@@ -1,4 +1,4 @@
-/* GTlab - Gas Turbine laboratory
+﻿/* GTlab - Gas Turbine laboratory
  *
  * SPDX-License-Identifier: MPL-2.0+
  * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
@@ -98,6 +98,13 @@ public:
                      GtDoubleProperty::BoundType boundType,
                      const double boundary,
                      const double& value = 0.0);
+
+    // operator overloads
+    inline void operator+=(GtDoubleProperty const& b);
+    inline void operator-=(GtDoubleProperty const& b);
+    inline void operator*=(GtDoubleProperty const& b);
+    inline void operator/=(GtDoubleProperty const& b);
+
 
     /**
      * @brief valueToVariant

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -110,6 +110,35 @@ GtIntProperty::GtIntProperty(const QString& ident,
     GtIntProperty(ident, name, brief, boundType, boundary, value)
 { }
 
+void
+GtIntProperty::operator+=(int b)
+{
+    int newVal = getVal() + b;
+    setVal(newVal);
+}
+
+void
+GtIntProperty::operator-=(int b)
+{
+    int newVal = getVal() - b;
+    setVal(newVal);
+}
+
+void
+GtIntProperty::operator*=(int b)
+{
+    int newVal = getVal() * b;
+    setVal(newVal);
+}
+
+void
+GtIntProperty::operator/=(int b)
+{
+    assert(b != 0);
+    int newVal = getVal() / b;
+    setVal(newVal);
+}
+
 QVariant
 GtIntProperty::valueToVariant(const QString& unit,
                               bool* success) const

--- a/src/dataprocessor/property/gt_intproperty.h
+++ b/src/dataprocessor/property/gt_intproperty.h
@@ -125,10 +125,10 @@ public:
                   const int& value = 0.0);
 
     // operator overloads
-    inline void operator+=(int b);
-    inline void operator-=(int b);
-    inline void operator*=(int b);
-    inline void operator/=(int b);
+    void operator+=(int b);
+    void operator-=(int b);
+    void operator*=(int b);
+    void operator/=(int b);
 
     /**
      * @brief valueToVariant

--- a/src/dataprocessor/property/gt_intproperty.h
+++ b/src/dataprocessor/property/gt_intproperty.h
@@ -124,6 +124,12 @@ public:
                   const int boundary,
                   const int& value = 0.0);
 
+    // operator overloads
+    inline void operator+=(int b);
+    inline void operator-=(int b);
+    inline void operator*=(int b);
+    inline void operator/=(int b);
+
     /**
      * @brief valueToVariant
      * @return

--- a/src/dataprocessor/property/gt_stringproperty.cpp
+++ b/src/dataprocessor/property/gt_stringproperty.cpp
@@ -50,6 +50,13 @@ GtStringProperty::GtStringProperty(const QString& ident,
     }
 }
 
+void
+GtStringProperty::operator+=(const QString& b)
+{
+    QString newVal = getVal() + b;
+    setVal(newVal);
+}
+
 QVariant
 GtStringProperty::valueToVariant(const QString& /*unit*/,
                                  bool* success) const

--- a/src/dataprocessor/property/gt_stringproperty.h
+++ b/src/dataprocessor/property/gt_stringproperty.h
@@ -51,7 +51,7 @@ public:
                      QValidator* validator = nullptr);
 
     // operator overloads
-    inline void operator+=(const QString& b);
+    void operator+=(const QString& b);
 
     /**
      * @brief valueToVariant

--- a/src/dataprocessor/property/gt_stringproperty.h
+++ b/src/dataprocessor/property/gt_stringproperty.h
@@ -50,6 +50,9 @@ public:
                      const QString& value = QString(),
                      QValidator* validator = nullptr);
 
+    // operator overloads
+    inline void operator+=(const QString& b);
+
     /**
      * @brief valueToVariant
      * @return

--- a/tests/unittests/datamodel/test_gt_doubleproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_doubleproperty.cpp
@@ -388,31 +388,33 @@ TEST_F(TestGtDoubleProperty, optional)
 
 TEST_F(TestGtDoubleProperty, extendenOperators)
 {
+	GtDoubleProperty prop("prop", "test", "test", GtUnit::Category::None, 4.0);
+	
 	// operator+=
 	double sum = 4.4;
-    m_prop->setVal(3.3);
+    prop.setVal(3.3);
 	
-	m_prop += sum;
-    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 + sum);
+	prop += sum;
+    ASSERT_DOUBLE_EQ(prop.get(), 3.3 + sum);
 	
 	// operator-=
 	double diff = 4.4;
-    m_prop->setVal(3.3);
+    prop.setVal(3.3);
 	
-	m_prop -= diff;
-    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 - diff);
+	prop -= diff;
+    ASSERT_DOUBLE_EQ(prop.get(), 3.3 - diff);
 	
 	// operator*=
 	double factor = 4.4;
-    m_prop->setVal(3.3);
+    prop.setVal(3.3);
 	
-	m_prop *= factor;
-    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 * factor);
+	prop *= factor;
+    ASSERT_DOUBLE_EQ(prop.get(), 3.3 * factor);
 	
 	// operator/=
 	double div = 4.4;
-    m_prop->setVal(3.3);
+    prop.setVal(3.3);
 	
-	m_prop /= div;
-    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 / div);
+	prop /= div;
+    ASSERT_DOUBLE_EQ(prop.get(), 3.3 / div);
 }

--- a/tests/unittests/datamodel/test_gt_doubleproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_doubleproperty.cpp
@@ -408,7 +408,7 @@ TEST_F(TestGtDoubleProperty, extendenOperators)
     double factor = 4.4;
     prop.setVal(3.3);
 	
-     prop *= factor;
+    prop *= factor;
     ASSERT_DOUBLE_EQ(prop.get(), 3.3 * factor);
 	
     // operator/=

--- a/tests/unittests/datamodel/test_gt_doubleproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_doubleproperty.cpp
@@ -388,33 +388,33 @@ TEST_F(TestGtDoubleProperty, optional)
 
 TEST_F(TestGtDoubleProperty, extendenOperators)
 {
-	GtDoubleProperty prop("prop", "test", "test", GtUnit::Category::None, 4.0);
+    GtDoubleProperty prop("prop", "test", "test", GtUnit::Category::None, 4.0);
 	
-	// operator+=
-	double sum = 4.4;
+    // operator+=
+    double sum = 4.4;
     prop.setVal(3.3);
 	
-	prop += sum;
+    prop += sum;
     ASSERT_DOUBLE_EQ(prop.get(), 3.3 + sum);
 	
-	// operator-=
-	double diff = 4.4;
+    // operator-=
+    double diff = 4.4;
     prop.setVal(3.3);
 	
-	prop -= diff;
+    prop -= diff;
     ASSERT_DOUBLE_EQ(prop.get(), 3.3 - diff);
 	
-	// operator*=
-	double factor = 4.4;
+    // operator*=
+    double factor = 4.4;
     prop.setVal(3.3);
 	
-	prop *= factor;
+     prop *= factor;
     ASSERT_DOUBLE_EQ(prop.get(), 3.3 * factor);
 	
-	// operator/=
-	double div = 4.4;
+    // operator/=
+    double div = 4.4;
     prop.setVal(3.3);
 	
-	prop /= div;
+    prop /= div;
     ASSERT_DOUBLE_EQ(prop.get(), 3.3 / div);
 }

--- a/tests/unittests/datamodel/test_gt_doubleproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_doubleproperty.cpp
@@ -385,3 +385,34 @@ TEST_F(TestGtDoubleProperty, optional)
     ASSERT_TRUE(prop.isActive());
     ASSERT_FALSE(prop.isOptional());
 }
+
+TEST_F(TestGtDoubleProperty, extendenOperators)
+{
+	// operator+=
+	double sum = 4.4;
+    m_prop->setVal(3.3);
+	
+	m_prop += sum;
+    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 + sum);
+	
+	// operator-=
+	double diff = 4.4;
+    m_prop->setVal(3.3);
+	
+	m_prop -= diff;
+    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 - diff);
+	
+	// operator*=
+	double factor = 4.4;
+    m_prop->setVal(3.3);
+	
+	m_prop *= factor;
+    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 * factor);
+	
+	// operator/=
+	double div = 4.4;
+    m_prop->setVal(3.3);
+	
+	m_prop /= div;
+    ASSERT_DOUBLE_EQ(m_prop->get(), 3.3 / div);
+}

--- a/tests/unittests/datamodel/test_gt_intproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_intproperty.cpp
@@ -310,32 +310,32 @@ TEST_F(TestGtIntProperty, optional)
 
 TEST_F(TestGtIntProperty, extendenOperators)
 {
-	GtIntProperty prop("prop", "test", "test", 4);
-	// operator+=
-	int sum = 4;
+    GtIntProperty prop("prop", "test", "test", 4);
+    // operator+=
+    int sum = 4;
     prop.setVal(13);
 	
-	prop += sum;
+    prop += sum;
     EXPECT_EQ(prop.get(), 13 + sum);
-	
-	// operator-=
-	int diff = 4;
+
+    // operator-=
+    int diff = 4;
     prop.setVal(13);
 	
-	prop -= diff;
+    prop -= diff;
     EXPECT_EQ(prop.get(), 13 - diff);
 	
-	// operator*=
-	int factor = 4;
+    // operator*=
+    int factor = 4;
     prop.setVal(13);
 	
-	prop *= factor;
+    prop *= factor;
     EXPECT_EQ(prop.get(), 13 * factor);
 	
-	// operator/=
-	int div = 4;
+    // operator/=
+    int div = 4;
     prop.setVal(13);
 	
-	prop /= div;
+    prop /= div;
     EXPECT_EQ(prop.get(), 3);
 }

--- a/tests/unittests/datamodel/test_gt_intproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_intproperty.cpp
@@ -310,31 +310,32 @@ TEST_F(TestGtIntProperty, optional)
 
 TEST_F(TestGtIntProperty, extendenOperators)
 {
+	GtIntProperty prop("prop", "test", "test", 4);
 	// operator+=
 	int sum = 4;
-    m_prop->setVal(13);
+    prop.setVal(13);
 	
-	m_prop += sum;
-    EXPECT_EQ(m_prop->get(), 13 + sum);
+	prop += sum;
+    EXPECT_EQ(prop.get(), 13 + sum);
 	
 	// operator-=
 	int diff = 4;
-    m_prop->setVal(13);
+    prop.setVal(13);
 	
-	m_prop -= diff;
-    EXPECT_EQ(m_prop->get(), 13 - diff);
+	prop -= diff;
+    EXPECT_EQ(prop.get(), 13 - diff);
 	
 	// operator*=
 	int factor = 4;
-    m_prop->setVal(13);
+    prop.setVal(13);
 	
-	m_prop *= factor;
-    EXPECT_EQ(m_prop->get(), 13 * factor);
+	prop *= factor;
+    EXPECT_EQ(prop.get(), 13 * factor);
 	
 	// operator/=
 	int div = 4;
-    m_prop->setVal(13);
+    prop.setVal(13);
 	
-	m_prop /= div;
-    EXPECT_EQ(m_prop->get(), 3);
+	prop /= div;
+    EXPECT_EQ(prop.get(), 3);
 }

--- a/tests/unittests/datamodel/test_gt_intproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_intproperty.cpp
@@ -307,3 +307,34 @@ TEST_F(TestGtIntProperty, optional)
     EXPECT_TRUE(prop.isActive());
     EXPECT_FALSE(prop.isOptional());
 }
+
+TEST_F(TestGtIntProperty, extendenOperators)
+{
+	// operator+=
+	int sum = 4;
+    m_prop->setVal(13);
+	
+	m_prop += sum;
+    EXPECT_EQ(m_prop->get(), 13 + sum);
+	
+	// operator-=
+	int diff = 4;
+    m_prop->setVal(13);
+	
+	m_prop -= diff;
+    EXPECT_EQ(m_prop->get(), 13 - diff);
+	
+	// operator*=
+	int factor = 4;
+    m_prop->setVal(13);
+	
+	m_prop *= factor;
+    EXPECT_EQ(m_prop->get(), 13 * factor);
+	
+	// operator/=
+	int div = 4;
+    m_prop->setVal(13);
+	
+	m_prop /= div;
+    EXPECT_EQ(m_prop->get(), 3);
+}

--- a/tests/unittests/datamodel/test_gt_stringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_stringproperty.cpp
@@ -145,5 +145,5 @@ TEST_F(TestGtStringProperty, extendenOperator)
     prop.setVal("GTlab");
 	
 	prop += added;
-    ASSERT_STREQ(&prop.get(), "GTlab is nice!");
+    ASSERT_STREQ(&prop.get().toStdString().c_str(), "GTlab is nice!");
 }

--- a/tests/unittests/datamodel/test_gt_stringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_stringproperty.cpp
@@ -136,7 +136,7 @@ TEST_F(TestGtStringProperty, optional)
     ASSERT_FALSE(prop.isOptional());
 }
 
-TEST_F(TestGtIntProperty, extendenOperator)
+TEST_F(TestGtStringProperty, extendenOperator)
 {
 	GtStringProperty prop("prop", "test", "test", "hello");
 	

--- a/tests/unittests/datamodel/test_gt_stringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_stringproperty.cpp
@@ -135,3 +135,13 @@ TEST_F(TestGtStringProperty, optional)
     ASSERT_TRUE(prop.isActive());
     ASSERT_FALSE(prop.isOptional());
 }
+
+TEST_F(TestGtIntProperty, extendenOperator)
+{
+	// operator+=
+	QString added = " is nice!";
+    m_prop->setVal("GTlab");
+	
+	m_prop += added;
+    ASSERT_STREQ(m_prop->get(), "GTlab is nice!");
+}

--- a/tests/unittests/datamodel/test_gt_stringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_stringproperty.cpp
@@ -145,5 +145,5 @@ TEST_F(TestGtStringProperty, extendenOperator)
     prop.setVal("GTlab");
 	
 	prop += added;
-    ASSERT_STREQ(&prop.get().toStdString().c_str(), "GTlab is nice!");
+    ASSERT_STREQ(prop.get().toStdString().c_str(), "GTlab is nice!");
 }

--- a/tests/unittests/datamodel/test_gt_stringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_stringproperty.cpp
@@ -138,10 +138,12 @@ TEST_F(TestGtStringProperty, optional)
 
 TEST_F(TestGtIntProperty, extendenOperator)
 {
+	GtStringProperty prop("prop", "test", "test", "hello");
+	
 	// operator+=
 	QString added = " is nice!";
-    m_prop->setVal("GTlab");
+    prop.setVal("GTlab");
 	
-	m_prop += added;
-    ASSERT_STREQ(m_prop->get(), "GTlab is nice!");
+	prop += added;
+    ASSERT_STREQ(&prop.get(), "GTlab is nice!");
 }

--- a/tests/unittests/datamodel/test_gt_stringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_stringproperty.cpp
@@ -138,12 +138,12 @@ TEST_F(TestGtStringProperty, optional)
 
 TEST_F(TestGtStringProperty, extendenOperator)
 {
-	GtStringProperty prop("prop", "test", "test", "hello");
+    GtStringProperty prop("prop", "test", "test", "hello");
 	
-	// operator+=
-	QString added = " is nice!";
+    // operator+=
+    QString added = " is nice!";
     prop.setVal("GTlab");
 	
-	prop += added;
+    prop += added;
     ASSERT_STREQ(prop.get().toStdString().c_str(), "GTlab is nice!");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Basic implementation of some operators for +=, -=, ... 
These are now implemented for double, int and string property


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
