### PR TITLE
Add support for multiple module directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ As such, many functions needed to be deprecated and should be replaced according
  - Fixed incorrect packages / modules in the project after a backup restore - #1211
  
 ### Added
+ - Module directories can now be customized via settings and the `GTLAB_MODULE_DIRS` environment variable (first dir wins on collisions).
  - Horizontal scrolling to the selected object in explorer view.
    This also fixes jumping of the scrollbar to the left - #1235
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ As such, many functions needed to be deprecated and should be replaced according
  - Fixed incorrect packages / modules in the project after a backup restore - #1211
  
 ### Added
- - Module directories can now be customized via settings and the `GTLAB_MODULE_DIRS` environment variable (first dir wins on collisions).
+ - GTlab now supports multiple module directories. These can be set via settings and the `GTLAB_MODULE_DIRS` environment variable (first dir wins on collisions).
  - Horizontal scrolling to the selected object in explorer view.
    This also fixes jumping of the scrollbar to the left - #1235
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -26,6 +26,7 @@ set(headers
     preferences/pages/gt_preferenceslanguage.h
     preferences/pages/gt_preferencessession.h
     preferences/pages/gt_preferencesshortcuts.h
+    preferences/pages/gt_moduledirectoriestab.h
     tools/gt_qmltoolbar.h
     tools/gt_iconbrowser.h
     widgets/gt_sessionlistwidget.h
@@ -105,7 +106,10 @@ set(headers
     dock_widgets/labels/gt_labeldelegate.h
 )
 
-set(forms ui/gt_mainwin.ui)
+set(forms 
+    ui/gt_mainwin.ui
+    preferences/pages/gt_moduledirectoriestab.ui
+)
 
 set(sources
     app.cpp
@@ -121,6 +125,7 @@ set(sources
     preferences/pages/gt_preferenceslanguage.cpp
     preferences/pages/gt_preferencessession.cpp
     preferences/pages/gt_preferencesshortcuts.cpp
+    preferences/pages/gt_moduledirectoriestab.cpp
     tools/gt_qmltoolbar.cpp
     tools/gt_iconbrowser.cpp
     widgets/gt_sessionlistwidget.cpp

--- a/src/app/dialogs/gt_aboutdialog.cpp
+++ b/src/app/dialogs/gt_aboutdialog.cpp
@@ -193,26 +193,30 @@ QWidget*
 GtAboutDialog::modulesWidget()
 {
     m_modulesTree = new QTreeWidget;
+    m_modulesTree->setTextElideMode(Qt::ElideMiddle);
 
     auto* w = new QWidget;
     auto* l = new QVBoxLayout;
 
     w->setLayout(l);
 
-    m_modulesTree->setColumnCount(2);
+    m_modulesTree->setColumnCount(3);
     m_modulesTree->setHeaderLabels(QStringList()
                                          << tr("Name")
-                                         << tr("Version"));
+                                         << tr("Version")
+                                         << tr("Location"));
     m_modulesTree->header()->setStretchLastSection(true);
-    m_modulesTree->setColumnWidth(0, 300);
+    m_modulesTree->setColumnWidth(0, 200);
     foreach (const QString& id, gtApp->moduleIds())
     {
         QStringList info;
         info << id;
         info << gtApp->moduleVersion(id).toString();
+        info << gtApp->moduleLocation(id);
         auto* item = new QTreeWidgetItem(info);
         item->setIcon(0, gt::gui::icon::plugin());
         item->setToolTip(0, gtApp->moduleDescription(id));
+        item->setToolTip(2, gtApp->moduleLocation(id));
         m_modulesTree->addTopLevelItem(item);
     }
 

--- a/src/app/dialogs/gt_moduledetailsdialog.cpp
+++ b/src/app/dialogs/gt_moduledetailsdialog.cpp
@@ -215,13 +215,23 @@ GtModuleDetailsDialog::addLine(const QString& title, const QString& value)
 std::tuple<QString,GtTextEdit::contentType>
 GtModuleDetailsDialog::loadInfoFile(QString const& filter)
 {
-    QString path = QCoreApplication::applicationDirPath() +
-            QDir::separator() + QStringLiteral("modules") +
+    assert(gtApp);
+
+    // the directory where the current module is located
+    auto moduleDir = QFileInfo(gtApp->moduleLocation(m_moduleId)).dir();
+
+    GtTextEdit::contentType none = GtTextEdit::NONE;
+
+    if (!moduleDir.exists())
+    {
+        return {QStringLiteral("Cannot determine the module directory"), none};
+    }
+
+    QString path = moduleDir.absolutePath() +
             QDir::separator() + QStringLiteral("meta") + QDir::separator();
 
     QDir modulesDir(path + windowTitle());
 
-    GtTextEdit::contentType none = GtTextEdit::NONE;
 
     if (modulesDir.exists())
     {

--- a/src/app/preferences/pages/gt_moduledirectoriestab.cpp
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.cpp
@@ -1,0 +1,451 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2025 German Aerospace Center (DLR)
+ */
+
+#include "gt_moduledirectoriestab.h"
+#include "ui_gt_moduledirectoriestab.h"
+
+#include <QFileDialog>
+#include <QDir>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QMenu>
+#include <QProcess>
+#include <QDesktopServices>
+#include <QUrl>
+#include <QDir>
+
+#include <gt_icons.h>
+#include <gt_logging.h>
+
+GtModuleDirectoriesTab::GtModuleDirectoriesTab(QWidget* parent) :
+    QWidget(parent), ui(new Ui::GtModuleDirectoriesTab)
+{
+    ui->setupUi(this);
+
+    ui->btnAddDirectory->setIcon(gt::gui::icon::folderAdd());
+    ui->btnRemoveDirectory->setIcon(gt::gui::icon::remove());
+
+    // Allow inline editing for user rows; F2, double-click, or selected-click
+    ui->directoriesList->setEditTriggers(QAbstractItemView::EditKeyPressed |
+                                         QAbstractItemView::SelectedClicked |
+                                         QAbstractItemView::DoubleClicked);
+
+    // Right-click context menu
+    ui->directoriesList->setContextMenuPolicy(Qt::CustomContextMenu);
+    ui->directoriesList->setUniformItemSizes(true);
+    ui->directoriesList->setIconSize(QSize(20, 20));
+
+    connect(ui->directoriesList, &QListWidget::customContextMenuRequested, this,
+            &GtModuleDirectoriesTab::onListContextMenu);
+
+    // Prepare two header items (greyed & disabled)
+    ensureHeaderItems();
+
+    // Wire buttons
+    connect(ui->btnAddDirectory, &QToolButton::clicked, this,
+            &GtModuleDirectoriesTab::onAddDirectory);
+    connect(ui->btnRemoveDirectory, &QToolButton::clicked, this,
+            &GtModuleDirectoriesTab::onRemoveDirectory);
+
+    // Keep remove button state in sync
+    connect(ui->directoriesList, &QListWidget::itemSelectionChanged, this,
+            &GtModuleDirectoriesTab::onSelectionChanged);
+
+    // Guard against accidental edits (only matters if edit triggers somehow)
+    connect(ui->directoriesList, &QListWidget::itemChanged, this,
+            &GtModuleDirectoriesTab::onItemChanged);
+
+    updateRemoveButton();
+}
+
+GtModuleDirectoriesTab::~GtModuleDirectoriesTab()
+{
+    delete ui;
+}
+
+void
+GtModuleDirectoriesTab::ensureHeaderItems()
+{
+    auto infoIcon = gt::gui::icon::info();
+
+    // Ensure the list has at least two items for defaults
+    while (ui->directoriesList->count() < 2)
+        ui->directoriesList->addItem(new QListWidgetItem);
+
+    for (int row = 0; row < 2; ++row)
+    {
+        auto* it = ui->directoriesList->item(row);
+        it->setFlags(Qt::NoItemFlags); // not selectable/editable
+        it->setForeground(Qt::gray);
+        it->setCheckState(Qt::Checked);
+        it->setIcon(infoIcon);
+    }
+
+    setHeaderText(0,
+                  m_defaultInstallPath.isEmpty() ? tr("<install modules path>")
+                                                 : m_defaultInstallPath,
+                  tr("Application module directory - always enabled"));
+    setHeaderText(1,
+                  m_defaultUserPath.isEmpty()
+                      ? tr("<default user modules path>")
+                      : m_defaultUserPath,
+                  tr("User module directory - always enabled"));
+}
+
+void
+GtModuleDirectoriesTab::setHeaderText(int row, const QString& text,
+                                      const QString& about)
+{
+    if (row < 0 || row >= 2)
+        return;
+    auto* it = ui->directoriesList->item(row);
+    if (!it)
+        return;
+    it->setText(text);
+    it->setToolTip(about);
+}
+
+bool
+GtModuleDirectoriesTab::isHeaderRow(int row) const
+{
+    return row == 0 || row == 1;
+}
+
+void
+GtModuleDirectoriesTab::setDefaultInstallPath(const QString& path)
+{
+    m_defaultInstallPath = QDir::toNativeSeparators(QDir(path).absolutePath());
+    ensureHeaderItems();
+}
+
+void
+GtModuleDirectoriesTab::setDefaultUserPath(const QString& path)
+{
+    m_defaultUserPath = QDir::toNativeSeparators(QDir(path).absolutePath());
+    ensureHeaderItems();
+}
+
+QStringList
+GtModuleDirectoriesTab::userPaths() const
+{
+    QStringList out;
+    for (int i = 2; i < ui->directoriesList->count(); ++i)
+    {
+        auto* item = ui->directoriesList->item(i);
+        auto path = item->text();
+        if (item->checkState() == Qt::Unchecked)
+            path = '#' + path;
+        out << path;
+    }
+    return out;
+}
+
+void
+GtModuleDirectoriesTab::setUserPaths(const QStringList& paths)
+{
+    m_blockSignals = true;
+
+    auto usericon = gt::gui::icon::folderEye();
+
+    // Remove all existing user-defined items
+    while (ui->directoriesList->count() > 2)
+        delete ui->directoriesList->takeItem(2);
+
+    // Add new ones (deduplicated, normalized)
+    QSet<QString> seen;
+    for (QString p : paths)
+    {
+        bool enabled = true;
+        if (p.startsWith('#'))
+        {
+            enabled = false;
+            p = p.mid(1);
+        }
+
+        if (p.isEmpty())
+            continue;
+
+        QString norm = QDir::toNativeSeparators(QDir(p).absolutePath());
+
+        if (norm.isEmpty() || seen.contains(norm))
+            continue;
+
+        seen.insert(norm);
+
+        auto* it = new QListWidgetItem(norm);
+        it->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
+                     Qt::ItemIsEditable | Qt::ItemIsUserCheckable);
+        it->setIcon(usericon);
+        it->setCheckState(enabled ? Qt::Checked : Qt::Unchecked);
+        applyUserItemAppearance(it);
+
+        ui->directoriesList->addItem(it);
+    }
+
+    m_blockSignals = false;
+    updateRemoveButton();
+    emit userPathsChanged(userPaths());
+}
+
+void
+GtModuleDirectoriesTab::onAddDirectory()
+{
+    const QString dir = QFileDialog::getExistingDirectory(
+        this, tr("Select Module Directory"), QString(),
+        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+
+    if (dir.isEmpty())
+        return;
+
+    const QString norm = QDir::toNativeSeparators(QDir(dir).absolutePath());
+
+    // Prevent duplicates (including headers)
+    for (int i = 0; i < ui->directoriesList->count(); ++i)
+    {
+        if (ui->directoriesList->item(i)->text().compare(
+                norm, Qt::CaseInsensitive) == 0)
+        {
+            ui->directoriesList->setCurrentRow(i);
+            updateRemoveButton();
+            return;
+        }
+    }
+
+    auto usericon = gt::gui::icon::folderEye();
+
+    auto* it = new QListWidgetItem(norm);
+    it->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable |
+                 Qt::ItemIsUserCheckable);
+    it->setCheckState(Qt::Checked); // enabled by default
+    it->setIcon(usericon);
+    ui->directoriesList->addItem(it);
+    ui->directoriesList->setCurrentItem(it);
+
+    emit userPathsChanged(userPaths());
+    updateRemoveButton();
+}
+
+void
+GtModuleDirectoriesTab::onRemoveDirectory()
+{
+    const auto selected = ui->directoriesList->selectedItems();
+    if (selected.isEmpty())
+        return;
+
+    // Remove only user defined (rows >= 2)
+    for (QListWidgetItem* it : selected)
+    {
+        const int row = ui->directoriesList->row(it);
+        if (row >= 2)
+            delete ui->directoriesList->takeItem(row);
+    }
+
+    emit userPathsChanged(userPaths());
+    updateRemoveButton();
+}
+
+void
+GtModuleDirectoriesTab::onSelectionChanged()
+{
+    updateRemoveButton();
+}
+
+void
+GtModuleDirectoriesTab::onItemChanged(QListWidgetItem* item)
+{
+    if (!item)
+        return;
+    const int row = ui->directoriesList->row(item);
+
+    // Protect headers
+    if (row == 0)
+    {
+        item->setText(m_defaultInstallPath);
+        return;
+    }
+    if (row == 1)
+    {
+        item->setText(m_defaultUserPath);
+        return;
+    }
+
+    // Always refresh appearance (covers checkbox toggles)
+    applyUserItemAppearance(item);
+
+    // If the text changed: normalize / dedupe / drop empties
+    QString txt = item->text().trimmed();
+    if (txt.isEmpty())
+    {
+        delete ui->directoriesList->takeItem(row);
+        emit userPathsChanged(userPaths());
+        return;
+    }
+
+    const QString norm = QDir::toNativeSeparators(QDir(txt).absolutePath());
+    if (norm != item->text())
+        item->setText(norm);
+
+    // Prevent duplicates (including vs headers)
+    for (int i = 0; i < ui->directoriesList->count(); ++i)
+    {
+        if (i == row)
+            continue;
+        if (ui->directoriesList->item(i)->text().compare(
+                norm, Qt::CaseInsensitive) == 0)
+        {
+            ui->directoriesList->setCurrentRow(i);
+            if (norm != item->text())
+                item->setText(norm);
+            return;
+        }
+    }
+
+    emit userPathsChanged(userPaths());
+}
+
+
+void
+GtModuleDirectoriesTab::updateRemoveButton()
+{
+    bool canRemove = false;
+    const auto selectedItems = ui->directoriesList->selectedItems();
+    for (const QListWidgetItem* it : selectedItems)
+    {
+        if (ui->directoriesList->row(it) >= 2)
+        {
+            canRemove = true;
+            break;
+        }
+    }
+    ui->btnRemoveDirectory->setEnabled(canRemove);
+}
+
+void
+GtModuleDirectoriesTab::onListContextMenu(const QPoint& pos)
+{
+    QListWidgetItem* item = ui->directoriesList->itemAt(pos);
+
+    if (item)
+    {
+        ui->directoriesList->setCurrentItem(item);
+    }
+
+    QMenu menu(this);
+
+    QAction* showAct = menu.addAction(tr("Show in Explorer"));
+    connect(showAct, &QAction::triggered, this,
+            &GtModuleDirectoriesTab::onShowInExplorer);
+
+    // For user-defined rows only (>= 2)
+    const bool userRow = (item && ui->directoriesList->row(item) >= 2);
+
+    QAction* editInlineAct = menu.addAction(tr("Rename / Edit Path"));
+    editInlineAct->setEnabled(userRow);
+    connect(editInlineAct, &QAction::triggered, this,
+            &GtModuleDirectoriesTab::onEditItemInline);
+
+    QAction* changeToDirAct = menu.addAction(tr("Change to…"));
+    changeToDirAct->setEnabled(userRow);
+    connect(changeToDirAct, &QAction::triggered, this,
+            &GtModuleDirectoriesTab::onChangeToDirectory);
+
+    menu.exec(ui->directoriesList->viewport()->mapToGlobal(pos));
+}
+
+void
+GtModuleDirectoriesTab::onShowInExplorer()
+{
+    auto* item = ui->directoriesList->currentItem();
+    if (!item)
+        return;
+
+    const QString path = item->text().trimmed();
+    if (path.isEmpty())
+        return;
+
+    openInFileManager(path);
+}
+
+void
+GtModuleDirectoriesTab::onEditItemInline()
+{
+    if (auto* it = currentUserItem())
+    {
+        ui->directoriesList->editItem(it);
+    }
+}
+
+void
+GtModuleDirectoriesTab::onChangeToDirectory()
+{
+    auto* it = currentUserItem();
+    if (!it)
+        return;
+
+    const QString startDir = it->text();
+    const QString dir = QFileDialog::getExistingDirectory(
+        this, tr("Select Module Directory"),
+        startDir.isEmpty() ? QString() : startDir,
+        QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+
+    if (dir.isEmpty())
+        return;
+
+    const QString norm = QDir::toNativeSeparators(QDir(dir).absolutePath());
+
+    // prevent duplicates vs all items (including headers)
+    for (int i = 0; i < ui->directoriesList->count(); ++i)
+    {
+        if (ui->directoriesList->item(i)->text().compare(
+                norm, Qt::CaseInsensitive) == 0)
+        {
+            ui->directoriesList->setCurrentRow(i);
+            return;
+        }
+    }
+
+    it->setText(norm);
+    emit userPathsChanged(userPaths());
+}
+
+bool
+GtModuleDirectoriesTab::openInFileManager(const QString& path)
+{
+    QFileInfo fi(path);
+    if (!fi.exists())
+        return false;
+
+    // If a file is passed, open its parent folder; if a dir, open it directly.
+    const QString target =
+        fi.isDir() ? fi.canonicalFilePath() : fi.absolutePath();
+
+    return QDesktopServices::openUrl(QUrl::fromLocalFile(target));
+}
+
+QListWidgetItem*
+GtModuleDirectoriesTab::currentUserItem() const
+{
+    auto* it = ui->directoriesList->currentItem();
+    if (!it)
+        return nullptr;
+    const int row = ui->directoriesList->row(it);
+    return (row >= 2) ? it : nullptr;
+}
+
+void
+GtModuleDirectoriesTab::applyUserItemAppearance(QListWidgetItem* item)
+{
+    if (!item)
+        return;
+    const bool disabled = (item->checkState() == Qt::Unchecked);
+
+    QFont f = item->font();
+    f.setStrikeOut(disabled);
+    item->setFont(f);
+
+    item->setToolTip(disabled ? tr("Disabled — this path will be ignored")
+                              : tr("Enabled"));
+}

--- a/src/app/preferences/pages/gt_moduledirectoriestab.cpp
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.cpp
@@ -123,7 +123,7 @@ void
 GtModuleDirectoriesTab::setHeaderText(int row, const QString& text,
                                       const QString& about)
 {
-    if (row < 0 || row >= 2)
+    if (row < 0 || row >= ui->directoriesList->count())
         return;
     auto* it = ui->directoriesList->item(row);
     if (!it)
@@ -375,16 +375,20 @@ GtModuleDirectoriesTab::onItemChanged(QListWidgetItem* item)
 
     // Protect headers
     const int count = ui->directoriesList->count();
-    const int installRow = count - 2;
-    const int userRow = count - 1;
+    const int userRow = count - 2;
+    const int installRow = count - 1;
     if (row == installRow)
     {
-        item->setText(m_defaultInstallPath);
+        item->setText(m_defaultInstallPath.isEmpty()
+                          ? tr("<install modules path>")
+                          : m_defaultInstallPath);
         return;
     }
     if (row == userRow)
     {
-        item->setText(m_defaultUserPath);
+        item->setText(m_defaultUserPath.isEmpty()
+                          ? tr("<default user modules path>")
+                          : m_defaultUserPath);
         return;
     }
 

--- a/src/app/preferences/pages/gt_moduledirectoriestab.cpp
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.cpp
@@ -28,6 +28,9 @@ GtModuleDirectoriesTab::GtModuleDirectoriesTab(QWidget* parent) :
     ui->btnAddDirectory->setIcon(gt::gui::icon::folderAdd());
     ui->btnRemoveDirectory->setIcon(gt::gui::icon::remove());
 
+    ui->btnAddDirectory->setToolTip(tr("Add directory"));
+    ui->btnRemoveDirectory->setToolTip(tr("Remove directory"));
+
     // Allow inline editing for user rows; F2, double-click, or selected-click
     ui->directoriesList->setEditTriggers(QAbstractItemView::EditKeyPressed |
                                          QAbstractItemView::SelectedClicked |

--- a/src/app/preferences/pages/gt_moduledirectoriestab.cpp
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.cpp
@@ -16,6 +16,7 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include <QDir>
+#include <QMessageBox>
 
 #include <algorithm>
 
@@ -31,6 +32,7 @@ GtModuleDirectoriesTab::GtModuleDirectoriesTab(QWidget* parent) :
     ui->btnRemoveDirectory->setIcon(gt::gui::icon::remove());
     ui->btnMoveUp->setIcon(gt::gui::icon::arrowUp());
     ui->btnMoveDown->setIcon(gt::gui::icon::arrowDown());
+    ui->btnHelpPrecedence->setIcon(gt::gui::icon::help());
 
     ui->btnAddDirectory->setToolTip(tr("Add directory"));
     ui->btnRemoveDirectory->setToolTip(tr("Remove directory"));
@@ -62,6 +64,8 @@ GtModuleDirectoriesTab::GtModuleDirectoriesTab(QWidget* parent) :
             &GtModuleDirectoriesTab::onMoveUp);
     connect(ui->btnMoveDown, &QToolButton::clicked, this,
             &GtModuleDirectoriesTab::onMoveDown);
+    connect(ui->btnHelpPrecedence, &QToolButton::clicked, this,
+            &GtModuleDirectoriesTab::onShowPrecedenceHelp);
 
     // Keep remove button state in sync
     connect(ui->directoriesList, &QListWidget::itemSelectionChanged, this,
@@ -554,6 +558,21 @@ GtModuleDirectoriesTab::onChangeToDirectory()
 
     it->setText(norm);
     emit userPathsChanged(userPaths());
+}
+
+void
+GtModuleDirectoriesTab::onShowPrecedenceHelp()
+{
+    const auto message = tr(
+        "Module loading order:\n"
+        "1. Environment variable GTLAB_MODULE_DIRS (left-to-right order)\n"
+        "2. Enabled user-defined directories in this list (top-to-bottom)\n"
+        "3. Default user module directory\n"
+        "4. Application module directory\n\n"
+        "If the same module id exists in multiple directories, the first "
+        "directory in this loading order wins and later matches are ignored.");
+
+    QMessageBox::information(this, tr("Module Loading Order"), message);
 }
 
 bool

--- a/src/app/preferences/pages/gt_moduledirectoriestab.h
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.h
@@ -1,0 +1,202 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2025 German Aerospace Center (DLR)
+ */
+
+#ifndef GT_MODULEDIRECTORIESTAB_H
+#define GT_MODULEDIRECTORIESTAB_H
+
+#include <QWidget>
+#include <QStringList>
+
+namespace Ui
+{
+    class GtModuleDirectoriesTab;
+}
+
+class QListWidgetItem;
+
+/**
+ * @brief Widget to manage module search directories for GTlab.
+ *
+ * The list shows two fixed, informational entries on top (default install path
+ * and default user path). All subsequent entries are user-defined and can be
+ * added/removed/edited. User entries are checkable to enable/disable them.
+ *
+ * @note The first two rows are non-interactive and never returned by userPaths().
+ */
+class GtModuleDirectoriesTab : public QWidget
+{
+    Q_OBJECT
+public:
+    /**
+     * @brief Construct the widget.
+     * @param parent Optional parent QWidget.
+     */
+    explicit GtModuleDirectoriesTab(QWidget* parent = nullptr);
+
+    /**
+     * @brief Destructor.
+     */
+    ~GtModuleDirectoriesTab() override;
+
+    /**
+     * @brief Set the default (built-in) install modules path.
+     *
+     * Shown as the first fixed row, greyed out and non-interactive.
+     * This is a visual hint only and is never included in userPaths().
+     *
+     * @param path Absolute or relative path; will be normalized for display.
+     */
+    void setDefaultInstallPath(const QString& path);
+
+    /**
+     * @brief Set the default user modules path.
+     *
+     * Shown as the second fixed row, greyed out and non-interactive.
+     * This is a visual hint only and is never included in userPaths().
+     *
+     * @param path Absolute or relative path; will be normalized for display.
+     */
+    void setDefaultUserPath(const QString& path);
+
+    /**
+     * @brief Return only enabled, user-defined module directories.
+     *
+     * The first two fixed rows are excluded. Unchecked (disabled) user entries
+     * are also excluded.
+     *
+     * @return QStringList of normalized, enabled user paths.
+     */
+    QStringList userPaths() const;
+
+    /**
+     * @brief Replace all user-defined module directories (enabled by default).
+     *
+     * Clears existing user entries (rows >= 2) and appends the given paths as
+     * editable, checkable items (checked). Paths are normalized and deduplicated.
+     *
+     * @param paths List of paths to set as user entries.
+     */
+    void setUserPaths(const QStringList& paths);
+
+signals:
+    /**
+     * @brief Emitted whenever the set of enabled user paths changes.
+     *
+     * Emitted after add/remove, edit, check/uncheck, or bulk updates.
+     *
+     * @param paths The current enabled user paths (same as userPaths()).
+     */
+    void userPathsChanged(const QStringList& paths);
+
+private slots:
+    /**
+     * @brief Open a directory chooser and append a new user entry.
+     */
+    void onAddDirectory();
+
+    /**
+     * @brief Remove the currently selected user entries (rows >= 2).
+     */
+    void onRemoveDirectory();
+
+    /**
+     * @brief Keep UI state (e.g., remove button enabled) in sync with selection.
+     */
+    void onSelectionChanged();
+
+    /**
+     * @brief React to edits or checkbox toggles on list items.
+     *
+     * Restores header rows, normalizes paths, deduplicates, and updates styling.
+     *
+     * @param item The item that changed.
+     */
+    void onItemChanged(QListWidgetItem* item);
+
+    /**
+     * @brief Show a context menu for the list at the given position.
+     *
+     * Provides actions like "Show in Explorer" and "Rename / Edit Path".
+     *
+     * @param pos Position in viewport coordinates.
+     */
+    void onListContextMenu(const QPoint& pos);
+
+    /**
+     * @brief Open the system file manager at the selected entry's path.
+     */
+    void onShowInExplorer();
+
+    /**
+     * @brief Start inline editing of the currently selected user entry.
+     */
+    void onEditItemInline();
+
+    /**
+     * @brief Replace the currently selected user entry via a directory chooser.
+     */
+    void onChangeToDirectory();
+
+private:
+    /**
+     * @brief Apply visual appearance to a user item.
+     *
+     * Sets strike-through/gray when unchecked (disabled), normal style when checked.
+     *
+     * @param item Target list item (must be a user row, i.e., row >= 2).
+     */
+    void applyUserItemAppearance(QListWidgetItem* item);
+
+    /**
+     * @brief Open a directory in the system file manager.
+     * @param path Target path (file or directory). Files open their parent dir.
+     * @return true on successful launch, false otherwise.
+     */
+    bool openInFileManager(const QString& path);
+
+    /**
+     * @brief Return the currently selected user item or nullptr if selection is invalid.
+     */
+    QListWidgetItem* currentUserItem() const;
+
+    /**
+     * @brief Ensure the two fixed header rows exist and are styled/locked.
+     */
+    void ensureHeaderItems();
+
+    /**
+     * @brief Set text and tooltip for one of the two header rows.
+     *
+     * @param row 0 for install path, 1 for user path.
+     * @param text Display text (path).
+     * @param about Tooltip/help text explaining the row.
+     */
+    void setHeaderText(int row, const QString& text, const QString& about);
+
+    /**
+     * @brief Whether a given row index is one of the two fixed headers.
+     */
+    bool isHeaderRow(int row) const;
+
+    /**
+     * @brief Enable/disable the Remove button based on current selection.
+     */
+    void updateRemoveButton();
+
+    //! Auto-generated UI.
+    Ui::GtModuleDirectoriesTab* ui;
+
+    //! Display text for the default install modules path (row 0).
+    QString m_defaultInstallPath;
+
+    //! Display text for the default user modules path (row 1).
+    QString m_defaultUserPath;
+
+    //! Prevent re-entrant signal handling during bulk updates.
+    bool m_blockSignals = false;
+};
+
+#endif // GT_MODULEDIRECTORIESTAB_H

--- a/src/app/preferences/pages/gt_moduledirectoriestab.h
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.h
@@ -20,11 +20,12 @@ class QListWidgetItem;
 /**
  * @brief Widget to manage module search directories for GTlab.
  *
- * The list shows two fixed, informational entries on top (default install path
- * and default user path). All subsequent entries are user-defined and can be
- * added/removed/edited. User entries are checkable to enable/disable them.
+ * The list shows two fixed, informational entries at the bottom (default
+ * install path and default user path). All preceding entries are user-defined
+ * and can be added/removed/edited. User entries are checkable to enable/disable
+ * them.
  *
- * @note The first two rows are non-interactive and never returned by userPaths().
+ * @note The last two rows are non-interactive and never returned by userPaths().
  */
 class GtModuleDirectoriesTab : public QWidget
 {
@@ -44,7 +45,7 @@ public:
     /**
      * @brief Set the default (built-in) install modules path.
      *
-     * Shown as the first fixed row, greyed out and non-interactive.
+     * Shown as a fixed row near the bottom, greyed out and non-interactive.
      * This is a visual hint only and is never included in userPaths().
      *
      * @param path Absolute or relative path; will be normalized for display.
@@ -54,7 +55,7 @@ public:
     /**
      * @brief Set the default user modules path.
      *
-     * Shown as the second fixed row, greyed out and non-interactive.
+     * Shown as a fixed row at the bottom, greyed out and non-interactive.
      * This is a visual hint only and is never included in userPaths().
      *
      * @param path Absolute or relative path; will be normalized for display.
@@ -64,7 +65,7 @@ public:
     /**
      * @brief Return only enabled, user-defined module directories.
      *
-     * The first two fixed rows are excluded. Unchecked (disabled) user entries
+     * The last two fixed rows are excluded. Unchecked (disabled) user entries
      * are also excluded.
      *
      * @return QStringList of normalized, enabled user paths.
@@ -74,8 +75,9 @@ public:
     /**
      * @brief Replace all user-defined module directories (enabled by default).
      *
-     * Clears existing user entries (rows >= 2) and appends the given paths as
-     * editable, checkable items (checked). Paths are normalized and deduplicated.
+     * Clears existing user entries (all rows except the last two) and appends
+     * the given paths as editable, checkable items (checked). Paths are
+     * normalized and deduplicated.
      *
      * @param paths List of paths to set as user entries.
      */
@@ -98,9 +100,19 @@ private slots:
     void onAddDirectory();
 
     /**
-     * @brief Remove the currently selected user entries (rows >= 2).
+     * @brief Remove the currently selected user entries (rows above headers).
      */
     void onRemoveDirectory();
+
+    /**
+     * @brief Move the selected user entries up by one row (user rows only).
+     */
+    void onMoveUp();
+
+    /**
+     * @brief Move the selected user entries down by one row (user rows only).
+     */
+    void onMoveDown();
 
     /**
      * @brief Keep UI state (e.g., remove button enabled) in sync with selection.
@@ -170,7 +182,7 @@ private:
     /**
      * @brief Set text and tooltip for one of the two header rows.
      *
-     * @param row 0 for install path, 1 for user path.
+     * @param row install path row or user path row (last two rows).
      * @param text Display text (path).
      * @param about Tooltip/help text explaining the row.
      */
@@ -185,6 +197,11 @@ private:
      * @brief Enable/disable the Remove button based on current selection.
      */
     void updateRemoveButton();
+
+    /**
+     * @brief Enable/disable move buttons based on current selection.
+     */
+    void updateMoveButtons();
 
     //! Auto-generated UI.
     Ui::GtModuleDirectoriesTab* ui;

--- a/src/app/preferences/pages/gt_moduledirectoriestab.h
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.h
@@ -152,6 +152,11 @@ private slots:
      */
     void onChangeToDirectory();
 
+    /**
+     * @brief Show module directory precedence information.
+     */
+    void onShowPrecedenceHelp();
+
 private:
     /**
      * @brief Apply visual appearance to a user item.

--- a/src/app/preferences/pages/gt_moduledirectoriestab.ui
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GtModuleDirectoriesTab</class>
+ <widget class="QWidget" name="GtModuleDirectoriesTab">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>405</width>
+    <height>281</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="leftMargin">
+       <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>2</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
+      <item>
+       <widget class="QToolButton" name="btnAddDirectory">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>+</string>
+        </property>
+        <property name="icon">
+         <iconset theme="QIcon::ThemeIcon::ListAdd"/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnRemoveDirectory">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>-</string>
+        </property>
+        <property name="icon">
+         <iconset theme="QIcon::ThemeIcon::ListRemove"/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="directoriesList">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="spacing">
+      <number>2</number>
+     </property>
+     <property name="viewMode">
+      <enum>QListView::ListMode</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/app/preferences/pages/gt_moduledirectoriestab.ui
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.ui
@@ -101,6 +101,62 @@
        </widget>
       </item>
       <item>
+       <widget class="QToolButton" name="btnMoveUp">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Up</string>
+        </property>
+        <property name="icon">
+         <iconset theme="QIcon::ThemeIcon::GoUp"/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btnMoveDown">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Down</string>
+        </property>
+        <property name="icon">
+         <iconset theme="QIcon::ThemeIcon::GoDown"/>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/src/app/preferences/pages/gt_moduledirectoriestab.ui
+++ b/src/app/preferences/pages/gt_moduledirectoriestab.ui
@@ -169,6 +169,31 @@
         </property>
        </spacer>
       </item>
+      <item>
+       <widget class="QToolButton" name="btnHelpPrecedence">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="baseSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>?</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/app/preferences/pages/gt_preferencesapp.cpp
+++ b/src/app/preferences/pages/gt_preferencesapp.cpp
@@ -21,9 +21,12 @@
 #include "gt_logmodel.h"
 #include "gt_logging.h"
 #include "gt_icons.h"
+#include "gt_moduledirectoriestab.h"
 
 #include "gt_preferencesapp.h"
 #include <QStandardItemModel>
+
+#include <gt_moduleloader.h>
 
 #include <cassert>
 
@@ -146,6 +149,9 @@ GtPreferencesApp::GtPreferencesApp() :
 
     generalLayout->addStretch(1);
 
+    m_moduleDirsTab = new GtModuleDirectoriesTab;
+    tabWidget->addTab(m_moduleDirsTab, tr("Module Directories"));
+
     QWidget* processRunnerPage = new QWidget;
     auto idx = tabWidget->addTab(processRunnerPage, tr("Process Runner"));
 
@@ -235,9 +241,16 @@ GtPreferencesApp::saveSettings(GtSettings& settings) const
         settings.setThemeMode("system");
         gtApp->setDarkMode(settings.darkMode());
     }
+
+    settings.setUserModuleDirs(m_moduleDirsTab->userPaths());
 }
 
 void
-GtPreferencesApp::loadSettings(const GtSettings&)
+GtPreferencesApp::loadSettings(const GtSettings& settings)
 {
+    assert(m_moduleDirsTab);
+
+    m_moduleDirsTab->setDefaultInstallPath(GtModuleLoader::applicationModuleDir());
+    m_moduleDirsTab->setDefaultUserPath(GtModuleLoader::defaultUserModuleDir());
+    m_moduleDirsTab->setUserPaths(settings.userModuleDirs());
 }

--- a/src/app/preferences/pages/gt_preferencesapp.h
+++ b/src/app/preferences/pages/gt_preferencesapp.h
@@ -16,6 +16,7 @@
 class QCheckBox;
 class QSpinBox;
 class QComboBox;
+class GtModuleDirectoriesTab;
 
 /**
  * @brief The GtPreferencesApp class
@@ -65,6 +66,7 @@ private:
     /// Select the theme to use (by system, dark, bright)
     QComboBox* m_themeSelection;
 
+    GtModuleDirectoriesTab* m_moduleDirsTab;
 };
 
 #endif // GTPREFERENCESAPP_H

--- a/src/core/gt_coreapplication.cpp
+++ b/src/core/gt_coreapplication.cpp
@@ -595,6 +595,17 @@ GtCoreApplication::moduleDescription(const QString& id) const
 }
 
 QString
+GtCoreApplication::moduleLocation(const QString& id) const
+{
+    if (!m_moduleLoader)
+    {
+        return QString();
+    }
+
+    return m_moduleLoader->moduleLocation(id);
+}
+
+QString
 GtCoreApplication::moduleAuthor(const QString& id) const
 {
     if (!m_moduleLoader)

--- a/src/core/gt_coreapplication.h
+++ b/src/core/gt_coreapplication.h
@@ -342,6 +342,14 @@ public:
     QString moduleDescription(const QString& id) const;
 
     /**
+     * @brief Returns the location of the module
+     *
+     * @param module identification string
+     * @return Location / Path
+     */
+    QString moduleLocation(const QString& id) const;
+
+    /**
      * @brief Returns name of modules author for given id. Returns empty
      * string for non existing modules.
      * @param module identification string

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -36,8 +36,6 @@
 #include "gt_qtutilities.h"
 #include "gt_settings.h"
 
-#include <QDebug>
-
 namespace
 {
 
@@ -283,11 +281,9 @@ QStringList
 GtModuleLoader::customUserModuleDirs()
 {
     assert(gtApp);
-
     auto settings = gtApp->settings();
 
     assert(settings);
-
     return settings->userModuleDirs();
 }
 

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -282,11 +282,13 @@ GtModuleLoader::defaultUserModuleDir()
 QStringList
 GtModuleLoader::customUserModuleDirs()
 {
-    assert(gtApp && gtApp->settings());
+    assert(gtApp);
 
-    QStringList userModuleDirs = gtApp->settings()->userModuleDirs();
+    auto settings = gtApp->settings();
 
-    return userModuleDirs;
+    assert(settings);
+
+    return settings->userModuleDirs();
 }
 
 namespace

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -34,6 +34,9 @@
 #include "gt_algorithms.h"
 #include "gt_utilities.h"
 #include "gt_qtutilities.h"
+#include "gt_settings.h"
+
+#include <QDebug>
 
 namespace
 {
@@ -254,10 +257,9 @@ GtModuleLoader::GtModuleLoader() :
 
 GtModuleLoader::~GtModuleLoader() = default;
 
-namespace
-{
 
-QDir getModuleDirectory()
+QString
+GtModuleLoader::applicationModuleDir()
 {
 #ifndef Q_OS_ANDROID
     QString path = QCoreApplication::applicationDirPath() +
@@ -266,33 +268,93 @@ QDir getModuleDirectory()
     QString path = QCoreApplication::applicationDirPath();
 #endif
 
-    QDir modulesDir(path);
-#ifdef Q_OS_WIN
-    modulesDir.setNameFilters(QStringList() << QStringLiteral("*.dll"));
-#endif
+    return path;
+}
 
-    return modulesDir;
+QString
+GtModuleLoader::defaultUserModuleDir()
+{
+    if (!gtApp) return "";
+
+    return gtApp->roamingPath() + "/modules";
+}
+
+QStringList
+GtModuleLoader::customUserModuleDirs()
+{
+    assert(gtApp && gtApp->settings());
+
+    QStringList userModuleDirs = gtApp->settings()->userModuleDirs();
+
+    return userModuleDirs;
+}
+
+namespace
+{
+
+QList<QDir> getModuleDirectories()
+{
+    QList<QDir> moduleDirectories;
+
+    // application module dir
+    QDir applicationModules(GtModuleLoader::applicationModuleDir());
+    if  (applicationModules.exists())
+        moduleDirectories.append(applicationModules);
+
+    // user module dir
+    QDir userDir(GtModuleLoader::defaultUserModuleDir());
+    if (userDir.exists())
+        moduleDirectories.push_back(userDir);
+
+    for (auto&& md : GtModuleLoader::customUserModuleDirs())
+    {
+        // check if module dir is disabled
+        if (md.startsWith('#')) continue;
+
+        QDir moduleDirectory(md);
+        if (moduleDirectory.exists())
+            moduleDirectories.push_back(moduleDirectory);
+    }
+
+    for (auto&& dir : moduleDirectories)
+    {
+#ifdef Q_OS_WIN
+        dir.setNameFilters(QStringList() << QStringLiteral("*.dll"));
+#endif
+    }
+
+    return moduleDirectories;
 }
 
 QStringList getModuleFilenames()
 {
-    auto modulesDir = getModuleDirectory();
+    const auto dirs = getModuleDirectories();
 
-    if (!modulesDir.exists())
+    QStringList result;
+    QSet<QString> seen; // avoid duplicates across directories
+
+    for (const QDir& dir : dirs)
     {
-        return {};
+        if (!dir.exists())
+            continue;
+
+        // File names within each dir (respects any nameFilters set on the QDir, e.g., on Windows)
+        const auto files = dir.entryList(QDir::Files);
+
+
+        // Convert to absolute paths and add (deduplicated)
+        for (const auto& localFileName : files)
+        {
+            const QString absolute = dir.absoluteFilePath(localFileName);
+            if (!seen.contains(absolute))
+            {
+                seen.insert(absolute);
+                result << absolute;
+            }
+        }
     }
 
-    // file names in dir
-    auto files = modulesDir.entryList(QDir::Files);
-
-    // convert to absolute file names
-    std::transform(files.begin(), files.end(), files.begin(),
-                   [&modulesDir](const QString& localFileName) {
-        return modulesDir.absoluteFilePath(localFileName);
-    });
-
-    return files;
+    return result;
 }
 
 QStringList getModulesToExclude()
@@ -646,6 +708,20 @@ GtModuleLoader::moduleLicence(const QString& id) const
 
     return QString();
 }
+
+QString
+GtModuleLoader::moduleLocation(const QString& id) const
+{
+    auto it = m_pimpl->m_metaData.find(id);
+
+    if (it != m_pimpl->m_metaData.end())
+    {
+        return it->second.location();
+    }
+
+    return QString();
+}
+
 QString
 GtModuleLoader::modulePackageId(const QString& id) const
 {

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -325,16 +325,6 @@ QList<QDir> getModuleDirectories()
         }
     }
 
-    // application module dir
-    QDir applicationModules(GtModuleLoader::applicationModuleDir());
-    if  (applicationModules.exists())
-        moduleDirectories.append(applicationModules);
-
-    // user module dir
-    QDir userDir(GtModuleLoader::defaultUserModuleDir());
-    if (userDir.exists())
-        moduleDirectories.push_back(userDir);
-
     for (auto&& md : GtModuleLoader::customUserModuleDirs())
     {
         // check if module dir is disabled
@@ -344,6 +334,16 @@ QList<QDir> getModuleDirectories()
         if (moduleDirectory.exists())
             moduleDirectories.push_back(moduleDirectory);
     }
+
+    // user module dir
+    QDir userDir(GtModuleLoader::defaultUserModuleDir());
+    if (userDir.exists())
+        moduleDirectories.push_back(userDir);
+
+    // application module dir
+    QDir applicationModules(GtModuleLoader::applicationModuleDir());
+    if  (applicationModules.exists())
+        moduleDirectories.append(applicationModules);
 
     for (auto&& dir : moduleDirectories)
     {

--- a/src/core/gt_moduleloader.h
+++ b/src/core/gt_moduleloader.h
@@ -148,6 +148,34 @@ public:
      * @return module licence information
      */
     QString moduleLicence(const QString& id) const;
+
+    /**
+     * @brief Returns the location of the module
+     *
+     * @param module identification string
+     * @return Location / Path
+     */
+    QString moduleLocation(const QString& id) const;
+
+    /**
+     * @brief Returns the application module directory
+     */
+    static QString applicationModuleDir();
+
+    /**
+     * @brief Returns the user module directory.
+     *
+     * Note the directory might not yet exist
+     */
+    static QString defaultUserModuleDir();
+
+    /**
+     * @brief Returns user directories
+     *
+     * Module dirs starting with '#' should be ignored
+     */
+    static QStringList customUserModuleDirs();
+
 protected:
     /**
      * @brief check

--- a/src/core/gt_moduleloader.h
+++ b/src/core/gt_moduleloader.h
@@ -27,6 +27,12 @@ class GtVersionNumber;
 
 /**
  * @brief The GtModuleLoader class
+ *
+ * Module search order (first wins on collisions):
+ * - GTLAB_MODULE_DIRS (list separator by platform)
+ * - Application module dir
+ * - Default user module dir
+ * - User-defined module dirs (settings, in listed order)
  */
 class GT_CORE_EXPORT GtModuleLoader
 {

--- a/src/core/gt_moduleloader.h
+++ b/src/core/gt_moduleloader.h
@@ -30,9 +30,9 @@ class GtVersionNumber;
  *
  * Module search order (first wins on collisions):
  * - GTLAB_MODULE_DIRS (list separator by platform)
- * - Application module dir
- * - Default user module dir
  * - User-defined module dirs (settings, in listed order)
+ * - Default user module dir
+ * - Application module dir
  */
 class GT_CORE_EXPORT GtModuleLoader
 {

--- a/src/core/settings/gt_settings.cpp
+++ b/src/core/settings/gt_settings.cpp
@@ -18,8 +18,6 @@
 #include <QKeySequence>
 #include <QString>
 
-#include <gt_logging.h>
-
 struct GtSettings::Impl
 {
 
@@ -575,7 +573,7 @@ GtSettings::userModuleDirs() const
 }
 
 void
-GtSettings::setUserModuleDirs(const QStringList &dirs)
+GtSettings::setUserModuleDirs(const QStringList& dirs)
 {
     QString dirStr = dirs.join(";");
     pimpl->userModuleDirs->setValue(dirStr);

--- a/src/core/settings/gt_settings.cpp
+++ b/src/core/settings/gt_settings.cpp
@@ -18,6 +18,8 @@
 #include <QKeySequence>
 #include <QString>
 
+#include <gt_logging.h>
+
 struct GtSettings::Impl
 {
 
@@ -76,6 +78,9 @@ struct GtSettings::Impl
 
     /// Whether to autostart the process runner
     GtSettingsItem* m_autostartProcessRunner;
+
+    /// User module directories
+    GtSettingsItem* userModuleDirs;
 };
 
 GtSettings::GtSettings()
@@ -93,6 +98,10 @@ GtSettings::GtSettings()
                                  true);
     pimpl->lastPath = registerSetting(QStringLiteral("application/general/lastPath"),
                                  QStringLiteral(""));
+
+    pimpl->userModuleDirs = registerSettingRestart(
+        QStringLiteral("application/general/module_dirs"),
+        QLatin1String(""));
 
     pimpl->lastPerspective =
             registerSetting(
@@ -556,4 +565,18 @@ void
 GtSettings::setAutostartProcessRunner(bool value)
 {
     return pimpl->m_autostartProcessRunner->setValue(value);
+}
+
+QStringList
+GtSettings::userModuleDirs() const
+{
+    auto dirString = pimpl->userModuleDirs->getValue().toString();
+    return dirString.split(";", Qt::SkipEmptyParts);
+}
+
+void
+GtSettings::setUserModuleDirs(const QStringList &dirs)
+{
+    QString dirStr = dirs.join(";");
+    pimpl->userModuleDirs->setValue(dirStr);
 }

--- a/src/core/settings/gt_settings.h
+++ b/src/core/settings/gt_settings.h
@@ -377,6 +377,16 @@ public:
      */
     void setAutostartProcessRunner(bool value);
 
+    /**
+     * @brief Returns the module directories defined by the user
+     */
+    QStringList userModuleDirs() const;
+
+    /**
+     * @brief Sets the user module directories
+     */
+    void setUserModuleDirs(const QStringList& dirs);
+
 private:
 
     struct Impl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds the support for multiple module directories.

 - Module directories are stored in the settings
 - There is a default user and app directory, in addition to multiple user locations
 - The module location now is also displayed in the module about dialog
 - The module location is used to determine module meta data files (Changelog, Readme ...)
 - The environment variable GTLAB_MODULE_DIRS can be used to configure module directories as well.

## How Has This Been Tested?

<img width="573"  alt="grafik" src="https://github.com/user-attachments/assets/77f83e7e-130a-4460-9082-cfcd87091850" />

<img width="573" height="503" alt="grafik" src="https://github.com/user-attachments/assets/71560367-7851-4c4e-a878-cec2a548ccf3" />




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
