### PR TITLE
Implemented map-style properties containers

### DIFF
--- a/src/dataprocessor/property/gt_propertystructcontainer.cpp
+++ b/src/dataprocessor/property/gt_propertystructcontainer.cpp
@@ -21,9 +21,10 @@
 
 struct GtPropertyStructContainer::Impl
 {
-    Impl(const QString& ident, const QString& name) :
+    Impl(const QString& ident, const QString& name, GtPropertyStructContainer::ContainerType type) :
         id(ident),
-        name(name)
+        name(name),
+        type(type)
     {
     }
 
@@ -33,16 +34,27 @@ struct GtPropertyStructContainer::Impl
     std::map<TypeIdStr, GtPropertyStructDefinition> allowedTypes;
     gt::PolyVector<GtPropertyStructInstance> entries;
     int flags = {0};
+    GtPropertyStructContainer::ContainerType type;
 };
 
 GtPropertyStructContainer::GtPropertyStructContainer(const QString& ident,
-                                                     const QString& name) :
-    pimpl(std::make_unique<GtPropertyStructContainer::Impl>(ident, name))
+                                                     const QString& name)
+    : GtPropertyStructContainer(ident, name, Sequential)
+{}
+
+GtPropertyStructContainer::GtPropertyStructContainer(const QString& ident,
+                                                     const QString& name,
+                                                    GtPropertyStructContainer::ContainerType type) :
+    pimpl(std::make_unique<GtPropertyStructContainer::Impl>(ident, name, type))
 {
 }
 
-GtPropertyStructContainer::GtPropertyStructContainer(const QString& ident) :
-    GtPropertyStructContainer(ident, ident)
+GtPropertyStructContainer::GtPropertyStructContainer(const QString& ident)
+    : GtPropertyStructContainer(ident, Sequential)
+{}
+
+GtPropertyStructContainer::GtPropertyStructContainer(const QString& ident, ContainerType type) :
+    GtPropertyStructContainer(ident, ident, type)
 {
 }
 
@@ -56,6 +68,12 @@ void
 GtPropertyStructContainer::setFlags(int flags)
 {
     pimpl->flags = flags;
+
+}
+
+GtPropertyStructContainer::ContainerType GtPropertyStructContainer::type() const
+{
+    return pimpl->type;
 }
 
 GtPropertyStructContainer::~GtPropertyStructContainer() = default;

--- a/src/dataprocessor/property/gt_propertystructcontainer.h
+++ b/src/dataprocessor/property/gt_propertystructcontainer.h
@@ -32,17 +32,28 @@ class GT_DATAMODEL_EXPORT GtPropertyStructContainer : public QObject
 {
     Q_OBJECT
 public:
+
+    enum ContainerType
+    {
+        Sequential,   /* Like a vector, ids are uuids */
+        Associative  /* Like a map with string key, ids are named keys */
+    };
+
     using iterator =
         gt::PolyVector<GtPropertyStructInstance>::iterator;
     using const_iterator =
         gt::PolyVector<GtPropertyStructInstance>::const_iterator;
 
+    // Creates a sequential container
     GtPropertyStructContainer(const QString& ident, const QString& name);
-
-
     explicit GtPropertyStructContainer(const QString& ident);
 
+    GtPropertyStructContainer(const QString& ident, const QString& name, ContainerType);
+    explicit GtPropertyStructContainer(const QString& ident, ContainerType);
+
     ~GtPropertyStructContainer() override;
+
+    ContainerType type() const;
 
     enum Flags
     {

--- a/src/gui/dock_widgets/properties/gt_propertymodel.cpp
+++ b/src/gui/dock_widgets/properties/gt_propertymodel.cpp
@@ -85,8 +85,23 @@ GtPropertyModel::data(const QModelIndex& index, int role) const
     {
         if (role == Qt::DisplayRole)
         {
-            return item->data(index.column(), role).toString() +
-                    + " [" + QString::number(index.row()) + "]";
+            auto* container = m_obj->findPropertyContainer(m_containerId);
+
+            if (!container) return {};
+
+            if (container->type() == GtPropertyStructContainer::Sequential)
+            {
+                return item->data(index.column(), role).toString() +
+                       + " [" + QString::number(index.row()) + "]";
+            }
+            else if (container->type() == GtPropertyStructContainer::Associative)
+            {
+                if (index.row() >= static_cast<int>(container->size())) return {};
+                return container->at(index.row()).ident();
+            }
+
+            return {};
+
         }
 
         if (role == Qt::ToolTipRole)

--- a/tests/modules/datamodel_interface/data/test_dmi_data.cpp
+++ b/tests/modules/datamodel_interface/data/test_dmi_data.cpp
@@ -19,6 +19,7 @@ TestDmiData::TestDmiData() :
     m_container("notes", "notes"),
     m_containerRO("tasks", "tasks (ro)"),
     m_containerHidden("hiddenNotes", "Hidden Notes"),
+    m_containerMap("mapContainer", "Map Example", GtPropertyStructContainer::Associative),
     m_mode("modeProp", "ModeProp", "A mode-property"),
     m_propTypeA("Type A", "Type A brief"),
     m_propTypeB("Type B", "Type B brief"),
@@ -45,10 +46,16 @@ TestDmiData::TestDmiData() :
     m_containerHidden.setFlags(GtPropertyStructContainer::Hidden);
 
 
+    GtPropertyStructDefinition doubleMapEntry("DoubleStruct");
+    doubleMapEntry.defineMember("value", gt::makeDoubleProperty(0.));
+
+    m_containerMap.registerAllowedType(doubleMapEntry);
+
 
     registerPropertyStructContainer(m_container);
     registerPropertyStructContainer(m_containerRO);
     registerPropertyStructContainer(m_containerHidden);
+    registerPropertyStructContainer(m_containerMap);
 
     m_mode.registerSubProperty(m_propTypeA);
     m_mode.registerSubProperty(m_propTypeB);
@@ -69,6 +76,13 @@ TestDmiData::TestDmiData() :
     e2.setMemberVal("name", "Force");
     auto& e3 = m_containerRO.newEntry("StringStruct", "entry_3");
     e3.setMemberVal("name", "Power");
+
+    // add some entries to the map
+    auto& answer_entry = m_containerMap.newEntry("DoubleStruct", "answer");
+    answer_entry.setMemberVal("value", 42.0);
+
+    auto& weight_entry = m_containerMap.newEntry("DoubleStruct", "weight");
+    weight_entry.setMemberVal("value", 123.4);
 
     registerProperty(m_color);
 }

--- a/tests/modules/datamodel_interface/data/test_dmi_data.h
+++ b/tests/modules/datamodel_interface/data/test_dmi_data.h
@@ -42,7 +42,8 @@ public:
 
 private:
     GtDoubleProperty m_value;
-    GtPropertyStructContainer m_container, m_containerRO, m_containerHidden;
+    GtPropertyStructContainer m_container, m_containerRO,
+        m_containerHidden, m_containerMap;
     GtModeProperty m_mode;
     GtModeTypeProperty m_propTypeA, m_propTypeB;
     GtDoubleProperty m_optionalValue;    


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The only difference between map container and the normal  (sequential) is, that map-style container don't use uuid as keys but user-defined keys.

These user-defined keys are then displayed in the UI, see:

![image](https://github.com/user-attachments/assets/1401ea6e-a133-4d0d-8048-2910513afdbc)


## Why is this important? ##

These could be used, to e.g. define input / output variables for python nodes. No need to use name / value entries. Instead,  name = key. It is much nicer to display and use.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
