### PR TITLE
Resolve "Output dock does not resize new rows that span multiple lines"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
  - Connecting GtStringMonitoringProperty to GtStringProperty in the connection editor now works as expected - #1380
+ - Fixed Output Dock not resizing new rows correctly. - #1260
 
 ## [2.0.11] - 2025-04-03
 ### Fixed

--- a/src/app/dock_widgets/output/gt_outputdock.cpp
+++ b/src/app/dock_widgets/output/gt_outputdock.cpp
@@ -416,7 +416,9 @@ GtOutputDock::GtOutputDock()
 
     // other connections
     connect(gtLogModel, &GtLogModel::rowsInserted,
-            this, &GtOutputDock::onRowsInserted);
+            this, [this](QModelIndex const& parent, int start, int end){
+        onRowsInserted(start, end);
+    });
     connect(gtLogModel, &GtLogModel::rowsRemoved,
             this, &GtOutputDock::onRowsRemoved);
     connect(m_model, &GtFilteredLogModel::modelReset,
@@ -546,8 +548,14 @@ GtOutputDock::scrollToBottom()
 }
 
 void
-GtOutputDock::onRowsInserted()
+GtOutputDock::onRowsInserted(int start, int last)
 {
+    assert(start < (last + 1));
+    for (auto idx : gt::range(start, last + 1))
+    {
+        m_logView->resizeRowToContents(idx);
+    }
+
     scrollToBottom();
 }
 

--- a/src/app/dock_widgets/output/gt_outputdock.h
+++ b/src/app/dock_widgets/output/gt_outputdock.h
@@ -110,8 +110,10 @@ private slots:
 
     /**
      * @brief Triggered when new rows were inserted
+     * @param first Start of insertion
+     * @param last End of insertion
      */
-    void onRowsInserted();
+    void onRowsInserted(int first, int last);
 
     /**
      * @brief Triggered on model reset


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1260 - fixed output dock not resizing new rows correctly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Manually. No performance degradation of the GUI (e.g. stuttering) was noted compared to the previous version

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
