### PR TITLE
Fixed wrong encoding in module license and readme widget

### DIFF
--- a/src/app/dialogs/gt_moduledetailsdialog.cpp
+++ b/src/app/dialogs/gt_moduledetailsdialog.cpp
@@ -246,7 +246,11 @@ GtModuleDetailsDialog::loadInfoFile(QString const& filter)
         }
 
         QTextStream in(&file);
+
+        // In Qt6, the encoding is detected automatically
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         in.setCodec("UTF-8");
+#endif
         QString content = in.readAll();
         file.close();
 


### PR DESCRIPTION
Closes #1395


## Description

By now assuming UTF-8 encoding, the text is rendered correctly.

## How Has This Been Tested?

<img width="503" height="163" alt="grafik" src="https://github.com/user-attachments/assets/5e1cb54e-d17e-4a73-aa80-013b7c060930" />



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
