### PR TITLE
Offer basic regular expression to restrict siblings names usage

### DIFF
--- a/src/dataprocessor/gt_regexp.h
+++ b/src/dataprocessor/gt_regexp.h
@@ -15,6 +15,8 @@
 
 #include "gt_datamodel_exports.h"
 
+#include "gt_object.h"
+
 /**
  * namespace for RegualrExpressions, used in GTlab
  */
@@ -119,6 +121,41 @@ QRegExp GT_DATAMODEL_EXPORT forSemVers();
  * "Textfiles (*.txt)"
  */
 GT_DATAMODEL_EXPORT const QRegExp& forFileDialogFilters();
+
+template <typename T>
+inline void restrictRegExpWithSiblingsNames(GtObject& obj,
+                                            QRegExp& defaultRegExp)
+{
+    GtObject* parent = obj.parentObject();
+
+    if (!parent) return;
+
+    QList<T*> siblings = parent->findDirectChildren<T*>();
+
+    if (siblings.isEmpty()) return;
+
+    QStringList names;
+
+    for (auto* s : qAsConst(siblings))
+    {
+        names.append(s->objectName());
+    }
+
+    names.removeAll(obj.objectName());
+
+    QString allNames = names.join("|");
+
+    QString pattern = "^";
+
+    for (QString name : names)
+    {
+        pattern += "(?!" + name + "$)";
+    }
+
+    pattern += defaultRegExp.pattern();
+
+    defaultRegExp = QRegExp(pattern);
+}
 
 } // namespace re
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A function is added to add siblings names to a regular expression.
A function like this is needed for different use cases in GTlab when it should be prohibited to name objects like its siblings.
As I implemented this now in two modules I think it should be offered in core to help developers.

## How Has This Been Tested?
The identical code has been used in the intelligraph module and leads to good results there


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
