### PR TITLE
Backported gtlab.cmake to improve transition to 2.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ windowsBuildDebug:
     - .build-win_20
     - .debugBuildRules
   script:
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DGTLAB_DEVTOOLS_DIR="$env:GTLAB_DEV_TOOLS" -DCMAKE_INSTALL_PREFIX=install-msvc2019-dbg -DBUILD_UNITTESTS=ON -DBUILD_TESTMODULES=ON
+    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DGTlabDevtools_ROOT="$env:GTLAB_DEV_TOOLS" -DCMAKE_INSTALL_PREFIX=install-msvc2019-dbg -DBUILD_UNITTESTS=ON -DBUILD_TESTMODULES=ON
     - cmake --build build --target install
   artifacts:
     paths:
@@ -86,7 +86,7 @@ windowsBuildRelease:
     - .build-win_20
     - .releaseBuildRules
   script:
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DGTLAB_DEVTOOLS_DIR="$env:GTLAB_DEV_TOOLS" -DCMAKE_INSTALL_PREFIX=install-msvc2019
+    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DGTlabDevtools_ROOT="$env:GTLAB_DEV_TOOLS" -DCMAKE_INSTALL_PREFIX=install-msvc2019
     - cmake --build build --target install
   artifacts:
     paths:
@@ -100,7 +100,7 @@ linuxBuildDebug:
     - .build-linux_20
     - .debugBuildRules
   script:
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DGTLAB_DEVTOOLS_DIR=$GTLAB_DEV_TOOLS -DCMAKE_INSTALL_PREFIX=install-linux-dbg -DBUILD_UNITTESTS=ON -DBUILD_WITH_COVERAGE=ON -DBUILD_TESTMODULES=ON
+    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DGTlabDevtools_ROOT=$GTLAB_DEV_TOOLS -DCMAKE_INSTALL_PREFIX=install-linux-dbg -DBUILD_UNITTESTS=ON -DBUILD_WITH_COVERAGE=ON -DBUILD_TESTMODULES=ON
     - cmake --build build --target install
   artifacts:
     paths:
@@ -120,7 +120,7 @@ linuxBuildRelease:
     - .build-linux_20
     - .releaseBuildRules
   script:
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DGTLAB_DEVTOOLS_DIR=$GTLAB_DEV_TOOLS -DCMAKE_INSTALL_PREFIX=install-linux
+    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DGTlabDevtools_ROOT=$GTLAB_DEV_TOOLS -DCMAKE_INSTALL_PREFIX=install-linux
     - cmake --build build --target install
   artifacts:
     paths:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(GTlab)
 
 gtlab_standard_setup()
-enable_gtlab_devtools()
+
+find_package(GTlabDevtools QUIET)
 
 find_package(Qt5 COMPONENTS Core Xml Network Widgets PrintSupport Svg Concurrent Qml QuickWidgets Test REQUIRED)
 

--- a/cmake/GTlab.cmake
+++ b/cmake/GTlab.cmake
@@ -206,8 +206,6 @@ function(require_qt)
         message(FATAL_ERROR "require_qt() called without COMPONENTS")
     endif()
 
-    message(STATUS "Find Qt Components" ${RQT_COMPONENTS})
-
     # --------------------------------------------------------
     # 1. Decide QT_VERSION_MAJOR once
     # --------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR backports changes of GTlab.cmake from master to 2.0.X. The rationale is to allow easier transition from 2.0.12 to 2.1.0.

In particular, this PR 
 - adds a require_qt function, that should be used by the modules instead of find_package(Qt..), to make sure to use the same Qt version as GTlab
 - Uses the devtools cmake package instead of hard-coding the paths to the third-party libraries

## How Has This Been Tested?

Locally and in the CI


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
