### PR TITLE
Resolve: "Destructor of GtAbstractFactory not marked as virtual"

### DIFF
--- a/src/dataprocessor/gt_abstractobjectfactory.cpp
+++ b/src/dataprocessor/gt_abstractobjectfactory.cpp
@@ -17,6 +17,8 @@ GtAbstractObjectFactory::GtAbstractObjectFactory(bool silent) : m_silent(silent)
 {
 }
 
+GtAbstractObjectFactory::~GtAbstractObjectFactory() = default;
+
 GtObject*
 GtAbstractObjectFactory::newObject(const QString& className, GtObject* parent)
 {

--- a/src/dataprocessor/gt_abstractobjectfactory.h
+++ b/src/dataprocessor/gt_abstractobjectfactory.h
@@ -25,6 +25,10 @@ class GtObject;
 class GT_DATAMODEL_EXPORT GtAbstractObjectFactory
 {
 public:
+
+    /// destructor
+    virtual ~GtAbstractObjectFactory();
+
     /**
      * @brief newObject - generates gtlab objects based on given classname
      * @param className


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Closes #1343 - marked destructor as virtual

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
