### PR TITLE
Hide irrelevant label for only calculator of core system

### DIFF
--- a/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
+++ b/src/core/process_management/calculators/gt_exporttomementocalculator.cpp
@@ -47,6 +47,9 @@ GtExportToMementoCalculator::GtExportToMementoCalculator() :
     m_fileMode.registerSubProperty(m_relativeToProjectFileMode);
 
     registerProperty(m_fileMode);
+
+    // hide label
+    hideLabelProperty(true);
 }
 
 bool


### PR DESCRIPTION
The label is not used in the calculator and so should be hidden

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
