### PR TITLE
Improve task group creation logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
  - Removed a warning, when double clicking on the current project while a task is running - #1282
+ - Improved logging when creating a default task group - #1341
  
 ### Added
  - Extended the batch mode for a command to upgrade a GTlab project - #1184

--- a/src/core/process_management/gt_processdata.cpp
+++ b/src/core/process_management/gt_processdata.cpp
@@ -465,7 +465,8 @@ GtProcessData::Impl::initDefaultUserGroup(const QString& projectPath)
     _currentScope = GtTaskGroup::USER;
     _currentGroupId = sysUsername;
 
-    gtInfo() << QObject::tr("Default user group successfully initialized");
+    gtInfo() << QObject::tr("Default task user group '%1' "
+                            "successfully initialized").arg(sysUsername);
 
     return true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This improves task group creation logging, which now displays the name of the created task group.
This allows users to debug, what groups they are using currently, in particular in a docker environment.

Closes #1341

## How Has This Been Tested?

Manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
