### PR TITLE
feat.: Adding Update Project Procedure to Batch-Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
  - Removed a warning, when double clicking on the current project while a task is running - #1282
+ 
 ### Added
+ - Extended the batch mode for a command to upgrade a GTlab project - #1184
  - Basic contxt menu to copy values of properties - #1267	
 
 ## [2.0.10] - 2024-08-29

--- a/src/batch/CMakeLists.txt
+++ b/src/batch/CMakeLists.txt
@@ -14,6 +14,7 @@ set(headers
     gt_remoteprocessrunner.h
     gt_remoteprocessrunnerstates.h
     gt_consolerunprocess.h
+    gt_consoleupgradeproject.h
 )
 
 set(sources
@@ -23,6 +24,7 @@ set(sources
     gt_remoteprocessrunner.cpp
     gt_remoteprocessrunnerstates.cpp
     gt_consolerunprocess.cpp
+    gt_consoleupgradeproject.cpp
 )
 
 if (WIN32)

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -780,7 +780,7 @@ initSystemOptions()
                     "Switches to the given session", {},
                     {GtCommandLineArgument{"session_id", "Session ID"}});
 
-    initPosArgument("upgrade_project", gt::console::upgrade_project,
+    initPosArgument("upgrade_project", gt::console::upgradeProjectCommand,
                     "Upgrades All Modules in the current project", {},
                     QList<GtCommandLineArgument>(),
                     false);

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -780,7 +780,7 @@ initSystemOptions()
                     "Switches to the given session", {},
                     {GtCommandLineArgument{"session_id", "Session ID"}});
 
-    initPosArgument("upgrade_Project", gt::console::upgrade_Project,
+    initPosArgument("upgrade_project", gt::console::upgrade_project,
                     "Upgrades All Modules in the current project",
                     gt::console::options(),
                     QList<GtCommandLineArgument>(),

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <gt_projectprovider.h>
 
 #include <QApplication>
 #include <QDomDocument>
@@ -706,6 +707,112 @@ switch_session(const QStringList& args)
     return 0;
 }
 
+int
+upgradeRoutine(const QString& projectFile, const QString& projectFilePath = "", QString newProjectName = "")
+{
+    GtProject* project = gtApp->findProject(projectFile);
+
+    if (!project)
+    {
+        gtError() << QObject::tr("Project not found!")
+        << QStringLiteral(" (") << projectFile << QStringLiteral(")");
+
+        return -1;
+    }
+
+    if (newProjectName.isEmpty())
+    {
+        newProjectName = projectFile + "Copy";
+    }
+
+    if (project->upgradesAvailable())
+    {
+        if (projectFilePath.isEmpty())
+        {
+            gtDebug() << "backup and overwriting project data...";
+            project->createBackup();
+            project->upgradeProjectData();
+
+            return 1;
+        }
+        else
+        {
+            gtDebug() << "upgrading data as new project...";
+            auto newProject = GtProjectProvider::duplicateExistingProject(
+                QDir(project->path()),
+                QDir(projectFilePath),
+                newProjectName
+                );
+
+            if (!newProject)
+            {
+                gtError() << "Could not save project to new directory";
+                return 0;
+            }
+
+            newProject->upgradeProjectData();
+            gtDataModel->newProject(newProject.release(), false);
+
+            return 1;
+        }
+    }
+
+    gtDebug() << "Project is up to date no further upgrades needed at the moment.";
+
+    return 0;
+}
+
+int
+upgrade_Project(const QStringList& args)
+{
+    GtCommandLineParser p;
+    p.addHelpOption();
+
+    for (const auto& o : gt::console::options())
+    {
+        p.addOption(o.names.first(), o);
+    }
+
+    if (!p.parse(args))
+    {
+        gtError() << QObject::tr("Run method without arguments is invalid");
+        return -1;
+    }
+
+    if (p.helpOption())
+    {
+        gt::console::printRunHelp();
+        return 0;
+    }
+
+    size_t posArgSize = p.positionalArguments().size();
+
+    if (p.option("overwrite"))
+    {
+        return upgradeRoutine(p.positionalArguments().at(0));
+    }
+
+    //default
+    if (posArgSize == 2)
+    {
+        gtError() << p.positionalArguments().at(0);
+        gtError() << p.positionalArguments().at(1);
+
+        return upgradeRoutine(p.positionalArguments().at(0), p.positionalArguments().at(1));
+    }
+    else if (posArgSize == 3)
+    {
+        return upgradeRoutine(p.positionalArguments().at(0), p.positionalArguments().at(1), p.positionalArguments().at(2));
+    }
+    else if (posArgSize < 2 || posArgSize > 3)
+    {
+        gtError() << QObject::tr("Invalid usage of file option");
+        return -1;
+    }
+
+    return 0;
+}
+
 void
 initPosArgument(QString const& id,
                 std::function<int(const QStringList&)> func,
@@ -777,6 +884,12 @@ initSystemOptions()
     initPosArgument("switch_session", switch_session,
                     "Switches to the given session", {},
                     {GtCommandLineArgument{"session_id", "Session ID"}});
+
+    initPosArgument("upgrade_Project", upgrade_Project,
+                    "Upgrades All Modules in the current project",
+                    gt::console::options(),
+                    QList<GtCommandLineArgument>(),
+                    false);
 }
 
 int

--- a/src/batch/batch.cpp
+++ b/src/batch/batch.cpp
@@ -743,7 +743,7 @@ initSystemOptions()
                     "To define a project name and a process name is the "
                     "default used option to execute this command."
                     "\n\t\t\tUse --help for more details.",
-                    gt::console::options(),
+                    gt::console::runOptions(),
                     QList<GtCommandLineArgument>(),
                     false);
 
@@ -781,8 +781,7 @@ initSystemOptions()
                     {GtCommandLineArgument{"session_id", "Session ID"}});
 
     initPosArgument("upgrade_project", gt::console::upgrade_project,
-                    "Upgrades All Modules in the current project",
-                    gt::console::options(),
+                    "Upgrades All Modules in the current project", {},
                     QList<GtCommandLineArgument>(),
                     false);
 }

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -37,7 +37,7 @@ gt::console::options()
     runOptions.append(GtCommandLineOption{
                           {"file", "f"}, "Define project by file"});
     runOptions.append(GtCommandLineOption{
-                          {"overwrite", "o"}, "Overwrite project with command"});
+                          {"output", "o"}, "Overwrite project with command by Output Path"});
 
     return runOptions;
 }

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -37,7 +37,7 @@ gt::console::options()
     runOptions.append(GtCommandLineOption{
                           {"file", "f"}, "Define project by file"});
     runOptions.append(GtCommandLineOption{
-                          {"output", "o"}, "Overwrite project with command by Output Path"});
+                          {"output", "o"}, "Write project to output path"});
 
     return runOptions;
 }

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -36,6 +36,8 @@ gt::console::options()
                           {"name", "n"}, "Define project by name"});
     runOptions.append(GtCommandLineOption{
                           {"file", "f"}, "Define project by file"});
+    runOptions.append(GtCommandLineOption{
+                          {"overwrite", "o"}, "Overwrite project with command"});
 
     return runOptions;
 }

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -26,7 +26,7 @@
 #include <QCoreApplication>
 
 QList<GtCommandLineOption>
-gt::console::options()
+gt::console::runOptions()
 {
     QList<GtCommandLineOption> runOptions;
     runOptions.append(GtCommandLineOption{
@@ -48,7 +48,7 @@ gt::console::run(const QStringList &args)
     GtCommandLineParser p;
     p.addHelpOption();
 
-    for (const auto& o : options())
+    for (const auto& o : runOptions())
     {
         p.addOption(o.names.first(), o);
     }

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -19,11 +19,9 @@
 #include "gt_task.h"
 #include "gt_processdata.h"
 
-#include <gt_logging.h>
+
 #include <iostream>
 #include <ostream>
-
-#include <QCoreApplication>
 
 QList<GtCommandLineOption>
 gt::console::runOptions()
@@ -225,29 +223,6 @@ gt::console::runProcess(const QString& projectId,
     }
 
     return 0;
-}
-
-/**
- * @brief Enters a temporary session
- *
- * The return value must be kept until the session is not needed anymore.
- * It is used to switch back to the current session
- */
-auto enterTempSession()
-{
-    auto tmpSessionID = QString("_tmp_batch_session_%1").arg(QCoreApplication::applicationPid());
-    QString currentSessionID = gtApp->session() ? gtApp->session()->objectName() : "default";
-
-    gtDebug() << QObject::tr("Creating temporary batch session '%1'").arg(tmpSessionID);
-
-    gtApp->newSession(tmpSessionID);
-    gtApp->switchSession(tmpSessionID);
-
-    // cleanup
-    return gt::finally([tmpSessionID, currentSessionID](){
-        gtApp->switchSession(currentSessionID);
-        gtApp->deleteSession(tmpSessionID);
-    });
 }
 
 int

--- a/src/batch/gt_consolerunprocess.h
+++ b/src/batch/gt_consolerunprocess.h
@@ -11,6 +11,12 @@
 #define GTCONSOLERUNPROCESS_H
 
 #include "gt_commandlineparser.h"
+
+#include <gt_logging.h>
+#include <gt_application.h>
+#include <gt_session.h>
+
+#include <QCoreApplication>
 #include <QStringList>
 
 class GtProject;
@@ -59,6 +65,30 @@ int
 runProcessByFile(const QString& projectFile, const QString& processId,
                  const QString& taskGroupId = "",
                  bool save = false);
+
+/**
+ * @brief Enters a temporary session
+ *
+ * The return value must be kept until the session is not needed anymore.
+ * It is used to switch back to the current session
+ */
+inline auto enterTempSession()
+{
+    auto tmpSessionID = QString("_tmp_batch_session_%1").arg(QCoreApplication::applicationPid());
+    QString currentSessionID = gtApp->session() ? gtApp->session()->objectName() : "default";
+
+    gtDebug() << QObject::tr("Creating temporary batch session '%1'").arg(tmpSessionID);
+
+    gtApp->newSession(tmpSessionID);
+    gtApp->switchSession(tmpSessionID);
+
+    // cleanup
+    return gt::finally([tmpSessionID, currentSessionID](){
+        gtApp->switchSession(currentSessionID);
+        gtApp->deleteSession(tmpSessionID);
+    });
+}
+
 
 } // namespace console
 } // namespace gt

--- a/src/batch/gt_consolerunprocess.h
+++ b/src/batch/gt_consolerunprocess.h
@@ -21,10 +21,10 @@ namespace gt
 namespace console
 {
 /**
- * @brief options
- * @return list of the command line options
+ * @brief runOptions
+ * @return list of the command line options for the run command
  */
-QList<GtCommandLineOption> options();
+QList<GtCommandLineOption> runOptions();
 
 int run(QStringList const& args);
 

--- a/src/batch/gt_consoleupgradeproject.cpp
+++ b/src/batch/gt_consoleupgradeproject.cpp
@@ -61,38 +61,10 @@ gt::console::upgradeRoutine(const QString& projectFile,
         return 0;
     }
 
-    if (newProjectFilePath.isEmpty())
-    {
-        gtDebug() << "backup and overwriting project data...";
-        project->createBackup();
-        project->upgradeProjectData();
+    // Return 0 if the upgrade was successfull
+    if (project->upgradeProjectRoutine(newProjectFilePath.isEmpty(), newProjectFilePath)) return 0;
 
-        return 1;
-    }
-    else
-    {
-        gtDebug() << "upgrading data as new project...";
-        auto newProject = GtProjectProvider::duplicateExistingProject(
-            QDir(project->path()),
-            QDir(newProjectFilePath),
-            QFileInfo(newProjectFilePath).fileName()
-            );
-
-        if (!newProject)
-        {
-            gtError() << "Could not save project to new directory";
-            return 0;
-        }
-
-        newProject->upgradeProjectData();
-        gtDataModel->newProject(newProject.release(), false);
-
-        return 1;
-    }
-
-    gtDebug() << "Project is up to date no further upgrades needed at the moment.";
-
-    return 0;
+    else return -1;
 }
 
 int

--- a/src/batch/gt_consoleupgradeproject.cpp
+++ b/src/batch/gt_consoleupgradeproject.cpp
@@ -1,0 +1,116 @@
+#include "gt_consoleupgradeproject.h"
+
+#include "gt_application.h"
+#include "gt_project.h"
+#include "gt_projectprovider.h"
+#include "gt_consolerunprocess.h"
+#include "gt_datamodel.h"
+
+#include <gt_commandlineparser.h>
+
+
+int
+gt::console::upgradeRoutine(const QString& projectFile,
+                            const QString& projectFilePath)
+{
+    GtProject* project = gtApp->findProject(projectFile);
+
+    if (!project)
+    {
+        gtError() << QObject::tr("Project not found!")
+        << QStringLiteral(" (") << projectFile << QStringLiteral(")");
+
+        return -1;
+    }
+
+    if (project->upgradesAvailable())
+    {
+        if (projectFilePath.isEmpty())
+        {
+            gtDebug() << "backup and overwriting project data...";
+            project->createBackup();
+            project->upgradeProjectData();
+
+            return 1;
+        }
+        else
+        {
+            gtDebug() << "upgrading data as new project...";
+            auto newProject = GtProjectProvider::duplicateExistingProject(
+                QDir(project->path()),
+                QDir(projectFilePath),
+                QFileInfo(projectFilePath).fileName()
+                );
+
+            if (!newProject)
+            {
+                gtError() << "Could not save project to new directory";
+                return 0;
+            }
+
+            newProject->upgradeProjectData();
+            gtDataModel->newProject(newProject.release(), false);
+
+            return 1;
+        }
+    }
+
+    gtDebug() << "Project is up to date no further upgrades needed at the moment.";
+
+    return 0;
+}
+
+int
+gt::console::upgrade_Project(const QStringList &args)
+{
+    GtCommandLineParser p;
+    p.addHelpOption();
+
+    for (const auto& o : gt::console::options())
+    {
+        p.addOption(o.names.first(), o);
+    }
+
+    if (!p.parse(args))
+    {
+        gtError() << QObject::tr("Run method without arguments is invalid");
+        return -1;
+    }
+
+    if (p.helpOption())
+    {
+        gt::console::printRunHelp();
+        return 0;
+    }
+
+    size_t posArgSize = p.positionalArguments().size();
+
+    if (p.option("output"))
+    {
+        if (posArgSize == 2)
+        {
+            gtError() << p.positionalArguments().at(0);
+            gtError() << p.positionalArguments().at(1);
+
+            return upgradeRoutine(p.positionalArguments().at(0), p.positionalArguments().at(1));
+        }
+        else
+        {
+            gtError() << QObject::tr("Invalid usage of file option");
+            return -1;
+        }
+    }
+
+    //default
+    if (posArgSize == 1)
+    {
+        return upgradeRoutine(p.positionalArguments().at(0));
+    }
+    else
+    {
+        gtError() << QObject::tr("Invalid usage of file option");
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/batch/gt_consoleupgradeproject.cpp
+++ b/src/batch/gt_consoleupgradeproject.cpp
@@ -10,17 +10,18 @@
 
 #include "gt_consoleupgradeproject.h"
 
-#include "gt_application.h"
 #include "gt_project.h"
 #include "gt_projectprovider.h"
 #include "gt_consolerunprocess.h"
-#include "gt_datamodel.h"
 
 #include <gt_commandlineparser.h>
 #include <iostream>
 
+namespace
+{
+
 void
-gt::console::printUpgradeProjectHelp()
+printUpgradeProjectHelp()
 {
     std::cout << std::endl;
     std::cout << "This is the help for the GTlab upgrade_project function\n\n";
@@ -39,8 +40,8 @@ gt::console::printUpgradeProjectHelp()
 }
 
 int
-gt::console::upgradeRoutine(const QString& projectPath,
-                            const QString& newProjectFilePath)
+upgradeRoutine(const QString& projectPath,
+               const QString& newProjectFilePath = "")
 {
     QFileInfo fi(projectPath);
     QString projectFile = projectPath;
@@ -59,7 +60,7 @@ gt::console::upgradeRoutine(const QString& projectPath,
     }
 
     // we need to create a temporary session in which the project is imported
-    auto tmpSession = enterTempSession();
+    auto tmpSession = gt::console::enterTempSession();
     Q_UNUSED(tmpSession);
 
     GtProjectProvider provider(projectFile);
@@ -78,8 +79,8 @@ gt::console::upgradeRoutine(const QString& projectPath,
         return 0;
     }
 
-    // Return 0 if the upgrade was successfull
-    if (project->upgradeProjectRoutine(newProjectFilePath)) {
+    // Return 0 if the upgrade was successful
+    if (project->upgradeProject(newProjectFilePath)) {
         gtInfo() << QObject::tr("Project %1 updated successfully")
                         .arg(project->objectName());
         return 0;
@@ -88,8 +89,11 @@ gt::console::upgradeRoutine(const QString& projectPath,
     else return -1;
 }
 
+} // namespace
+
+
 int
-gt::console::upgrade_project(const QStringList &upgradeProjectArguments)
+gt::console::upgradeProjectCommand(const QStringList &upgradeProjectArguments)
 {
     GtCommandLineParser upgradeProjectParser;
     upgradeProjectParser.addHelpOption();
@@ -102,13 +106,14 @@ gt::console::upgrade_project(const QStringList &upgradeProjectArguments)
     if (!upgradeProjectParser.parse(upgradeProjectArguments))
     {
         std::cerr << QObject::tr("\n\nrunning upgrade_project "
-                                 "without arguments is invalid\n\n").toStdString();
+                                 "without arguments is invalid\n\n")
+                         .toStdString();
         return -1;
     }
 
     if (upgradeProjectParser.helpOption())
     {
-        gt::console::printUpgradeProjectHelp();
+        printUpgradeProjectHelp();
         return 0;
     }
 
@@ -124,11 +129,12 @@ gt::console::upgrade_project(const QStringList &upgradeProjectArguments)
         {
             std::cerr << QObject::tr("\n\nInvalid usage "
                                      "of output argument!\n\n").toStdString();
-            gt::console::printUpgradeProjectHelp();
+            printUpgradeProjectHelp();
             return -1;
         }
 
-        return upgradeRoutine(upgradeProjectParser.positionalArguments().at(0), upgradeProjectParser.positionalArguments().at(1));
+        return upgradeRoutine(upgradeProjectParser.positionalArguments().at(0),
+                              upgradeProjectParser.positionalArguments().at(1));
     }
 
     //default
@@ -139,8 +145,9 @@ gt::console::upgrade_project(const QStringList &upgradeProjectArguments)
     else
     {
         std::cerr << QObject::tr("\n\nInvalid usage "
-                                 "of upgrade_project routine!\n\n").toStdString();
-        gt::console::printUpgradeProjectHelp();
+                                 "of upgrade_project routine!\n\n")
+                         .toStdString();
+        printUpgradeProjectHelp();
         return -1;
     }
 

--- a/src/batch/gt_consoleupgradeproject.cpp
+++ b/src/batch/gt_consoleupgradeproject.cpp
@@ -62,7 +62,7 @@ gt::console::upgradeRoutine(const QString& projectFile,
     }
 
     // Return 0 if the upgrade was successfull
-    if (project->upgradeProjectRoutine(newProjectFilePath.isEmpty(), newProjectFilePath)) return 0;
+    if (project->upgradeProjectRoutine(newProjectFilePath)) return 0;
 
     else return -1;
 }

--- a/src/batch/gt_consoleupgradeproject.h
+++ b/src/batch/gt_consoleupgradeproject.h
@@ -1,0 +1,31 @@
+#ifndef GT_CONSOLEUPGRADEPROJECT_H
+#define GT_CONSOLEUPGRADEPROJECT_H
+
+#include <QStringList>
+
+namespace gt
+{
+namespace console
+{
+
+/**
+ * @brief upgradeRoutine
+ * @param projectFile
+ * @param projectFilePath
+ * @param newProjectName
+ * @return
+ */
+    int upgradeRoutine(const QString& projectFile,
+                       const QString& projectFilePath = "");
+
+/**
+ * @brief upgrade_Project
+ * @param args
+ * @return
+ */
+int upgrade_Project(const QStringList& args);
+
+}
+}
+
+#endif // GT_CONSOLEUPGRADEPROJECT_H

--- a/src/batch/gt_consoleupgradeproject.h
+++ b/src/batch/gt_consoleupgradeproject.h
@@ -19,21 +19,26 @@ namespace console
 {
 
 /**
+ * @brief printRunHelp
+ */
+void printUpgradeProjectHelp();
+
+/**
  * @brief upgradeRoutine
  * @param projectFile
- * @param projectFilePath
+ * @param newProjectFilePath
  * @param newProjectName
  * @return
  */
-    int upgradeRoutine(const QString& projectFile,
-                       const QString& projectFilePath = "");
+int upgradeRoutine(const QString& projectFile,
+                   const QString& newProjectFilePath = "");
 
 /**
  * @brief upgrade_Project
- * @param args
+ * @param upgradeProjectArguments
  * @return
  */
-int upgrade_project(const QStringList& args);
+int upgrade_project(const QStringList& upgradeProjectArguments);
 
 }
 }

--- a/src/batch/gt_consoleupgradeproject.h
+++ b/src/batch/gt_consoleupgradeproject.h
@@ -19,26 +19,12 @@ namespace console
 {
 
 /**
- * @brief printRunHelp
+ * @brief A batch command to upgrade a gtlab project
+ * @param args Command line parameters passed from main
+ *
+ * @return 0 on success
  */
-void printUpgradeProjectHelp();
-
-/**
- * @brief upgradeRoutine
- * @param projectFile
- * @param newProjectFilePath
- * @param newProjectName
- * @return
- */
-int upgradeRoutine(const QString& projectFile,
-                   const QString& newProjectFilePath = "");
-
-/**
- * @brief upgrade_Project
- * @param upgradeProjectArguments
- * @return
- */
-int upgrade_project(const QStringList& upgradeProjectArguments);
+int upgradeProjectCommand(const QStringList& args);
 
 }
 }

--- a/src/batch/gt_consoleupgradeproject.h
+++ b/src/batch/gt_consoleupgradeproject.h
@@ -1,3 +1,13 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
+ *
+ *  Created on: 14.10.2024
+ *  Author: Jannis Kruse (AT-TWK)
+ *  E-Mail: jannis.kruse@dlr.de
+ */
+
 #ifndef GT_CONSOLEUPGRADEPROJECT_H
 #define GT_CONSOLEUPGRADEPROJECT_H
 
@@ -23,7 +33,7 @@ namespace console
  * @param args
  * @return
  */
-int upgrade_Project(const QStringList& args);
+int upgrade_project(const QStringList& args);
 
 }
 }

--- a/src/core/gt_project.cpp
+++ b/src/core/gt_project.cpp
@@ -14,7 +14,9 @@
 #include <QDateTime>
 
 #include "gt_project.h"
+#include "gt_coredatamodel.h"
 #include "gt_processdata.h"
+#include "gt_projectprovider.h"
 #include "gt_task.h"
 #include "gt_objectfactory.h"
 #include "gt_objectmemento.h"
@@ -32,6 +34,7 @@
 #include "gt_xmlutilities.h"
 #include "gt_qtutilities.h"
 #include "gt_filesystem.h"
+#include "gt_abstractloadinghelper.h"
 
 #include "internal/gt_moduleupgrader.h"
 #include "internal/gt_moduleupgrader.h"
@@ -1127,6 +1130,66 @@ bool
 GtProject::upgradesAvailable() const
 {
     return m_upgradesAvailable;
+}
+
+bool GtProject::upgradeProjectRoutine(bool overwriteExistingData, const QString& newProjectFilePath)
+{
+    if (overwriteExistingData)
+    {
+        gtDebug() << "backup and overwriting project data...";
+
+        if (gtApp->batchMode())
+        {
+            createBackup();
+            upgradeProjectData();
+        }
+        else
+        {
+            // upgrade project data in separate thread
+            gtApp->loadingProcedure(gt::makeLoadingHelper([this]() {
+                                        createBackup();
+                                        upgradeProjectData();
+                                    }).get());
+        }
+
+        return true;
+    }
+    else
+    {
+        gtDebug() << "upgrading data as new project...";
+        gtDebug() << "  |-> " << QFileInfo(newProjectFilePath).fileName();
+        gtDebug() << "  |-> " << newProjectFilePath;
+
+        auto newProject = GtProjectProvider::duplicateExistingProject(
+            QDir(path()),
+            QDir(newProjectFilePath),
+            QFileInfo(newProjectFilePath).fileName()
+            );
+
+        if (!newProject)
+        {
+            gtError() << "Could not save project to new directory";
+            return false;
+        }
+
+        newProject->upgradeProjectData();
+
+        if (gtApp->batchMode())
+        {
+            newProject->upgradeProjectData();
+        }
+        else
+        {
+            // upgrade project data in separate thread
+            gtApp->loadingProcedure(gt::makeLoadingHelper([&newProject]() {
+                                        newProject->upgradeProjectData();
+                                    }).get());
+        }
+
+        gtDataModel->newProject(newProject.release(), false);
+
+        return true;
+    }
 }
 
 GtProcessData*

--- a/src/core/gt_project.cpp
+++ b/src/core/gt_project.cpp
@@ -1132,7 +1132,8 @@ GtProject::upgradesAvailable() const
     return m_upgradesAvailable;
 }
 
-bool GtProject::upgradeProjectRoutine(const QString& newProjectFilePath)
+bool
+GtProject::upgradeProject(const QString& newProjectFilePath)
 {
     if (newProjectFilePath.isEmpty() || path() == newProjectFilePath)
     {

--- a/src/core/gt_project.cpp
+++ b/src/core/gt_project.cpp
@@ -1132,25 +1132,17 @@ GtProject::upgradesAvailable() const
     return m_upgradesAvailable;
 }
 
-bool GtProject::upgradeProjectRoutine(bool overwriteExistingData, const QString& newProjectFilePath)
+bool GtProject::upgradeProjectRoutine(const QString& newProjectFilePath)
 {
-    if (overwriteExistingData)
+    if (newProjectFilePath.isEmpty() || path() == newProjectFilePath)
     {
         gtDebug() << "backup and overwriting project data...";
 
-        if (gtApp->batchMode())
-        {
-            createBackup();
-            upgradeProjectData();
-        }
-        else
-        {
-            // upgrade project data in separate thread
+            // upgrade project data in separate thread if possible
             gtApp->loadingProcedure(gt::makeLoadingHelper([this]() {
                                         createBackup();
                                         upgradeProjectData();
                                     }).get());
-        }
 
         return true;
     }
@@ -1174,17 +1166,9 @@ bool GtProject::upgradeProjectRoutine(bool overwriteExistingData, const QString&
 
         newProject->upgradeProjectData();
 
-        if (gtApp->batchMode())
-        {
-            newProject->upgradeProjectData();
-        }
-        else
-        {
-            // upgrade project data in separate thread
-            gtApp->loadingProcedure(gt::makeLoadingHelper([&newProject]() {
-                                        newProject->upgradeProjectData();
-                                    }).get());
-        }
+        gtApp->loadingProcedure(gt::makeLoadingHelper([&newProject]() {
+                                    newProject->upgradeProjectData();
+                                }).get());
 
         gtDataModel->newProject(newProject.release(), false);
 

--- a/src/core/gt_project.cpp
+++ b/src/core/gt_project.cpp
@@ -1164,8 +1164,6 @@ bool GtProject::upgradeProjectRoutine(const QString& newProjectFilePath)
             return false;
         }
 
-        newProject->upgradeProjectData();
-
         gtApp->loadingProcedure(gt::makeLoadingHelper([&newProject]() {
                                     newProject->upgradeProjectData();
                                 }).get());

--- a/src/core/gt_project.h
+++ b/src/core/gt_project.h
@@ -82,6 +82,14 @@ public:
     bool upgradesAvailable() const;
 
     /**
+     * @brief upgrades Project via upgradeProject() method. Either the project is overwritten or written to a new dir.
+     * @param overwriteExistingData
+     * @return
+     */
+    bool upgradeProjectRoutine(bool overwriteExistingData, const QString &newProjectFilePath);
+
+
+    /**
      * @brief processData
      * @return
      */
@@ -431,7 +439,6 @@ private:
      * @param modIds Module identification strings.
      */
     void updateModuleFootprint(const QStringList &modIds);
-
 };
 
 namespace gt {

--- a/src/core/gt_project.h
+++ b/src/core/gt_project.h
@@ -86,7 +86,7 @@ public:
      * @param overwriteExistingData
      * @return
      */
-    bool upgradeProjectRoutine(bool overwriteExistingData, const QString &newProjectFilePath);
+    bool upgradeProjectRoutine(const QString &newProjectFilePath);
 
 
     /**

--- a/src/core/gt_project.h
+++ b/src/core/gt_project.h
@@ -81,13 +81,6 @@ public:
      */
     bool upgradesAvailable() const;
 
-    /**
-     * @brief upgrades Project via upgradeProject() method. Either the project is overwritten or written to a new dir.
-     * @param overwriteExistingData
-     * @return
-     */
-    bool upgradeProjectRoutine(const QString &newProjectFilePath);
-
 
     /**
      * @brief processData
@@ -230,6 +223,22 @@ public:
      * @brief Triggers upgrade routine of project data.
      */
     void upgradeProjectData();
+
+    /**
+     * @brief Performs a full project upgrade including
+     *
+     *  - Backup
+     *  - Project duplication
+     *  - Data upgrade
+     *
+     *  The project is added to the current session after upgrade
+     *
+     * @param newProjectFilePath The path to store the new project. If empty,
+     *                           a backup is created and the project
+     *                           will be overwritten.
+     * @return True on success
+     */
+    bool upgradeProject(const QString &newProjectFilePath);
 
     /**
      * @brief Generates a backup of all relevant project data. the backup is

--- a/src/gui/object_ui/gt_projectui.cpp
+++ b/src/gui/object_ui/gt_projectui.cpp
@@ -1486,45 +1486,14 @@ GtProjectUI::upgradeProjectData(GtObject* obj)
 
     if (dialog.exec())
     {
+        project->upgradeProjectRoutine(dialog.overwriteExistingDataAllowed(), dialog.newProjectPath());
+
         if (dialog.overwriteExistingDataAllowed())
         {
-            gtDebug() << "backup and overwriting project data...";
-
-            // upgrade project data in separate thread
-            gtApp->loadingProcedure(gt::makeLoadingHelper([&project]() {
-                project->createBackup();
-                project->upgradeProjectData();
-            }).get());
-
             gtDataModel->openProject(project);
             gtApp->setCurrentProject(project);
         }
-        else
-        {
-            gtDebug() << "upgrading data as new project...";
-            gtDebug() << "  |-> " << dialog.newProjectName();
-            gtDebug() << "  |-> " << dialog.newProjectPath();
 
-            auto newProject = GtProjectProvider::duplicateExistingProject(
-                QDir(project->path()),
-                QDir(dialog.newProjectPath()),
-                dialog.newProjectName()
-            );
-
-            if (!newProject)
-            {
-                gtError() << "Could not save project to new directory";
-                return;
-            }
-
-            // upgrade project data in separate thread
-            gtApp->loadingProcedure(gt::makeLoadingHelper([&newProject]() {
-                newProject->upgradeProjectData();
-            }).get());
-
-            // append to session but don't open
-            gtDataModel->newProject(newProject.release(), false);
-        }
     }
 }
 

--- a/src/gui/object_ui/gt_projectui.cpp
+++ b/src/gui/object_ui/gt_projectui.cpp
@@ -1490,7 +1490,7 @@ GtProjectUI::upgradeProjectData(GtObject* obj)
         QString projectPath = overwrite ? project->path()
                                         : dialog.newProjectPath();
 
-        project->upgradeProjectRoutine(projectPath);
+        project->upgradeProject(projectPath);
 
         if (overwrite)
         {

--- a/src/gui/object_ui/gt_projectui.cpp
+++ b/src/gui/object_ui/gt_projectui.cpp
@@ -1486,7 +1486,7 @@ GtProjectUI::upgradeProjectData(GtObject* obj)
 
     if (dialog.exec())
     {
-        project->upgradeProjectRoutine(dialog.overwriteExistingDataAllowed(), dialog.newProjectPath());
+        project->upgradeProjectRoutine(dialog.newProjectPath());
 
         if (dialog.overwriteExistingDataAllowed())
         {

--- a/src/gui/object_ui/gt_projectui.cpp
+++ b/src/gui/object_ui/gt_projectui.cpp
@@ -1486,9 +1486,13 @@ GtProjectUI::upgradeProjectData(GtObject* obj)
 
     if (dialog.exec())
     {
-        project->upgradeProjectRoutine(dialog.newProjectPath());
+        bool overwrite = dialog.overwriteExistingDataAllowed();
+        QString projectPath = overwrite ? project->path()
+                                        : dialog.newProjectPath();
 
-        if (dialog.overwriteExistingDataAllowed())
+        project->upgradeProjectRoutine(projectPath);
+
+        if (overwrite)
         {
             gtDataModel->openProject(project);
             gtApp->setCurrentProject(project);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

It is now possible to update projects with batch commands.

The new commands are: 

-    .\GTlabConsole.exe upgrade_project c:\data\my_project
-   .\GTlabConsole.exe upgrade_project c:\data\my_project -o c:\data\my_new_project

Exact information can be viewed by 
`GTlabConsole.exe upgrade_project --help`

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1184

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

MS: Since the code now affects gui and batch mode, I tested both with an intelligraph update for also the two cases
 - Inplace upgrade
 - Save to a new project path

All 4 cases are successful.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [x] The number of code quality warnings is not increasing.
