### PR TITLE
Fixed memleak in color property editor

### DIFF
--- a/src/gui/dock_widgets/properties/editors/gt_colorpropertyeditor.cpp
+++ b/src/gui/dock_widgets/properties/editors/gt_colorpropertyeditor.cpp
@@ -39,7 +39,7 @@ GtColorPropertyEditor::GtColorPropertyEditor(QWidget* parent) :
     lay->setSpacing(0);
     m_colorLineEdit->setFrame(false);
     m_colorLineEdit->setValidator(new QRegExpValidator(
-        gt::re::forHexColorCode()));
+        gt::re::forHexColorCode(), this));
 
     connect(m_selectButton, SIGNAL(clicked(bool)),
             SLOT(selectColor()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Fixed a small memory leak  in the editor of the color property. The line edit does not take ownership of the validator, 
hence we  give the ownership to the editor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
