### PR TITLE
Fixed toolbar resize on startup

### DIFF
--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -966,9 +966,6 @@ GtApplication::onUndoStackChange()
 void
 GtApplication::onGuiInitializationFinished()
 {
-    // update theme
-    emit themeChanged(m_darkMode);
-
     initModules();
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The theme update seems to interfere with the window resize. Due to changes in the main window logic, the line is not
necessary anymore. The theme has been set up correctly before.

Fixes #1367

## How Has This Been Tested?

I tested it with the python module. The setup-module shows a dialog, when the interpreter is not setup-correctly. The dialog is shown in the correct theme, not as in issue #1357 .

@mariusalexander Could you please verify, that this fixes your issue?


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
