### PR TITLE
Add hint for deprecated class GtStringMapContainer

### DIFF
--- a/src/gui/post/gt_stringmapcontainer.h
+++ b/src/gui/post/gt_stringmapcontainer.h
@@ -17,6 +17,7 @@
 /**
  * @brief The GtStringMapContainer class
  */
+
 class GT_GUI_EXPORT GtStringMapContainer : public GtObject
 {
     Q_OBJECT
@@ -26,6 +27,9 @@ class GT_GUI_EXPORT GtStringMapContainer : public GtObject
 
 public:
 
+    [[deprecated("This class is deprecated and will not be supported after"
+                 "GTlab 2-1. If you need a storage of flexible size for"
+                 "properties use the GtPropertyStructContainer")]]
     Q_INVOKABLE GtStringMapContainer();
 
     QStringList keys() const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the deprecated macro to the class GtStringMapContainer as it not used and has no effect in the GTlab Gui Core library

## How Has This Been Tested?
It is not used in the core or any part of the master build


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
