### PR TITLE
Include gtlabcmake from gtlabconfigcmake

### DIFF
--- a/cmake/GTlabConfig.cmake
+++ b/cmake/GTlabConfig.cmake
@@ -11,6 +11,7 @@ find_dependency(GTlabLogging)
 find_dependency(GenH5)
 
 include("${CMAKE_CURRENT_LIST_DIR}/GTlabTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/GTlab.cmake")
 
 # create aliases.
 if (NOT TARGET GTlab::DataProcessor)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->



## Description

This just adds an include of GTlab.cmake, such that the provided function (`add_gtlab_module` etc) are automatically included when GTlab was found by cmake.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
