### PR TITLE
Replace QValidator by RegExpPattern-String

### DIFF
--- a/src/dataprocessor/CMakeLists.txt
+++ b/src/dataprocessor/CMakeLists.txt
@@ -174,7 +174,6 @@ target_include_directories(GTlabDataProcessor
 target_link_libraries(GTlabDataProcessor
     PUBLIC
       Qt5::Core
-      Qt5::Gui # for QValidator
       Qt5::Xml
       GTlab::Logging
     PRIVATE

--- a/src/dataprocessor/gt_regexp.cpp
+++ b/src/dataprocessor/gt_regexp.cpp
@@ -82,31 +82,31 @@ gt::re::onlyLettersAndNumbersAndSpaceHint()
 QRegExp
 gt::re::forUnits()
 {
-    return QRegExp(("[A-Za-z0-9\\_\\-\\+\\^\\°\\%\\/]*"));
+    return QRegExp("[A-Za-z0-9\\_\\-\\+\\^\\°\\%\\/]*");
 }
 
 QRegExp
 gt::re::forExpressions()
 {
-    return QRegExp(("[A-Za-z0-9\\_\\-\\+\\^\\°\\/\\*\\.\\,\\(\\)\\[\\]]*"));
+    return QRegExp("[A-Za-z0-9\\_\\-\\+\\^\\°\\/\\*\\.\\,\\(\\)\\[\\]]*");
 }
 
 QRegExp
 gt::re::forStations()
 {
-    return QRegExp(("S[0-9]{1,3}"));
+    return QRegExp("S[0-9]{1,3}");
 }
 
 QRegExp
 gt::re::forDoubles()
 {
-    return QRegExp(("-?[0-9]+.*[E,e]?-?[0-9]*"));
+    return QRegExp("-?[0-9]+.*[E,e]?-?[0-9]*");
 }
 
 QRegExp
 gt::re::forDoublesLists()
 {
-    return QRegExp(("[eE0-9\\-\\.\\;]+"));
+    return QRegExp("[eE0-9\\-\\.\\;]+");
 }
 
 QRegExp

--- a/src/dataprocessor/property/gt_stringproperty.cpp
+++ b/src/dataprocessor/property/gt_stringproperty.cpp
@@ -21,14 +21,14 @@ GtStringProperty::GtStringProperty(const QString& ident, const QString& name)
     m_unitCategory = GtUnit::Category::None;
     m_value = QString();
     m_initValue = QString();
-    m_validatorPattern = gt::re::forExpressions().pattern();
+    m_validatorPattern = QRegularExpression(gt::re::forExpressions().pattern());
 }
 
 GtStringProperty::GtStringProperty(const QString& ident,
                                    const QString& name,
                                    const QString& brief,
                                    const QString& value,
-                                   const QString& validationPattern)
+                                   const QRegularExpression& validationPattern)
 {
     setObjectName(name);
 
@@ -66,7 +66,7 @@ GtStringProperty::setValueFromVariant(const QVariant& val,
 }
 
 
-QString
+QRegularExpression const&
 GtStringProperty::validator()
 {
     return m_validatorPattern;

--- a/src/dataprocessor/property/gt_stringproperty.cpp
+++ b/src/dataprocessor/property/gt_stringproperty.cpp
@@ -21,7 +21,7 @@ GtStringProperty::GtStringProperty(const QString& ident, const QString& name)
     m_unitCategory = GtUnit::Category::None;
     m_value = QString();
     m_initValue = QString();
-    m_validatorPattern = "[A-Za-z0-9\\_\\-\\+\\^\\°\\/\\*\\.\\,\\(\\)\\[\\]]*";
+    m_validatorPattern = gt::re::forExpressions().pattern();
 }
 
 GtStringProperty::GtStringProperty(const QString& ident,

--- a/src/dataprocessor/property/gt_stringproperty.cpp
+++ b/src/dataprocessor/property/gt_stringproperty.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "gt_stringproperty.h"
-#include <QValidator>
 #include "gt_regexp.h"
 
 GtStringProperty::GtStringProperty(const QString& ident, const QString& name)

--- a/src/dataprocessor/property/gt_stringproperty.cpp
+++ b/src/dataprocessor/property/gt_stringproperty.cpp
@@ -13,8 +13,7 @@
 #include <QValidator>
 #include "gt_regexp.h"
 
-GtStringProperty::GtStringProperty(const QString& ident, const QString& name) :
-    m_validator(std::make_unique<QRegExpValidator>(gt::re::forExpressions()))
+GtStringProperty::GtStringProperty(const QString& ident, const QString& name)
 {
     setObjectName(name);
 
@@ -23,13 +22,14 @@ GtStringProperty::GtStringProperty(const QString& ident, const QString& name) :
     m_unitCategory = GtUnit::Category::None;
     m_value = QString();
     m_initValue = QString();
+    m_validatorPattern = "[A-Za-z0-9\\_\\-\\+\\^\\°\\/\\*\\.\\,\\(\\)\\[\\]]*";
 }
 
 GtStringProperty::GtStringProperty(const QString& ident,
                                    const QString& name,
                                    const QString& brief,
                                    const QString& value,
-                                   QValidator* validator)
+                                   const QString& validationPattern)
 {
     setObjectName(name);
 
@@ -39,15 +39,7 @@ GtStringProperty::GtStringProperty(const QString& ident,
     m_value = value;
     m_initValue = value;
 
-    if (validator)
-    {
-        m_validator.reset(validator);
-    }
-    else
-    {
-        m_validator = std::make_unique<QRegExpValidator>(
-                    gt::re::forExpressions());
-    }
+    m_validatorPattern = validationPattern;
 }
 
 void
@@ -75,10 +67,10 @@ GtStringProperty::setValueFromVariant(const QVariant& val,
 }
 
 
-QValidator*
+QString
 GtStringProperty::validator()
 {
-    return m_validator.get();
+    return m_validatorPattern;
 }
 
 GtStringProperty::~GtStringProperty() = default;

--- a/src/dataprocessor/property/gt_stringproperty.h
+++ b/src/dataprocessor/property/gt_stringproperty.h
@@ -15,6 +15,7 @@
 #include "gt_datamodel_exports.h"
 
 #include "gt_property.h"
+#include "gt_regexp.h"
 
 class GT_DATAMODEL_EXPORT GtStringProperty : public GtProperty<QString>
 {
@@ -39,13 +40,18 @@ public:
      * @param name
      * @param brief
      * @param value
+     * @param validationPattern - this pattern can be set for validation of
+     * vale manipulation. The default value is the GTRegExp "forExpressions"
+     * which means allowed are letter, numbers and a list of special
+     * characters which are related to usage
+     * in mathematical descriptions: _ - + ^ ° / * . , ( ) [ ]
      */
     GtStringProperty(const QString& ident,
                      const QString& name,
                      const QString& brief,
                      const QString& value = QString(),
                      const QString& validationPattern =
-            "[A-Za-z0-9\\_\\-\\+\\^\\°\\/\\*\\.\\,\\(\\)\\[\\]]*");
+                        gt::re::forExpressions().pattern());
 
     // operator overloads
     void operator+=(const QString& b);

--- a/src/dataprocessor/property/gt_stringproperty.h
+++ b/src/dataprocessor/property/gt_stringproperty.h
@@ -16,6 +16,7 @@
 
 #include "gt_property.h"
 #include "gt_regexp.h"
+#include <QRegularExpression>
 
 class GT_DATAMODEL_EXPORT GtStringProperty : public GtProperty<QString>
 {
@@ -50,8 +51,8 @@ public:
                      const QString& name,
                      const QString& brief,
                      const QString& value = QString(),
-                     const QString& validationPattern =
-                        gt::re::forExpressions().pattern());
+                     const QRegularExpression& validationPattern =
+                        QRegularExpression(gt::re::forExpressions().pattern()));
 
     // operator overloads
     void operator+=(const QString& b);
@@ -75,12 +76,12 @@ public:
      * @brief validator
      * @return the validator to use
      */
-    QString validator();
+    const QRegularExpression& validator();
 
     ~GtStringProperty() override;
 
 protected:
-    QString m_validatorPattern;
+    QRegularExpression m_validatorPattern;
 };
 
 namespace gt

--- a/src/dataprocessor/property/gt_stringproperty.h
+++ b/src/dataprocessor/property/gt_stringproperty.h
@@ -16,10 +16,6 @@
 
 #include "gt_property.h"
 
-#include <memory>
-
-class QValidator;
-
 class GT_DATAMODEL_EXPORT GtStringProperty : public GtProperty<QString>
 {
     Q_OBJECT
@@ -48,7 +44,8 @@ public:
                      const QString& name,
                      const QString& brief,
                      const QString& value = QString(),
-                     QValidator* validator = nullptr);
+                     const QString& validationPattern =
+            "[A-Za-z0-9\\_\\-\\+\\^\\°\\/\\*\\.\\,\\(\\)\\[\\]]*");
 
     // operator overloads
     void operator+=(const QString& b);
@@ -72,12 +69,12 @@ public:
      * @brief validator
      * @return the validator to use
      */
-    QValidator* validator();
+    QString validator();
 
     ~GtStringProperty() override;
 
 protected:
-    std::unique_ptr<QValidator> m_validator;
+    QString m_validatorPattern;
 };
 
 namespace gt

--- a/src/dataprocessor/property/gt_stringproperty.h
+++ b/src/dataprocessor/property/gt_stringproperty.h
@@ -41,8 +41,8 @@ public:
      * @param name
      * @param brief
      * @param value
-     * @param validationPattern - this pattern can be set for validation of
-     * vale manipulation. The default value is the GTRegExp "forExpressions"
+     * @param validationPattern - this regular expression can be set to validate the
+     * manipulation of the value. The default value is the GTRegExp "forExpressions"
      * which means allowed are letter, numbers and a list of special
      * characters which are related to usage
      * in mathematical descriptions: _ - + ^ ° / * . , ( ) [ ]

--- a/src/gui/dock_widgets/properties/items/gt_propertyitem.cpp
+++ b/src/gui/dock_widgets/properties/items/gt_propertyitem.cpp
@@ -285,7 +285,8 @@ GtPropertyItem::editorWidget(QWidget* parent,
 
             if (s)
             {
-                validator = s->validator();
+                validator = new QRegExpValidator(QRegExp(s->validator()),
+                                                 lineEdit);
             }
             else if (p)
             {

--- a/src/gui/dock_widgets/properties/items/gt_propertyitem.cpp
+++ b/src/gui/dock_widgets/properties/items/gt_propertyitem.cpp
@@ -285,8 +285,9 @@ GtPropertyItem::editorWidget(QWidget* parent,
 
             if (s)
             {
-                if (!s->validator().isEmpty()) 
-                    validator = new QRegExpValidator(QRegExp(s->validator()), lineEdit);
+                if (!s->validator().pattern().isEmpty())
+                    validator = new QRegularExpressionValidator(s->validator(),
+                                                                lineEdit);
             }
             else if (p)
             {

--- a/tests/unittests/datamodel/test_gt_object.h
+++ b/tests/unittests/datamodel/test_gt_object.h
@@ -66,7 +66,7 @@ public:
         m_modeTypeProp("Test Type", QString()),
         m_linkProp("linkProp", "Test Link", QString(), QString(), this, {}),
         m_strProp("strProp", "Test String",  QString(), "Test",
-                   new QRegExpValidator(gt::re::onlyLettersAndNumbers(), this)),
+                  gt::re::onlyLettersAndNumbers().pattern()),
         m_varProp("variantProp", "Test Variant", QString()),
         m_doubleListProp("dblList", "Double List Property"),
         m_exDirProp("exDir", "Existing Directory", "Existing Directory Property"),

--- a/tests/unittests/datamodel/test_gt_object.h
+++ b/tests/unittests/datamodel/test_gt_object.h
@@ -13,7 +13,6 @@
 #define TEST_GT_OBJECT_H
 
 #include <QPointF>
-#include <QRegExpValidator>
 
 #include "gt_objectgroup.h"
 
@@ -31,7 +30,6 @@
 #include "gt_doublelistproperty.h"
 #include "gt_existingdirectoryproperty.h"
 #include "gt_openfilenameproperty.h"
-#include "gt_regexp.h"
 #include "test_propertycontainerobject.h"
 
 class TestSpecialGtObject : public GtObjectGroup
@@ -66,7 +64,7 @@ public:
         m_modeTypeProp("Test Type", QString()),
         m_linkProp("linkProp", "Test Link", QString(), QString(), this, {}),
         m_strProp("strProp", "Test String",  QString(), "Test",
-                  gt::re::onlyLettersAndNumbers().pattern()),
+                  QRegularExpression(gt::re::onlyLettersAndNumbers().pattern())),
         m_varProp("variantProp", "Test Variant", QString()),
         m_doubleListProp("dblList", "Double List Property"),
         m_exDirProp("exDir", "Existing Directory", "Existing Directory Property"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Usage of QValidator is the last reason for the core libraries (DataProcessor and Core) to have a dependency to QtGUI.

## Description
The QValidator is replaced by a string to hold the validator pattern.
As it is part of the GtStringProperty the needed changes leads to ABI and API breaks.

## How Has This Been Tested?
Manual in the GTlab GUI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
