### PR TITLE
Fixed toolbar resizing on app start

### DIFF
--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -247,6 +247,10 @@ GtMainWin::GtMainWin(QWidget* parent) : QMainWindow(parent),
 
     ui->qmlToolBar->setStyleSheet("QToolBar { margin: 0px; padding: 0px; border: none;}");
     ui->qmlToolBar->addWidget(m_mainWindowToolbar);
+
+    loadPerspectiveSettings();
+    emit gtApp->themeChanged(gtApp->inDarkMode());
+
 }
 
 GtMainWin::~GtMainWin()
@@ -1146,8 +1150,6 @@ GtMainWin::initAfterStartup()
 
         e->initAfterStartup();
     });
-
-    loadPerspectiveSettings();
 
     m_firstTimeShowEvent = false;
 }

--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -971,8 +971,5 @@ void
 GtApplication::onGuiInitializationFinished()
 {
     initModules();
-
-    // update theme
-    emit themeChanged(m_darkMode);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the toolbar resize problem on app start.

Source of the issue was, that app perspective restore was happening simultaneously as the `themeChanged` event was thrown, leading to a theme update. Somehow, this resulted in a bad timing leading to a wrong resize.

I now moved the themeChanged event to the mainwindow code just before restoring the perspective, which seem to fix it for me.

Closes #1318

## How Has This Been Tested?

Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
