### PR TITLE
Configurable property locations and expand states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Extended the batch mode for a command to upgrade a GTlab project - #1184
  - Basic contxt menu to copy values of properties - #1267	
+ - Property groups can now be reordered and collapsed by default - #1344
  - Process Dock retains the expanded/collapsed states of tasks when switching between projects or task groups - #1294
  - Added methods `highSideBoundaryActive` and `lowSideBoundaryActive` for `GtDoubleProperty` and `GtIntProperty` to check, whether property boundaries are set - #1327
 

--- a/src/dataprocessor/gt_object.cpp
+++ b/src/dataprocessor/gt_object.cpp
@@ -896,8 +896,8 @@ GtObject::registerProperty(GtAbstractProperty& property,
 }
 
 bool
-GtObject::registerProperty(GtAbstractProperty &property,
-                           const QString &cat, int catPriority,
+GtObject::registerProperty(GtAbstractProperty& property,
+                           const QString& cat, int catPriority,
                            bool collapsedByDefault)
 {
     QString catString = QString("%1||%2").arg(catPriority).arg(cat);

--- a/src/dataprocessor/gt_object.cpp
+++ b/src/dataprocessor/gt_object.cpp
@@ -896,6 +896,17 @@ GtObject::registerProperty(GtAbstractProperty& property,
 }
 
 bool
+GtObject::registerProperty(GtAbstractProperty &property,
+                           const QString &cat, int catPriority,
+                           bool collapsedByDefault)
+{
+    QString catString = QString("%1||%2").arg(catPriority).arg(cat);
+    if (collapsedByDefault) catString += '-';
+
+    return registerProperty(property, catString);
+}
+
+bool
 GtObject::registerSilentProperty(GtAbstractProperty& property)
 {
     if (pimpl->properties.contains(&property))

--- a/src/dataprocessor/gt_object.h
+++ b/src/dataprocessor/gt_object.h
@@ -664,6 +664,52 @@ protected:
      * @param cat
      */
     bool registerProperty(GtAbstractProperty& property, const QString& cat);
+
+    /**
+     * @brief Register a property to a category using a priority
+     *
+     * The Main category has priority 0, others have by default 1.
+     * Properties larger priority will be placed below properties with low priority
+     * (i.e. Main comes before others by default)
+     * @param property
+     * @param cat
+     * @param catPriority
+     * @param collapsedByDefault If true, the category will be collapsed by default
+     */
+    bool registerProperty(GtAbstractProperty& property, const QString& cat,
+                          int catPriority, bool collapsedByDefault);
+
+
+    /**
+     * @brief Register a property to a category using a priority
+     *
+     * The Main category has priority 0, others have by default 1.
+     * Properties larger priority will be placed below properties with low priority
+     * (i.e. Main comes before others by default)
+     * @param property
+     * @param cat
+     * @param catPriority
+     * @param collapsedByDefault If true, the category will be collapsed by default
+     */
+    bool registerProperty(GtAbstractProperty& property, const QString& cat,
+                          int catPriority)
+    {
+        return registerProperty(property, cat, catPriority, false);
+    }
+
+    /**
+     * @brief Register a property
+     *
+     * @param property
+     * @param cat
+     * @param collapsedByDefault If true, the category will be collapsed by default
+     */
+    bool registerProperty(GtAbstractProperty& property, const QString& cat,
+                          bool collapsedByDefault)
+    {
+        return registerProperty(property, cat, 1, collapsedByDefault);
+    }
+
     /**
      * @brief registerProperty
      * @param property

--- a/src/dataprocessor/property/gt_abstractproperty.cpp
+++ b/src/dataprocessor/property/gt_abstractproperty.cpp
@@ -339,6 +339,21 @@ GtAbstractProperty::isConnected() const
     return const_cast<GtAbstractProperty*>(this)->isConnected();
 }
 
+void
+GtAbstractProperty::setCollapsedByDefault(bool collapsed)
+{
+    setProperty("collapsed", collapsed);
+}
+
+bool
+GtAbstractProperty::collapsedByDefault() const
+{
+    auto collapsedState = property("collapsed");
+    if (!collapsedState.isValid()) return false;
+
+    return collapsedState.toBool();
+}
+
 GtAbstractProperty::GtAbstractProperty() = default;
 
 void

--- a/src/dataprocessor/property/gt_abstractproperty.h
+++ b/src/dataprocessor/property/gt_abstractproperty.h
@@ -259,6 +259,10 @@ public:
      */
     bool isConnected();
     bool isConnected() const;
+
+    void setCollapsedByDefault(bool collapsed);
+    bool collapsedByDefault() const;
+
 protected:
     /**
      * @brief GtAbstractProperty

--- a/src/gui/dock_widgets/properties/gt_propertymodel.h
+++ b/src/gui/dock_widgets/properties/gt_propertymodel.h
@@ -38,7 +38,8 @@ public:
         OptionalRole,
         ActiveRole,
         MonitoringRole,
-        ContainerRole
+        ContainerRole,
+        DefaultCollapseRole
     };
 
     /**

--- a/src/gui/dock_widgets/properties/gt_propertytreeview.cpp
+++ b/src/gui/dock_widgets/properties/gt_propertytreeview.cpp
@@ -41,7 +41,8 @@ namespace
         if (!model) return;
 
         int rowCount = model->rowCount(parent);
-        for (int row = 0; row < rowCount; ++row) {
+        for (int row = 0; row < rowCount; ++row)
+        {
             QModelIndex idx = model->index(row, 0, parent);
 
             // Retrieve the property from the model

--- a/src/gui/dock_widgets/properties/gt_propertytreeview.cpp
+++ b/src/gui/dock_widgets/properties/gt_propertytreeview.cpp
@@ -30,6 +30,35 @@
 #include "gt_icons.h"
 #include "gt_propertystructcontainer.h"
 
+
+namespace
+{
+    /// make expand state as requested by the data model
+    void
+    restoreDefaultExpandStates(QTreeView* view, const QModelIndex& parent = QModelIndex())
+    {
+        QAbstractItemModel* model = view->model();
+        if (!model) return;
+
+        int rowCount = model->rowCount(parent);
+        for (int row = 0; row < rowCount; ++row) {
+            QModelIndex idx = model->index(row, 0, parent);
+
+            // Retrieve the property from the model
+            bool collapsedByDefault = idx.data(GtPropertyModel::DefaultCollapseRole).toBool();
+
+            // Collapse or expand accordingly
+            if (collapsedByDefault)
+                view->collapse(idx);
+            else
+                view->expand(idx);
+
+            // Recursively handle children
+            restoreDefaultExpandStates(view, idx);
+        }
+    }
+}
+
 GtPropertyTreeView::GtPropertyTreeView(GtObject* scope,
                                        QWidget* parent) :
     GtTreeView(parent)
@@ -145,7 +174,7 @@ GtPropertyTreeView::setObject(GtObject* obj, bool processEvents)
             QCoreApplication::processEvents();
         }
         
-        expandAll();
+        restoreDefaultExpandStates(this);
         resizeColumns();
     }
 }

--- a/src/gui/dock_widgets/properties/items/gt_propertycategoryitem.cpp
+++ b/src/gui/dock_widgets/properties/items/gt_propertycategoryitem.cpp
@@ -19,6 +19,9 @@
 #include "gt_propertyitemfactory.h"
 #include "gt_icons.h"
 
+#include <gt_logging.h>
+
+
 GtPropertyCategoryItem::GtPropertyCategoryItem(GtObject* scope,
                                                const QString& id,
                                                GtPropertyModel* model,
@@ -29,6 +32,16 @@ GtPropertyCategoryItem::GtPropertyCategoryItem(GtObject* scope,
     setModel(model);
     setScope(scope);
     setParent(parent);
+}
+
+QString GtPropertyCategoryItem::displayName() const
+{
+    int startIndex = m_id.indexOf("||");
+    startIndex =  startIndex < 0 ? 0 : startIndex + 2;
+
+    int stopIndex = !m_id.endsWith('-') ? m_id.size() : m_id.size() - 1;
+
+    return m_id.mid(startIndex, stopIndex - startIndex);
 }
 
 void
@@ -52,6 +65,12 @@ GtPropertyCategoryItem::isContainer() const
     return m_isContainer;
 }
 
+bool
+GtPropertyCategoryItem::isCollapsed() const
+{
+    return m_id.endsWith('-');
+}
+
 const QString&
 GtPropertyCategoryItem::categoryId() const
 {
@@ -67,7 +86,7 @@ GtPropertyCategoryItem::data(int column, int role) const
         {
             if (column == 0)
             {
-                return m_id;
+                return displayName();
             }
 
             break;
@@ -95,11 +114,10 @@ GtPropertyCategoryItem::data(int column, int role) const
 
         case GtPropertyModel::MonitoringRole:
         {
-            if (m_id == QStringLiteral("Monitoring"))
-            {
-                return true;
-            }
+            return m_id == QStringLiteral("Monitoring");
         }
+        case GtPropertyModel::DefaultCollapseRole:
+            return isCollapsed();
     }
 
     return QVariant();

--- a/src/gui/dock_widgets/properties/items/gt_propertycategoryitem.h
+++ b/src/gui/dock_widgets/properties/items/gt_propertycategoryitem.h
@@ -53,11 +53,20 @@ public:
      */
     bool isContainer() const;
 
+    bool isCollapsed() const;
+
     /**
      * @brief categoryId
      * @return
      */
     const QString& categoryId() const;
+
+    /**
+     * @brief The text to display in the GUI
+     *        omittung collapse and priority status
+     * @return
+     */
+    QString displayName() const;
 
     /**
      * @brief data

--- a/src/gui/dock_widgets/properties/items/gt_propertyitem.cpp
+++ b/src/gui/dock_widgets/properties/items/gt_propertyitem.cpp
@@ -181,6 +181,8 @@ GtPropertyItem::data(int column, int role) const
 
         case GtPropertyModel::ActiveRole:
             return m_property->isActive();
+        case GtPropertyModel::DefaultCollapseRole:
+            return m_property->collapsedByDefault();
     }
 
     return {};


### PR DESCRIPTION
Closes #1344

<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows to configure the position and the expand state of property groups. 

- Each group can be assigned to a priority. The higher it is, the lower the group will be positioned
- The main group comes always first (by default), which has a priority of 1
- It is implemented by modifying the group names internally, thus there is no ABI break

## How Has This Been Tested?

Manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
