### PR TITLE
Implemented toolbar separators and toggle actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Unknown tasks (corrseponding module did not load) are now displayed as Dummy Objects in the `GtTaskGroup` - #612
 
 ### Changed
- - The main toolbar is now modularized. It can be extended by modules, e.g. to insert own editor contexts or actions. - #1298
+ - The main toolbar is now modularized. It can be extended by modules, e.g. to insert own editor contexts, separators or actions.
+   Also, actions can now have an on / off toggle state (i.e. toggle actions) - #1298, #1310
  - Renaming elments in GTlab explorer and process dock widget extended to be able to give better feedback and allow sibling objects to be taken into account - #1304
- 
+
 ### Fixed
  - Fixed alphabetically sorting of Shortcuts in Preference View #482
 

--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -242,12 +242,8 @@ GtMainWin::GtMainWin(QWidget* parent) : QMainWindow(parent),
     connect(modulesOverview, SIGNAL(activated()),
             SLOT(openAboutModulesDialog()));
 
-    loadPerspectiveSettings();
-
     connect(ui->mdiArea, SIGNAL(currentChanged(int)),
             SLOT(onEditorWindowActive(int)));
-
-    loadPerspectiveSettings();
 
     ui->qmlToolBar->setStyleSheet("QToolBar {border-bottom: 0px solid black; border-top: 0px solid black;}");
 

--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -1152,6 +1152,8 @@ GtMainWin::initAfterStartup()
         e->initAfterStartup();
     });
 
+    loadPerspectiveSettings();
+
     m_firstTimeShowEvent = false;
 }
 

--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -245,8 +245,7 @@ GtMainWin::GtMainWin(QWidget* parent) : QMainWindow(parent),
     connect(ui->mdiArea, SIGNAL(currentChanged(int)),
             SLOT(onEditorWindowActive(int)));
 
-    ui->qmlToolBar->setStyleSheet("QToolBar {border-bottom: 0px solid black; border-top: 0px solid black;}");
-
+    ui->qmlToolBar->setStyleSheet("QToolBar { margin: 0px; padding: 0px; border: none;}");
     ui->qmlToolBar->addWidget(m_mainWindowToolbar);
 }
 

--- a/src/gui/gt_mdiitem.cpp
+++ b/src/gui/gt_mdiitem.cpp
@@ -190,6 +190,13 @@ GtMdiItem::addToolbarAction(const QString& text, const QUrl& url)
     return action;
 }
 
+void
+GtMdiItem::addToolbarSeparator()
+{
+    auto action = GtQmlAction::makeSeparator(this);
+    pimpl->m_toolbarActions.push_back(action);
+}
+
 QKeySequence
 GtMdiItem::getShortCut(const QString& id)
 {

--- a/src/gui/gt_mdiitem.h
+++ b/src/gui/gt_mdiitem.h
@@ -210,6 +210,11 @@ protected:
     GtQmlAction* addToolbarAction(const QString& text, const QUrl& iconUrl);
 
     /**
+     * @brief Adds a separator to the toolbar context
+     */
+    void addToolbarSeparator();
+
+    /**
      * @brief getShortCut
      * @param id - identification string of the short cut to read
      * @return short cut for this id registered in this object

--- a/src/gui/gt_qmlaction.cpp
+++ b/src/gui/gt_qmlaction.cpp
@@ -15,6 +15,7 @@ struct GtQmlAction::Impl
     QString m_tooltip;
     bool m_enabled = {true};
     bool m_visible = {true};
+    bool m_isSeparator = {false};
 };
 
 GtQmlAction::~GtQmlAction() = default;
@@ -27,6 +28,14 @@ GtQmlAction::GtQmlAction(QString text, QUrl icon, QObject *parent)
 {
     pimpl->m_iconSource = std::move(icon);
     pimpl->m_text = std::move(text);
+}
+
+GtQmlAction*
+GtQmlAction::makeSeparator(QObject *parent)
+{
+    auto obj = new GtQmlAction("", QUrl(), parent);
+    obj->pimpl->m_isSeparator = true;
+    return obj;
 }
 
 QUrl
@@ -103,3 +112,11 @@ GtQmlAction::setVisible(bool visible)
     pimpl->m_visible = visible;
     emit visibleChanged();
 }
+
+
+bool
+GtQmlAction::isSeparator() const
+{
+    return pimpl->m_isSeparator;
+}
+

--- a/src/gui/gt_qmlaction.cpp
+++ b/src/gui/gt_qmlaction.cpp
@@ -16,6 +16,8 @@ struct GtQmlAction::Impl
     bool m_enabled = {true};
     bool m_visible = {true};
     bool m_isSeparator = {false};
+    bool m_isCheckable = {false};
+    bool m_isChecked = {false};
 };
 
 GtQmlAction::~GtQmlAction() = default;
@@ -111,6 +113,36 @@ GtQmlAction::setVisible(bool visible)
 
     pimpl->m_visible = visible;
     emit visibleChanged();
+}
+
+void
+GtQmlAction::setCheckable(bool checkable)
+{
+    if (pimpl->m_isCheckable == checkable) return;
+
+    pimpl->m_isCheckable = checkable;
+    emit checkableChanged();
+}
+
+bool
+GtQmlAction::checkable() const
+{
+    return pimpl->m_isCheckable;
+}
+
+bool
+GtQmlAction::isChecked() const
+{
+    return pimpl->m_isChecked;
+}
+
+void
+GtQmlAction::setChecked(bool checked)
+{
+    if (pimpl->m_isChecked == checked) return;
+
+    pimpl->m_isChecked = checked;
+    emit checkedChanged();
 }
 
 

--- a/src/gui/gt_qmlaction.cpp
+++ b/src/gui/gt_qmlaction.cpp
@@ -79,6 +79,7 @@ GtQmlAction::toolTip() const
 void
 GtQmlAction::setToolTip(QString t)
 {
+    t = t.trimmed();
     if (t == pimpl->m_tooltip) return;
 
     pimpl->m_tooltip = std::move(t);

--- a/src/gui/gt_qmlaction.h
+++ b/src/gui/gt_qmlaction.h
@@ -83,6 +83,8 @@ public:
     explicit GtQmlAction(QObject* parent = nullptr);
     GtQmlAction(QString text, QUrl icon, QObject* parent = nullptr);
 
+    static GtQmlAction* makeSeparator(QObject* parent = nullptr);
+
     ~GtQmlAction() override;
 
     QString text() const;
@@ -100,6 +102,11 @@ public:
 
     bool isVisible() const;
     void setVisible(bool visible);
+
+    /**
+     * @brief Returns true if this action acts only as a separator
+     */
+    Q_INVOKABLE bool isSeparator() const;
 
 signals:
     /**

--- a/src/gui/gt_qmlaction.h
+++ b/src/gui/gt_qmlaction.h
@@ -79,6 +79,16 @@ class GT_GUI_EXPORT GtQmlAction : public QObject
      * See also `GtQmlAction::toolTip` and `GtQmlAction::setToolTip`
      */
     Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibleChanged)
+
+    /**
+     * @brief This property holds whether the action can toggled / checked
+     */
+    Q_PROPERTY(bool checkable READ checkable WRITE setCheckable NOTIFY checkableChanged FINAL)
+
+    /**
+     * @brief This property holds whether the action is checked or not
+     */
+    Q_PROPERTY(bool checked READ isChecked WRITE setChecked NOTIFY checkedChanged FINAL)
 public:
     explicit GtQmlAction(QObject* parent = nullptr);
     GtQmlAction(QString text, QUrl icon, QObject* parent = nullptr);
@@ -104,6 +114,17 @@ public:
     void setVisible(bool visible);
 
     /**
+     * @brief If enabled, the state of the button can be toggled
+     *
+     * A signal `::toggled` will be emitted, when it checked-state changes
+     */
+    void setCheckable(bool);
+    bool checkable() const;
+
+    bool isChecked() const;
+    void setChecked(bool checked);
+
+    /**
      * @brief Returns true if this action acts only as a separator
      */
     Q_INVOKABLE bool isSeparator() const;
@@ -115,12 +136,20 @@ signals:
      */
     void triggered();
 
+    /**
+     * @brief This signal is emitted, when a checkable action
+     *        changes it's checked state
+     * @param checked
+     */
+    void toggled(bool checked);
 
     void iconUrlChanged();
     void textChanged();
     void enabledChanged();
     void visibleChanged();
     void toolTipChanged();
+    void checkableChanged();
+    void checkedChanged();
 
 private:
     struct Impl;

--- a/src/gui/tools/gt_qmltoolbargroup.h
+++ b/src/gui/tools/gt_qmltoolbargroup.h
@@ -74,6 +74,11 @@ public:
     bool append(GtQmlAction* action);
 
     /**
+     * @brief Adds a separator into the group at the current position
+     */
+    bool addSeparator();
+
+    /**
      * @brief Overloaded function to set all actions at once
      * @param data List of actions
      */
@@ -84,6 +89,19 @@ signals:
     void visibleChanged();
 
 private:
+    /**
+     * @brief Updates the visibility of the toolbar and its separators
+     * depending on the actions visibility
+     *
+     * - If no action is visible, the whole group gets invisible
+     *   since there is nothing to show
+     *
+     * - If no action is in front of any separator, the separator gets invisible
+     * - If no action is visible after a separator, it gets invisible as well
+     */
+    void updateVisibility();
+
+
     using Base = GtListModel<GtQmlAction*>;
 
     QString m_groupName;

--- a/src/resources/qml/AnimatedButton.qml
+++ b/src/resources/qml/AnimatedButton.qml
@@ -29,6 +29,7 @@ Button {
 
     text: "My Button"
     hoverEnabled: true
+    checkable: false
     flat: true
 
     signal clicked
@@ -61,7 +62,9 @@ Button {
         opacity: enabled ? 1 : 0.3
 
         radius: 15
-        //border.color: hovered ? "#047eff" : "transparent"
+
+        border.color: checked ? (darkMode ? Qt.lighter(custom_backgroundColor)
+                                          : Qt.darker(custom_backgroundColor, 1.1)) : "transparent"
 
         //border.color: "#047eff"
         ColorAnimation on color {
@@ -203,7 +206,13 @@ Button {
 
     MouseArea {
         anchors.fill: parent
-        onClicked: control.clicked()
+        onClicked: {
+            control.clicked()
+            if (control.checkable) {
+                control.checked = !control.checked
+            }
+        }
+
         onPressed: control.pressed()
         onReleased: control.released()
 
@@ -223,7 +232,6 @@ Button {
             }
         }
     }
-
 }
 
 /*##^##

--- a/src/resources/qml/Toolbar.qml
+++ b/src/resources/qml/Toolbar.qml
@@ -16,6 +16,23 @@ Rectangle {
 
     property int spacing: 5
 
+    Rectangle {
+        id: leftOverlay
+        width: spacing + spacer.radius
+        height: toolBar.height - spacing * 2
+        color: spacer.color
+        y: spacing
+    }
+
+    Rectangle {
+        id: rightOverlay
+        width: spacing + spacer.radius
+        height: toolBar.height - spacing * 2
+        color: spacer.color
+        anchors.right: toolBar.right
+        y: spacing
+    }
+
     // the list of groups
     Row {
         id: row

--- a/src/resources/qml/ToolbarButton.qml
+++ b/src/resources/qml/ToolbarButton.qml
@@ -32,7 +32,7 @@ Item {
             onClicked: tbButton.action.triggered()
 
             onCheckedChanged: {
-                if (tbButton.action) {
+                if (tbButton.action && tbButton.action.checked !== checked) {
                     tbButton.action.checked = b.checked
                     tbButton.action.toggled(b.checked)
                 }
@@ -53,6 +53,25 @@ Item {
             hasTooltip: tooltipText != ""
             custom_Enabled: tbButton.enabled
             checkable: tbButton.action ? tbButton.action.checkable : false
+
+            function syncButtonCheckedState() {
+                if (b.checked !== tbButton.action.checked) {
+                    b.checked = tbButton.action.checked
+                }
+            }
+
+            // make the button change, if the action changes
+            Connections {
+                target: tbButton.action
+
+                function onCheckedChanged() {
+                    syncButtonCheckedState()
+                }
+            }
+
+            Component.onCompleted: {
+                syncButtonCheckedState()
+            }
         }
     }
 

--- a/src/resources/qml/ToolbarButton.qml
+++ b/src/resources/qml/ToolbarButton.qml
@@ -1,8 +1,6 @@
 // GTlab - Gas Turbine laboratory
-//
 // SPDX-License-Identifier: MPL-2.0+
 // SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
-
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
@@ -14,19 +12,35 @@ Item {
     property ToolbarAction action: None
     property bool darkMode: false
 
-    width: _button.width
-    height: _button.height
+    width: l.width
+    height: l.height
     visible: action ? action.visible : false
     enabled: action ? action.enabled : false
 
-    AnimatedButton {
-        id: _button
-        text: tbButton.action ? tbButton.action.text : ""
-        onClicked: tbButton.action.triggered()
-        icon.source: tbButton.action ? tbButton.action.iconUrl : ""
-        darkMode: tbButton.darkMode
-        tooltipText: tbButton.action ? tbButton.action.toolTip : ""
-        hasTooltip: _button.tooltipText != ""
-        custom_Enabled: tbButton.enabled
+    Loader {
+        id: l
+        sourceComponent: action ? (action.isSeparator() ? sep : btn) : null
+    }
+
+    Component {
+        id: btn
+
+        AnimatedButton {
+            text: tbButton.action ? tbButton.action.text : ""
+            onClicked: tbButton.action.triggered()
+            icon.source: tbButton.action ? tbButton.action.iconUrl : ""
+            darkMode: tbButton.darkMode
+            tooltipText: tbButton.action ? tbButton.action.toolTip : ""
+            hasTooltip: tooltipText != ""
+            custom_Enabled: tbButton.enabled
+        }
+    }
+
+    Component {
+        id: sep
+
+        ToolbarSeparator {
+            darkMode: tbButton.darkMode
+        }
     }
 }

--- a/src/resources/qml/ToolbarButton.qml
+++ b/src/resources/qml/ToolbarButton.qml
@@ -26,13 +26,33 @@ Item {
         id: btn
 
         AnimatedButton {
+            id: b
+
             text: tbButton.action ? tbButton.action.text : ""
             onClicked: tbButton.action.triggered()
+
+            onCheckedChanged: {
+                if (tbButton.action) {
+                    tbButton.action.checked = b.checked
+                    tbButton.action.toggled(b.checked)
+                }
+            }
+
+            function bgColor() {
+                if (!checked)
+                    return "transparent"
+                else
+                    return darkMode ? "#1e2a3a" : "#efefef"
+            }
+
+            custom_backgroundColor: bgColor()
+
             icon.source: tbButton.action ? tbButton.action.iconUrl : ""
             darkMode: tbButton.darkMode
             tooltipText: tbButton.action ? tbButton.action.toolTip : ""
             hasTooltip: tooltipText != ""
             custom_Enabled: tbButton.enabled
+            checkable: tbButton.action ? tbButton.action.checkable : false
         }
     }
 

--- a/src/resources/qml/ToolbarSeparator.qml
+++ b/src/resources/qml/ToolbarSeparator.qml
@@ -1,0 +1,21 @@
+// GTlab - Gas Turbine laboratory
+// SPDX-License-Identifier: MPL-2.0+
+// SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
+import QtQuick 2.15
+
+Item {
+    property bool darkMode: false
+    property int margin: 4
+
+    width: sep.width + 2 * margin
+    height: 30
+
+    Rectangle {
+        id: sep
+
+        width: 2
+        height: parent.height - 6
+        color: darkMode ? "#202c3c" : "#f0f0f0"
+        anchors.centerIn: parent
+    }
+}

--- a/src/resources/qml/qml.qrc
+++ b/src/resources/qml/qml.qrc
@@ -9,5 +9,6 @@
         <file>DockBarButton.qml</file>
         <file>ToolbarButton.qml</file>
         <file>ToolbarGroup.qml</file>
+        <file>ToolbarSeparator.qml</file>
     </qresource>
 </RCC>

--- a/tests/modules/mdi_interface_ext/mdi/test_mdi_ext_viewer.cpp
+++ b/tests/modules/mdi_interface_ext/mdi/test_mdi_ext_viewer.cpp
@@ -21,23 +21,26 @@ TestMdiExtViewer::TestMdiExtViewer()
 
     cutAction = addToolbarAction("Cut", icon::url(icon::cut));
     copyAction  = addToolbarAction("Copy", icon::url(icon::copy));
+
+    addToolbarSeparator();
+
     pasteAction = addToolbarAction("Paste", icon::url(icon::paste));
 
-    pasteAction->setEnabled(false);
+    pasteAction->setVisible(false);
 
     connect(cutAction, &GtQmlAction::triggered, this, [this](){
         gtInfo() << "Cut";
-        pasteAction->setEnabled(true);
+        pasteAction->setEnabled(!pasteAction->enabled());
     });
 
     connect(copyAction, &GtQmlAction::triggered, this, [this](){
         gtInfo() << "Copy";
-        pasteAction->setEnabled(true);
+        pasteAction->setVisible(true);
     });
 
     connect(pasteAction, &GtQmlAction::triggered, this, [this](){
         gtInfo() << "Paste";
-        pasteAction->setEnabled(false);
+        pasteAction->setVisible(false);
     });
 
     setObjectName("Test Mdi Ext Viewer");

--- a/tests/modules/mdi_interface_ext/mdi/test_mdi_ext_viewer.cpp
+++ b/tests/modules/mdi_interface_ext/mdi/test_mdi_ext_viewer.cpp
@@ -19,6 +19,18 @@ TestMdiExtViewer::TestMdiExtViewer()
 {
     using namespace gt::gui;
 
+    auto toggleAction = addToolbarAction("View", icon::url(icon::eyeOff));
+    toggleAction->setCheckable(true);
+
+    connect(toggleAction, &GtQmlAction::toggled, this, [toggleAction](bool checked){
+        if (checked) {
+            toggleAction->setIconUrl(icon::url(icon::eye));
+        }
+        else {
+            toggleAction->setIconUrl(icon::url(icon::eyeOff));
+        }
+    });
+
     cutAction = addToolbarAction("Cut", icon::url(icon::cut));
     copyAction  = addToolbarAction("Copy", icon::url(icon::copy));
 

--- a/tests/unittests/gui/test_toolbargroup.cpp
+++ b/tests/unittests/gui/test_toolbargroup.cpp
@@ -1,0 +1,72 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
+ */
+
+#include <gtest/gtest.h>
+#include <gt_qmltoolbargroup.h>
+
+struct TestToolbarGroup : public testing::Test
+{
+    TestToolbarGroup()
+    {
+        // a1 | a2 | a3
+        actions.push_back(new GtQmlAction("a1", QUrl(""), &group));
+        actions.push_back(GtQmlAction::makeSeparator(&group));
+        actions.push_back(new GtQmlAction("a2", QUrl(""), &group));
+        actions.push_back(GtQmlAction::makeSeparator(&group));
+        actions.push_back(new GtQmlAction("a3", QUrl(""), &group));
+
+        for (auto& a : actions) group.append(a);
+    }
+
+    GtQmlToolbarGroup group;
+    std::vector<GtQmlAction*> actions;
+};
+
+TEST_F(TestToolbarGroup, toolbarvisible)
+{
+    EXPECT_EQ(true, group.isVisible());
+}
+
+TEST_F(TestToolbarGroup, toolbarInvisible)
+{
+    // all invisible, hence no toolbar
+
+    actions[0]->setVisible(false);
+    actions[2]->setVisible(false);
+    actions[4]->setVisible(false);
+
+    EXPECT_EQ(true, !group.isVisible());
+}
+
+TEST_F(TestToolbarGroup, firstSeparatorInv)
+{
+    // a2 | a3
+    actions[0]->setVisible(false);
+
+    EXPECT_EQ(false, actions[1]->isVisible());
+    EXPECT_EQ(true, actions[3]->isVisible());
+    EXPECT_EQ(true, group.isVisible());
+}
+
+TEST_F(TestToolbarGroup, lastSeparatorInv)
+{
+    // a1 | a2
+    actions[4]->setVisible(false);
+
+    EXPECT_EQ(true, actions[1]->isVisible());
+    EXPECT_EQ(false, actions[3]->isVisible());
+    EXPECT_EQ(true, group.isVisible());
+}
+
+TEST_F(TestToolbarGroup, aggregateSeparators)
+{
+    // a1 | a3
+    actions[2]->setVisible(false);
+
+    EXPECT_EQ(true, actions[1]->isVisible());
+    EXPECT_EQ(false, actions[3]->isVisible());
+    EXPECT_EQ(true, group.isVisible());
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I implemented more toolbar features, namely
 - Toolbar separators
 - Actions, that can be toggled

Separators are not show, if not necessary, e.g. if all actions left or right from the separator are invisible.

## How Has This Been Tested?

 - Both features have been implemented in the mdi test module
 - I added unit tests for separator visibiliry

# Screenshots

Dark-mode:
![image](https://github.com/user-attachments/assets/450b2537-5be2-4f46-859b-4693afd5488c)

Bright-mode:
![image](https://github.com/user-attachments/assets/c366c1db-8e6c-4b8b-a917-a77c5165bc80)

Closes #1310 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
