### PR TITLE
Fixed zombie theme during module initialization

### DIFF
--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -866,9 +866,9 @@ GtApplication::onUndoStackChange()
 void
 GtApplication::onGuiInitializationFinished()
 {
-    initModules();
-
     // update theme
     emit themeChanged(m_darkMode);
+
+    initModules();
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #1357 

## How Has This Been Tested?

Now, the python interpreter query is printed after theme switching, see:

![image](https://github.com/user-attachments/assets/9eac7783-d609-4162-bf37-462aed56bb51)



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
