### PR TITLE
Try to use QString instead of keysequence to avid Gui dependency

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -158,7 +158,7 @@ main(int argc, char* argv[])
     });
 
     splash.process([&app](){
-        // chort cuts initialization
+        // short cuts initialization
         app.initShortCuts();
     });
 

--- a/src/app/preferences/pages/gt_preferencesshortcuts.cpp
+++ b/src/app/preferences/pages/gt_preferencesshortcuts.cpp
@@ -163,8 +163,7 @@ GtPreferencesShortCuts::restoreDefaults()
 {
     assert(m_tab);
 
-    QList<GtShortCutSettingsData> initialShortcuts =
-            gtApp->settings()->intialShortCutsList();
+    QList<GtShortCutSettingsData> initialShortcuts = gtApp->initCoreShortCuts();
 
     /// add the default vales from the modules
     initialShortcuts.append(gtApp->moduleShortCuts());

--- a/src/app/preferences/pages/gt_preferencesshortcuts.cpp
+++ b/src/app/preferences/pages/gt_preferencesshortcuts.cpp
@@ -141,7 +141,7 @@ GtPreferencesShortCuts::saveSettings(GtSettings& settings) const
         }
 
         current->setKey(key);
-        settingsList.append({id, cat, key, current->isReadOnly()});
+        settingsList.append({id, cat, key.toString(), current->isReadOnly()});
     }
 
     if (anyChange)
@@ -203,20 +203,20 @@ GtPreferencesShortCuts::restoreDefaults()
         }
 
         // pointer to keysequence to check if key was found
-        QKeySequence const* key{};
+        QKeySequence key{};
 
         // find default shortcut value
         for (GtShortCutSettingsData const& entry : qAsConst(initialShortcuts))
         {
             if (entry.id == id && entry.category == cat)
             { // cppcheck-suppress useStlAlgorithm
-                key = &entry.shortCut;
+                key = QKeySequence::fromString(entry.shortCut);
                 break;
             }
         }
 
         // key not found -> shortcut is a remnant
-        if (!key)
+        if (key.isEmpty())
         {
             gtWarning().medium() << tr("Removed unknown shortcut") << id;
             m_tab->removeRow(i--);
@@ -224,7 +224,7 @@ GtPreferencesShortCuts::restoreDefaults()
         }
 
         // apply shortcut
-        e->setKeySequence(*key);
+        e->setKeySequence(key);
         handledShortCuts.append(uid);
     }
 

--- a/src/core/settings/gt_settings.cpp
+++ b/src/core/settings/gt_settings.cpp
@@ -15,7 +15,6 @@
 #include <QDir>
 #include <QSettings>
 #include <QMap>
-#include <QKeySequence>
 #include <QString>
 
 struct GtSettings::Impl
@@ -130,8 +129,7 @@ GtSettings::GtSettings()
                 QStringList());
 
     pimpl->shortcutsTable = registerSetting(
-                QStringLiteral("application/general/shortCuts"),
-                initialShortCuts());
+                QStringLiteral("application/general/shortCuts"));
 
     pimpl->themeSelection = registerSettingRestart(
                         QStringLiteral("application/general/themeSelection"),
@@ -193,107 +191,13 @@ GtSettings::setShortcutsTable(QList<GtShortCutSettingsData> const& list)
 QVariant
 GtSettings::initialShortCuts() const
 {
-    QMap<QString, QVariant> shortCutDataMap;
-
-    for (GtShortCutSettingsData const& s : intialShortCutsList())
-    {
-        shortCutDataMap.insert(s.id, s.dataToVariant());
-    }
-
-    return QVariant(shortCutDataMap);
+    return {};
 }
 
 QList<GtShortCutSettingsData>
 GtSettings::intialShortCutsList() const
 {
-    QString const& catCore = QStringLiteral("Core");
-
-    QList<GtShortCutSettingsData> shortCuts;
-
-    /// rename object
-    shortCuts.append({QStringLiteral("rename"), catCore,
-                      QKeySequence(Qt::Key_F2).toString(), true});
-
-    /// openContectMenu
-    shortCuts.append({QStringLiteral("openContextMenu"), catCore,
-                      QKeySequence(Qt::Key_F4).toString()});
-
-    /// ShowFootprint
-    shortCuts.append({QStringLiteral("showFootprint"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_I).toString()});
-    /// redo
-    shortCuts.append({QStringLiteral("redo"), catCore,
-                      QKeySequence(QKeySequence::Redo).toString(), true});
-
-    /// undo
-    shortCuts.append({QStringLiteral("undo"), catCore,
-                      QKeySequence(QKeySequence::Undo).toString(), true});
-
-    /// cut
-    shortCuts.append({QStringLiteral("cut"), catCore,
-                      QKeySequence(QKeySequence::Cut).toString(), true});
-
-    /// copy
-    shortCuts.append({QStringLiteral("copy"), catCore,
-                      QKeySequence(QKeySequence::Copy).toString(), true});
-
-    /// clone/duplicate
-    shortCuts.append({QStringLiteral("clone"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_D).toString(), true});
-
-    /// paste
-    shortCuts.append({QStringLiteral("paste"), catCore,
-                      QKeySequence(QKeySequence::Paste).toString(), true});
-
-    /// delete
-    shortCuts.append({QStringLiteral("delete"), catCore,
-                      QKeySequence(QKeySequence::Delete).toString(), true});
-
-    /// search
-    shortCuts.append({QStringLiteral("search"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_F).toString()});
-
-    /// switchPerspective
-    shortCuts.append({QStringLiteral("switchPerspective"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_P).toString(), true});
-
-    /// switchPerspective
-    shortCuts.append({QStringLiteral("closeTab"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_W).toString(), false});
-
-    /// Preferences
-    shortCuts.append({QStringLiteral("openPreferences"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_Enter).toString(), true});
-
-    /// Preferences
-    shortCuts.append({QStringLiteral("openModulesInfo"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_M).toString(), true});
-
-    /// save
-    shortCuts.append({QStringLiteral("save"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_S).toString(), true});
-
-    /// new Project
-    shortCuts.append({QStringLiteral("newProject"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_N).toString(), true});
-
-    /// open Project
-    shortCuts.append({QStringLiteral("openProject"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_O).toString(), true});
-
-    /// close Project
-    shortCuts.append({QStringLiteral("closeProject"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_W).toString(), true});
-
-    /// help
-    shortCuts.append({QStringLiteral("help"), catCore,
-                      QKeySequence(Qt::Key_F1).toString(), true});
-
-    /// undo
-    shortCuts.append({QStringLiteral("modulesOverview"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_M).toString(), true});
-
-    return shortCuts;
+    return {};
 }
 
 

--- a/src/core/settings/gt_settings.cpp
+++ b/src/core/settings/gt_settings.cpp
@@ -212,86 +212,86 @@ GtSettings::intialShortCutsList() const
 
     /// rename object
     shortCuts.append({QStringLiteral("rename"), catCore,
-                      QKeySequence(Qt::Key_F2), true});
+                      QKeySequence(Qt::Key_F2).toString(), true});
 
     /// openContectMenu
     shortCuts.append({QStringLiteral("openContextMenu"), catCore,
-                      QKeySequence(Qt::Key_F4)});
+                      QKeySequence(Qt::Key_F4).toString()});
 
     /// ShowFootprint
     shortCuts.append({QStringLiteral("showFootprint"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_I)});
+                      QKeySequence(Qt::CTRL + Qt::Key_I).toString()});
     /// redo
     shortCuts.append({QStringLiteral("redo"), catCore,
-                      QKeySequence(QKeySequence::Redo), true});
+                      QKeySequence(QKeySequence::Redo).toString(), true});
 
     /// undo
     shortCuts.append({QStringLiteral("undo"), catCore,
-                      QKeySequence(QKeySequence::Undo), true});
+                      QKeySequence(QKeySequence::Undo).toString(), true});
 
     /// cut
     shortCuts.append({QStringLiteral("cut"), catCore,
-                      QKeySequence(QKeySequence::Cut), true});
+                      QKeySequence(QKeySequence::Cut).toString(), true});
 
     /// copy
     shortCuts.append({QStringLiteral("copy"), catCore,
-                      QKeySequence(QKeySequence::Copy), true});
+                      QKeySequence(QKeySequence::Copy).toString(), true});
 
     /// clone/duplicate
     shortCuts.append({QStringLiteral("clone"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_D), true});
+                      QKeySequence(Qt::CTRL + Qt::Key_D).toString(), true});
 
     /// paste
     shortCuts.append({QStringLiteral("paste"), catCore,
-                      QKeySequence(QKeySequence::Paste), true});
+                      QKeySequence(QKeySequence::Paste).toString(), true});
 
     /// delete
     shortCuts.append({QStringLiteral("delete"), catCore,
-                      QKeySequence(QKeySequence::Delete), true});
+                      QKeySequence(QKeySequence::Delete).toString(), true});
 
     /// search
     shortCuts.append({QStringLiteral("search"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_F)});
+                      QKeySequence(Qt::CTRL + Qt::Key_F).toString()});
 
     /// switchPerspective
     shortCuts.append({QStringLiteral("switchPerspective"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_P), true});
+                      QKeySequence(Qt::ALT + Qt::Key_P).toString(), true});
 
     /// switchPerspective
     shortCuts.append({QStringLiteral("closeTab"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_W), false});
+                      QKeySequence(Qt::CTRL + Qt::Key_W).toString(), false});
 
     /// Preferences
     shortCuts.append({QStringLiteral("openPreferences"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_Enter), true});
+                      QKeySequence(Qt::ALT + Qt::Key_Enter).toString(), true});
 
     /// Preferences
     shortCuts.append({QStringLiteral("openModulesInfo"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_M), true});
+                      QKeySequence(Qt::ALT + Qt::Key_M).toString(), true});
 
     /// save
     shortCuts.append({QStringLiteral("save"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_S), true});
+                      QKeySequence(Qt::CTRL + Qt::Key_S).toString(), true});
 
     /// new Project
     shortCuts.append({QStringLiteral("newProject"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_N), true});
+                      QKeySequence(Qt::CTRL + Qt::Key_N).toString(), true});
 
     /// open Project
     shortCuts.append({QStringLiteral("openProject"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::Key_O), true});
+                      QKeySequence(Qt::CTRL + Qt::Key_O).toString(), true});
 
     /// close Project
     shortCuts.append({QStringLiteral("closeProject"), catCore,
-                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_W), true});
+                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_W).toString(), true});
 
     /// help
     shortCuts.append({QStringLiteral("help"), catCore,
-                      QKeySequence(Qt::Key_F1), true});
+                      QKeySequence(Qt::Key_F1).toString(), true});
 
     /// undo
     shortCuts.append({QStringLiteral("modulesOverview"), catCore,
-                      QKeySequence(Qt::ALT + Qt::Key_M), true});
+                      QKeySequence(Qt::ALT + Qt::Key_M).toString(), true});
 
     return shortCuts;
 }

--- a/src/core/settings/gt_settings.h
+++ b/src/core/settings/gt_settings.h
@@ -327,12 +327,16 @@ public:
      * @return the default shortcuts as a variant (QMap<QString, QStringList>).
      * QStringList contains two elements (keysequence and category)
      */
+    [[deprecated("Deprecated function has no effect anymore and is only kept "
+                 "for ABI/API compatibility reasons")]]
     QVariant initialShortCuts() const;
 
     /**
      * @brief intialShortCutsList
      * @return list of default shortcuts as a list
      */
+    [[deprecated("Deprecated function has no effect anymore and is replaced"
+                 "by GtApplication::initShortCuts()")]]
     QList<GtShortCutSettingsData> intialShortCutsList() const;
 
     /**

--- a/src/core/settings/gt_shortcutsettingsdata.cpp
+++ b/src/core/settings/gt_shortcutsettingsdata.cpp
@@ -15,8 +15,9 @@ GtShortCutSettingsData::GtShortCutSettingsData()
 
 }
 
-GtShortCutSettingsData::GtShortCutSettingsData(QString const& identifier, QString const& cat,
-        QString key, bool readOnly) :
+GtShortCutSettingsData::GtShortCutSettingsData(
+        QString const& identifier, QString const& cat,
+        const QString& key,  bool readOnly) :
     id(identifier), category(cat),
     shortCut(key), isReadOnly(readOnly)
 {

--- a/src/core/settings/gt_shortcutsettingsdata.cpp
+++ b/src/core/settings/gt_shortcutsettingsdata.cpp
@@ -15,9 +15,8 @@ GtShortCutSettingsData::GtShortCutSettingsData()
 
 }
 
-GtShortCutSettingsData::GtShortCutSettingsData(
-        QString const& identifier, QString const& cat,
-        QKeySequence key, bool readOnly) :
+GtShortCutSettingsData::GtShortCutSettingsData(QString const& identifier, QString const& cat,
+        QString key, bool readOnly) :
     id(identifier), category(cat),
     shortCut(key), isReadOnly(readOnly)
 {
@@ -33,6 +32,6 @@ GtShortCutSettingsData::dataToVariant() const
         readOnly = "true";
     }
 
-    QStringList l {shortCut.toString(), category, readOnly};
+    QStringList l {shortCut, category, readOnly};
     return QVariant(l);
 }

--- a/src/core/settings/gt_shortcutsettingsdata.h
+++ b/src/core/settings/gt_shortcutsettingsdata.h
@@ -36,7 +36,7 @@ struct GT_CORE_EXPORT GtShortCutSettingsData{
      * @param readOnly - is the short cut read only and is not editable
      */
     GtShortCutSettingsData(QString const& identifier, QString const& cat,
-                           QString key, bool readOnly = false);
+                           QString const& key, bool readOnly = false);
 
     /**
      * @brief dataToVariant

--- a/src/core/settings/gt_shortcutsettingsdata.h
+++ b/src/core/settings/gt_shortcutsettingsdata.h
@@ -25,6 +25,7 @@ struct GT_CORE_EXPORT GtShortCutSettingsData{
     /**
      * @brief shortCutSettingsData - default constructor
      */
+
     GtShortCutSettingsData();
 
     /**

--- a/src/core/settings/gt_shortcutsettingsdata.h
+++ b/src/core/settings/gt_shortcutsettingsdata.h
@@ -35,7 +35,7 @@ struct GT_CORE_EXPORT GtShortCutSettingsData{
      * @param readOnly - is the short cut read only and is not editable
      */
     GtShortCutSettingsData(QString const& identifier, QString const& cat,
-                           QKeySequence key, bool readOnly = false);
+                           QString key, bool readOnly = false);
 
     /**
      * @brief dataToVariant
@@ -50,7 +50,7 @@ struct GT_CORE_EXPORT GtShortCutSettingsData{
     QString category;
 
     /// short cut key sequence
-    QKeySequence shortCut;
+    QString shortCut;
 
     /// is the short cut read only an not editable
     bool isReadOnly;

--- a/src/core/settings/gt_shortcutsettingsdata.h
+++ b/src/core/settings/gt_shortcutsettingsdata.h
@@ -11,7 +11,6 @@
 #ifndef GTSHORTCUTSETTINGSDATA_H
 #define GTSHORTCUTSETTINGSDATA_H
 
-#include <QKeySequence>
 #include <QVariant>
 #include "gt_core_exports.h"
 

--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -712,7 +712,7 @@ GtApplication::extendShortCuts(const GtShortCutSettingsData& shortcut)
 
 void
 GtApplication::extendShortCuts(const QString& id, const QString& category,
-                               const QKeySequence k, bool readOnly)
+                               const QKeySequence &k, bool readOnly)
 {
     extendShortCuts({id, category, k.toString(), readOnly});
 }

--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -710,6 +710,13 @@ GtApplication::extendShortCuts(const GtShortCutSettingsData& shortcut)
     sList->initialize(shortcut);
 }
 
+void
+GtApplication::extendShortCuts(const QString& id, const QString& category,
+                               const QKeySequence k, bool readOnly)
+{
+    extendShortCuts({id, category, k.toString(), readOnly});
+}
+
 
 QList<GtShortCutSettingsData>
 GtApplication::moduleShortCuts() const

--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -375,7 +375,7 @@ GtApplication::initShortCuts()
     QList<GtShortCutSettingsData> tab = settings()->shortcutsList();
 
     /// Short cuts from default list
-    QList<GtShortCutSettingsData> listBasic = settings()->intialShortCutsList();
+    QList<GtShortCutSettingsData> listBasic = initCoreShortCuts();
 
     /// if short cut in default list, but not in settings add it to settings
     for (GtShortCutSettingsData const& k : qAsConst(listBasic))
@@ -711,8 +711,8 @@ GtApplication::extendShortCuts(const GtShortCutSettingsData& shortcut)
 }
 
 void
-GtApplication::extendShortCuts(const QString& id, const QString& category,
-                               const QKeySequence &k, bool readOnly)
+GtApplication::addShortCut(const QString& id, const QString& category,
+                           const QKeySequence &k, bool readOnly)
 {
     extendShortCuts({id, category, k.toString(), readOnly});
 }
@@ -850,6 +850,99 @@ GtApplication::initFirstRun()
     }
 
     return true;
+}
+
+QList<GtShortCutSettingsData>
+GtApplication::initCoreShortCuts() const
+{
+    QString const& catCore = QStringLiteral("Core");
+
+    QList<GtShortCutSettingsData> shortCuts;
+
+    /// rename object
+    shortCuts.append({QStringLiteral("rename"), catCore,
+                      QKeySequence(Qt::Key_F2).toString(), true});
+
+    /// openContectMenu
+    shortCuts.append({QStringLiteral("openContextMenu"), catCore,
+                      QKeySequence(Qt::Key_F4).toString()});
+
+    /// ShowFootprint
+    shortCuts.append({QStringLiteral("showFootprint"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::Key_I).toString()});
+    /// redo
+    shortCuts.append({QStringLiteral("redo"), catCore,
+                      QKeySequence(QKeySequence::Redo).toString(), true});
+
+    /// undo
+    shortCuts.append({QStringLiteral("undo"), catCore,
+                      QKeySequence(QKeySequence::Undo).toString(), true});
+
+    /// cut
+    shortCuts.append({QStringLiteral("cut"), catCore,
+                      QKeySequence(QKeySequence::Cut).toString(), true});
+
+    /// copy
+    shortCuts.append({QStringLiteral("copy"), catCore,
+                      QKeySequence(QKeySequence::Copy).toString(), true});
+
+    /// clone/duplicate
+    shortCuts.append({QStringLiteral("clone"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::Key_D).toString(), true});
+
+    /// paste
+    shortCuts.append({QStringLiteral("paste"), catCore,
+                      QKeySequence(QKeySequence::Paste).toString(), true});
+
+    /// delete
+    shortCuts.append({QStringLiteral("delete"), catCore,
+                      QKeySequence(QKeySequence::Delete).toString(), true});
+
+    /// search
+    shortCuts.append({QStringLiteral("search"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::Key_F).toString()});
+
+    /// switchPerspective
+    shortCuts.append({QStringLiteral("switchPerspective"), catCore,
+                      QKeySequence(Qt::ALT + Qt::Key_P).toString(), true});
+
+    /// switchPerspective
+    shortCuts.append({QStringLiteral("closeTab"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::Key_W).toString(), false});
+
+    /// Preferences
+    shortCuts.append({QStringLiteral("openPreferences"), catCore,
+                      QKeySequence(Qt::ALT + Qt::Key_Enter).toString(), true});
+
+    /// Preferences
+    shortCuts.append({QStringLiteral("openModulesInfo"), catCore,
+                      QKeySequence(Qt::ALT + Qt::Key_M).toString(), true});
+
+    /// save
+    shortCuts.append({QStringLiteral("save"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::Key_S).toString(), true});
+
+    /// new Project
+    shortCuts.append({QStringLiteral("newProject"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::Key_N).toString(), true});
+
+    /// open Project
+    shortCuts.append({QStringLiteral("openProject"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::Key_O).toString(), true});
+
+    /// close Project
+    shortCuts.append({QStringLiteral("closeProject"), catCore,
+                      QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_W).toString(), true});
+
+    /// help
+    shortCuts.append({QStringLiteral("help"), catCore,
+                      QKeySequence(Qt::Key_F1).toString(), true});
+
+    /// undo
+    shortCuts.append({QStringLiteral("modulesOverview"), catCore,
+                      QKeySequence(Qt::ALT + Qt::Key_M).toString(), true});
+
+    return shortCuts;
 }
 
 void

--- a/src/gui/gt_application.h
+++ b/src/gui/gt_application.h
@@ -317,7 +317,7 @@ public:
      */
     void extendShortCuts(const QString& id,
                          QString const& category,
-                         const QKeySequence k,
+                         const QKeySequence& k,
                          bool readOnly = false);
 
     /**

--- a/src/gui/gt_application.h
+++ b/src/gui/gt_application.h
@@ -306,6 +306,9 @@ public:
      * @brief extendShortCuts
      * @param shortcut to add
      */
+    [[deprecated("Use extendShortCuts(const QString& id, "
+                 "QString const& category, const QKeySequence k, "
+                 "bool readOnly = false) instead")]]
     void extendShortCuts(const GtShortCutSettingsData &shortcut);
 
     /**

--- a/src/gui/gt_application.h
+++ b/src/gui/gt_application.h
@@ -309,6 +309,15 @@ public:
     void extendShortCuts(const GtShortCutSettingsData &shortcut);
 
     /**
+     * @brief extendShortCuts
+     * @param shortcut to add
+     */
+    void extendShortCuts(const QString& id,
+                         QString const& category,
+                         const QKeySequence k,
+                         bool readOnly = false);
+
+    /**
      * @brief moduleShortCuts
      * @return shortcuts registered via interface
      */

--- a/src/gui/gt_application.h
+++ b/src/gui/gt_application.h
@@ -348,6 +348,13 @@ public:
      */
     static const QList<PageFactory>& customPreferencePages();
 
+    /**
+     * @brief initCoreShortCuts
+     * @return The list of the initial shortcuts added by the
+     * the core system
+     */
+    QList<GtShortCutSettingsData> initCoreShortCuts() const;
+
 private:
     /// List of user specific perspective ids
     QStringList m_perspectiveIds;
@@ -385,8 +392,6 @@ private:
      * @brief initFirstRun
      */
     bool initFirstRun() override;
-
-    QList<GtShortCutSettingsData> initCoreShortCuts() const;
 
 private slots:
     /**

--- a/src/gui/gt_application.h
+++ b/src/gui/gt_application.h
@@ -315,10 +315,8 @@ public:
      * @brief extendShortCuts
      * @param shortcut to add
      */
-    void extendShortCuts(const QString& id,
-                         QString const& category,
-                         const QKeySequence& k,
-                         bool readOnly = false);
+    void addShortCut(const QString& id, QString const& category,
+                     const QKeySequence& k, bool readOnly = false);
 
     /**
      * @brief moduleShortCuts
@@ -387,6 +385,8 @@ private:
      * @brief initFirstRun
      */
     bool initFirstRun() override;
+
+    QList<GtShortCutSettingsData> initCoreShortCuts() const;
 
 private slots:
     /**

--- a/src/gui/gt_dockwidget.cpp
+++ b/src/gui/gt_dockwidget.cpp
@@ -73,7 +73,7 @@ GtDockWidget::registerShortCut(const QString& id,
                                bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    return registerShortCut({id, m->className(), k, readOnly});
+    return registerShortCut({id, m->className(), k.toString(), readOnly});
 }
 
 QKeySequence

--- a/src/gui/gt_dockwidget.cpp
+++ b/src/gui/gt_dockwidget.cpp
@@ -73,7 +73,8 @@ GtDockWidget::registerShortCut(const QString& id,
                                bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    return registerShortCut({id, m->className(), k.toString(), readOnly});
+    gtApp->extendShortCuts(id, m->className(), k.toString(), readOnly);
+    return getShortCut(id);
 }
 
 QKeySequence
@@ -90,7 +91,7 @@ GtDockWidget::registerShortCuts(const QList<GtShortCutSettingsData>& list)
 }
 
 QKeySequence
-GtDockWidget::getShortCut(const QString &id)
+GtDockWidget::getShortCut(const QString& id)
 {
     const QMetaObject* m = metaObject();
     return gtApp->getShortCutSequence(id, m->className());

--- a/src/gui/gt_dockwidget.cpp
+++ b/src/gui/gt_dockwidget.cpp
@@ -73,7 +73,7 @@ GtDockWidget::registerShortCut(const QString& id,
                                bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    gtApp->extendShortCuts(id, m->className(), k.toString(), readOnly);
+    gtApp->addShortCut(id, m->className(), k.toString(), readOnly);
     return getShortCut(id);
 }
 

--- a/src/gui/gt_dockwidget.h
+++ b/src/gui/gt_dockwidget.h
@@ -77,12 +77,16 @@ protected:
      * @param data - short cut data to register
      * @return the key sequence used for this id
      */
+    [[deprecated("Use registerShortCut(QString const& id,"
+                 " QKeySequence const& k, bool readOnly = false) instead")]]
     QKeySequence registerShortCut(GtShortCutSettingsData const& data);
 
     /**
      * @brief registerShortCuts
      * @param list - list of short cuts to register
      */
+    [[deprecated("Use registerShortCut(QString const& id,"
+                 " QKeySequence const& k, bool readOnly = false) instead")]]
     void registerShortCuts(QList<GtShortCutSettingsData> const& list);
 
     /**

--- a/src/gui/gt_mdiitem.cpp
+++ b/src/gui/gt_mdiitem.cpp
@@ -125,7 +125,8 @@ GtMdiItem::registerShortCut(const QString& id,
                             bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    return registerShortCut({id, m->className(), k.toString(), readOnly});
+    gtApp->extendShortCuts(id, m->className(), k.toString(), readOnly);
+    return getShortCut(id);
 }
 
 QKeySequence

--- a/src/gui/gt_mdiitem.cpp
+++ b/src/gui/gt_mdiitem.cpp
@@ -125,7 +125,7 @@ GtMdiItem::registerShortCut(const QString& id,
                             bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    return registerShortCut({id, m->className(), k, readOnly});
+    return registerShortCut({id, m->className(), k.toString(), readOnly});
 }
 
 QKeySequence

--- a/src/gui/gt_mdiitem.cpp
+++ b/src/gui/gt_mdiitem.cpp
@@ -125,7 +125,7 @@ GtMdiItem::registerShortCut(const QString& id,
                             bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    gtApp->extendShortCuts(id, m->className(), k.toString(), readOnly);
+    gtApp->addShortCut(id, m->className(), k.toString(), readOnly);
     return getShortCut(id);
 }
 

--- a/src/gui/gt_mdiitem.h
+++ b/src/gui/gt_mdiitem.h
@@ -178,12 +178,16 @@ protected:
      * @param data - short cut data to register
      * @return the key sequence used for this id
      */
+    [[deprecated("Use registerShortCut(QString const& id,"
+                 " QKeySequence const& k, bool readOnly = false) instead")]]
     QKeySequence registerShortCut(GtShortCutSettingsData const& data);
 
     /**
      * @brief registerShortCuts
      * @param list - list of short cuts to register
      */
+    [[deprecated("Use registerShortCut(QString const& id,"
+                 " QKeySequence const& k, bool readOnly = false) instead")]]
     void registerShortCuts(QList<GtShortCutSettingsData> const& list);
 
     /**

--- a/src/gui/gt_objectui.cpp
+++ b/src/gui/gt_objectui.cpp
@@ -181,7 +181,7 @@ GtObjectUI::registerShortCut(const QString& id,
                              bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    gtApp->extendShortCuts(id, m->className(), k.toString(), readOnly);
+    gtApp->addShortCut(id, m->className(), k.toString(), readOnly);
     return getShortCut(id);
 }
 

--- a/src/gui/gt_objectui.cpp
+++ b/src/gui/gt_objectui.cpp
@@ -181,7 +181,8 @@ GtObjectUI::registerShortCut(const QString& id,
                              bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    return registerShortCut({id, m->className(), k.toString(), readOnly});
+    gtApp->extendShortCuts(id, m->className(), k.toString(), readOnly);
+    return getShortCut(id);
 }
 
 QKeySequence

--- a/src/gui/gt_objectui.cpp
+++ b/src/gui/gt_objectui.cpp
@@ -181,7 +181,7 @@ GtObjectUI::registerShortCut(const QString& id,
                              bool readOnly)
 {
     const QMetaObject* m = metaObject();
-    return registerShortCut({id, m->className(), k, readOnly});
+    return registerShortCut({id, m->className(), k.toString(), readOnly});
 }
 
 QKeySequence

--- a/src/gui/gt_objectui.h
+++ b/src/gui/gt_objectui.h
@@ -342,12 +342,16 @@ protected:
      * @param data - short cut data to register
      * @return the key sequence used for this id
      */
+    [[deprecated("Use registerShortCut(QString const& id,"
+                 " QKeySequence const& k, bool readOnly = false) instead")]]
     QKeySequence registerShortCut(GtShortCutSettingsData const& data);
 
     /**
      * @brief registerShortCuts
      * @param list - list of short cuts to register
      */
+    [[deprecated("Use registerShortCut(QString const& id,"
+                 " QKeySequence const& k, bool readOnly = false) instead")]]
     void registerShortCuts(QList<GtShortCutSettingsData> const& list);
 
     /**

--- a/src/gui/gt_objectuiaction.cpp
+++ b/src/gui/gt_objectuiaction.cpp
@@ -212,7 +212,7 @@ GtObjectUIAction::registerShortCut(const QString& id,
                                    const QKeySequence& k,
                                    bool readOnly)
 {
-    gtApp->extendShortCuts({id, cat, k, readOnly});
+    gtApp->extendShortCuts({id, cat, k.toString(), readOnly});
     m_shortCut = gtApp->getShortCutSequence(id, cat);
     return *this;
 }

--- a/src/gui/gt_shortcut.cpp
+++ b/src/gui/gt_shortcut.cpp
@@ -17,7 +17,7 @@ GtShortCut::GtShortCut(const QString& id,
 {  
     m_data.id = id;
     m_data.category = cat;
-    m_data.shortCut = key;
+    m_data.shortCut = key.toString();
     m_data.isReadOnly = isReadOnly;
 }
 
@@ -46,7 +46,7 @@ GtShortCut::key() const
 void
 GtShortCut::setKey(const QKeySequence &key)
 {
-    m_data.shortCut = key;
+    m_data.shortCut = key.toString();
 }
 
 QString


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The core has a dependency to the QtGUI library only because of the usage of the QKeySequence to store ShortCut information.

This is changed in this PR. The GtShortCutSettingsData now stored the key information in a QString. This is an ABI change!
And as also the constructor changes this is also an API change!

First overview in our modules showed there would be the need in 2 modules to make simple adaptions but external module developers might be affected as well if they use short cuts with this old interface.

As the transfer from keySequence to string and vice versa could lead to wrong usage the interface was extended to avoid the usage of the  GtShortCutSettingsData for module developers but use interface functions still have the option to use keysequences to store the used keys.

## How Has This Been Tested?
First a GUI test failed as one feature had been missing but now all tests are successfull and test usage of few short cuts lead to the same behavior as before. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
