### PR TITLE
Fixed memory leaks when registering settings

### DIFF
--- a/src/core/settings/gt_abstractsettings.cpp
+++ b/src/core/settings/gt_abstractsettings.cpp
@@ -57,6 +57,13 @@ GtSettingsItem*
 GtAbstractSettings::registerSetting(const QString& ident,
                                     const QVariant& initVal)
 {
+    auto oldSettingIter = m_settings.find(ident);
+    if (oldSettingIter != m_settings.end())
+    {
+        // we need to remove the old value, otherwise we get a memleak
+        delete oldSettingIter.value();
+    }
+
     GtSettingsItem* retval = new GtSettingsItem(ident, initVal);
     m_settings.insert(ident, retval);
     return retval;
@@ -66,6 +73,13 @@ GtSettingsItem*
 GtAbstractSettings::registerSettingRestart(const QString &ident,
                                            const QVariant &initVal)
 {
+    auto oldSettingIter = m_settings.find(ident);
+    if (oldSettingIter != m_settings.end())
+    {
+        // we need to remove the old value, otherwise we get a memleak
+        delete oldSettingIter.value();
+    }
+
     GtSettingsItem* retval = new GtSettingsItem(ident, initVal, true);
     m_settings.insert(ident, retval);
     return retval;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The previoius code created a memleak, if a
setting is registered multiple times.
In this case, the old pointer is discarded
and its memory is lost.

Now, we delete the old setting first.

## How Has This Been Tested?

Using AddressSanitizer (Clang) on Linux.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
