### PR TITLE
Enable request if low and high bounds are active or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Extended the batch mode for a command to upgrade a GTlab project - #1184
  - Basic contxt menu to copy values of properties - #1267	
  - Process Dock retains the expanded/collapsed states of tasks when switching between projects or task groups - #1294
+ - Added methods `highSideBoundaryActive` and `lowSideBoundaryActive` for `GtDoubleProperty` and `GtIntProperty` to check, whether property boundaries are set - #1327
 
 ## [2.0.10] - 2024-08-29
 ### Fixed

--- a/src/dataprocessor/property/gt_doubleproperty.cpp
+++ b/src/dataprocessor/property/gt_doubleproperty.cpp
@@ -224,6 +224,18 @@ GtDoubleProperty::initialValue() const
     return m_initValue;
 }
 
+bool
+GtDoubleProperty::lowSideBoundaryActive() const
+{
+    return m_boundsCheckFlagLow;
+}
+
+bool
+GtDoubleProperty::highSideBoundaryActive() const
+{
+    return m_boundsCheckFlagHi;
+}
+
 gt::PropertyFactoryFunction
 gt::makeDoubleProperty(double value)
 {

--- a/src/dataprocessor/property/gt_doubleproperty.h
+++ b/src/dataprocessor/property/gt_doubleproperty.h
@@ -135,6 +135,18 @@ public:
      */
     double initialValue() const;
 
+    /**
+     * @brief lowBoundActive
+     * @return true if low bound value for the property is active
+     */
+    bool lowSideBoundaryActive() const;
+
+    /**
+     * @brief highBoundActive
+     * @return true if high bound value for the property is active
+     */
+    bool highSideBoundaryActive() const;
+
 protected:
     /// Perform low boundary check flag (true=perform check)
     bool m_boundsCheckFlagLow;

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -171,6 +171,18 @@ GtIntProperty::validateValue(const int& value)
     return true;
 }
 
+bool
+GtIntProperty::lowSideBoundaryActive() const
+{
+    return m_boundsCheckFlagLow;
+}
+
+bool
+GtIntProperty::highSideBoundaryActive() const
+{
+    return m_boundsCheckFlagHi;
+}
+
 gt::PropertyFactoryFunction
 gt::makeIntProperty(int value)
 {

--- a/src/dataprocessor/property/gt_intproperty.h
+++ b/src/dataprocessor/property/gt_intproperty.h
@@ -154,6 +154,18 @@ public:
      */
     int highSideBoundary() const;
 
+    /**
+     * @brief lowBoundActive
+     * @return true if low bound value for the property is active
+     */
+    bool lowSideBoundaryActive() const;
+
+    /**
+     * @brief highBoundActive
+     * @return true if high bound value for the property is active
+     */
+    bool highSideBoundaryActive() const;
+
 protected:
     /// Perform low boundary check flag (true=perform check)
     bool m_boundsCheckFlagLow;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Double and Int-Property already had flags as private member if the bounds are active or not.
Now there are getter to request these states

## Description
Simple getter functions had been added.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

Closes #1327