### PR TITLE
Improved hex representation of colors

### DIFF
--- a/src/gui/dock_widgets/properties/editors/gt_colorpropertyeditor.cpp
+++ b/src/gui/dock_widgets/properties/editors/gt_colorpropertyeditor.cpp
@@ -70,7 +70,8 @@ GtColorPropertyEditor::update(bool lineEditTrigger)
 
     if (!lineEditTrigger)
     {
-        m_colorLineEdit->setText(c.name(QColor::HexArgb));
+        gt::rgb tmp(c.red(), c.green(), c.blue(), c.alpha());
+        m_colorLineEdit->setText(tmp.toHexString());
     }
     m_selectButton->setAutoFillBackground(true);
 
@@ -138,11 +139,9 @@ GtColorPropertyEditor::onLineEditChanged()
 
     if (m_colorLineEdit->text() != m_prop->getVal())
     {
-        disconnect(m_prop.data(), SIGNAL(changed()),
-                   this, SLOT(propertyValueChanged()));
+        // prevent signal loops
+        QSignalBlocker blockSignal(m_colorLineEdit);
         m_prop->setVal(m_colorLineEdit->text());
-        connect(m_prop.data(), SIGNAL(changed()),
-                this, SLOT(propertyValueChanged()));
         update(true);
     }
 }

--- a/src/gui/dock_widgets/properties/items/gt_colorpropertyitem.cpp
+++ b/src/gui/dock_widgets/properties/items/gt_colorpropertyitem.cpp
@@ -43,7 +43,8 @@ GtColorPropertyItem::data(int column, int role) const
                     return QStringLiteral("-");
                 }
 
-                return c.name(QColor::HexArgb);
+                gt::rgb col(c.red(), c.green(), c.blue(), c.alpha());
+                return col.toHexString();
             }
         }
     }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This improves the display of color properties in the property dock widget.

In particular, the alpha value is not shown, if alpha == 255.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
![image](https://github.com/user-attachments/assets/b97bea4f-526a-4688-bb60-1486380d2697)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
