### PR TITLE
Deprecate unique object name

### DIFF
--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -354,7 +354,7 @@ GtProcessDock::addEmptyTask(GtObject* root)
 {
     if (!root) return;
 
-    QString taskId = gtDataModel->uniqueObjectName(tr("New Task"), root);
+    QString taskId = gt::makeUniqueName(tr("New Task"), root);
 
     if (taskId.isEmpty()) return;
 
@@ -537,8 +537,7 @@ GtProcessDock::addTaskToParent(GtObject* parentObj)
 
     if (!newObj) return;
 
-    QString taskId = gtDataModel->uniqueObjectName(newObj->objectName(),
-                     parentObj);
+    QString taskId = gt::makeUniqueName(newObj->objectName(), parentObj);
     newObj->setObjectName(taskId);
 
     gtDebug().verbose() << tr("Task appended! (%1)").arg(
@@ -1706,8 +1705,7 @@ GtProcessDock::pasteElement(GtObject* obj, GtObject* parent)
     }
 
     // create new unique identification string
-    QString newId = gtDataModel->uniqueObjectName(obj->objectName(),
-                    parent);
+    QString newId = gt::makeUniqueName(obj->objectName(), parent);
 
     // set new identification string
     obj->setObjectName(newId);

--- a/src/app/dock_widgets/process/gt_taskgroupmodel.cpp
+++ b/src/app/dock_widgets/process/gt_taskgroupmodel.cpp
@@ -8,8 +8,6 @@
  *  Tel.: +49 2203 601 2907
  */
 
-#include "gt_processdata.h"
-
 #include "gt_taskgroupmodel.h"
 
 GtTaskGroupModel::GtTaskGroupModel(QObject* parent) :

--- a/src/app/mdi_items/examples/gt_examplesmdiwidget.cpp
+++ b/src/app/mdi_items/examples/gt_examplesmdiwidget.cpp
@@ -256,7 +256,7 @@ GtExamplesMdiWidget::onOpenProject(const QString& exampleName)
 
     QString newDirPath;
 
-    QString id = gtDataModel->uniqueObjectName(exampleName.split("#").last(),
+    QString id = gt::makeUniqueName(exampleName.split("#").last(),
                  gtApp->session());
 
     dialog.setWindowTitle(tr("Save Example Project As..."));
@@ -355,7 +355,7 @@ GtExamplesMdiWidget::onOpenProject(const QString& exampleName)
     if (gtApp->session()->findProject(project->objectName()))
     {
         gtInfo() << tr("There is already a project with name of the example.");
-        project->setObjectName(gtDataModel->uniqueObjectName(
+        project->setObjectName(gt::makeUniqueName(
                                project->objectName(), gtApp->session()));
     }
 

--- a/src/core/gt_coredatamodel.cpp
+++ b/src/core/gt_coredatamodel.cpp
@@ -12,18 +12,15 @@
 #include <QMimeData>
 #include <QDir>
 
+#include <gt_logging.h>
 #include "gt_session.h"
 #include "gt_project.h"
 #include "gt_objectfactory.h"
 #include "gt_objectmemento.h"
 #include "gt_coreapplication.h"
-#include "gt_command.h"
-#include "gt_logging.h"
 #include "gt_state.h"
 #include "gt_statehandler.h"
 #include "gt_externalizationmanager.h"
-#include "gt_projectanalyzer.h"
-#include "gt_versionnumber.h"
 
 #include "gt_coredatamodel.h"
 
@@ -1041,7 +1038,7 @@ GtCoreDatamodel::uniqueObjectName(const QString& name,
     if (parent.model() != this) return {};
 
     // return unique object name
-    return uniqueObjectName(name, objectFromIndex(parent));
+    return gt::makeUniqueName(name, objectFromIndex(parent));
 }
 
 GtObject*

--- a/src/core/gt_coredatamodel.h
+++ b/src/core/gt_coredatamodel.h
@@ -294,6 +294,7 @@ public:
      * @param Parent object
      * @return Unique object name
      */
+    [[deprecated("Use gt::makeUniqueName(name, parent) instead")]]
     QString uniqueObjectName(const QString& name,
                              GtObject* parent);
 

--- a/src/gui/dialogs/project_upgrader/gt_projectupgradesettingspage.cpp
+++ b/src/gui/dialogs/project_upgrader/gt_projectupgradesettingspage.cpp
@@ -15,8 +15,8 @@
 #include "gt_project.h"
 #include "gt_projectspecwidget.h"
 #include "gt_projectupgradedialog.h"
-#include "gt_datamodel.h"
 #include "gt_application.h"
+#include "gt_qtutilities.h"
 
 #include "gt_projectupgradesettingspage.h"
 
@@ -48,7 +48,7 @@ GtProjectUpgradeSettingsPage::GtProjectUpgradeSettingsPage(GtProject* project,
 
     m_specWid->setVisible(false);
 
-    QString id = gtDataModel->uniqueObjectName(
+    QString id = gt::makeUniqueName(
                 project->objectName() + "_upgraded",
                 gtApp->session());
 

--- a/src/gui/dock_widgets/process/gt_processcomponentmodel.cpp
+++ b/src/gui/dock_widgets/process/gt_processcomponentmodel.cpp
@@ -13,7 +13,6 @@
 #include <QMimeData>
 #include <QFont>
 
-#include "gt_application.h"
 #include "gt_objectlinkproperty.h"
 #include "gt_extendedcalculatordata.h"
 #include "gt_extendedtaskdata.h"

--- a/src/gui/gt_datamodel.cpp
+++ b/src/gui/gt_datamodel.cpp
@@ -15,7 +15,6 @@
 #include "gt_loadprojecthelper.h"
 #include "gt_saveprojecthelper.h"
 #include "gt_project.h"
-#include "gt_command.h"
 #include "gt_settings.h"
 #include "gt_projectanalyzer.h"
 #include "gt_projectanalyzerdialog.h"

--- a/src/gui/object_ui/gt_projectui.cpp
+++ b/src/gui/object_ui/gt_projectui.cpp
@@ -508,8 +508,7 @@ GtProjectUI::saveProjectAs(GtObject* obj)
         return;
     }
 
-    QString id = gtDataModel->uniqueObjectName(project->objectName(),
-                 gtApp->session());
+    QString id = gt::makeUniqueName(project->objectName(), gtApp->session());
 
     GtDialog dialog;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Deprecation of the unique object name function in the core datamodel to reduce access to the datamodel instance if it is not needed

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
