### PR TITLE
Add "projectAboutToBeSaved" signal to GtCoreDatamodel

### DIFF
--- a/src/core/gt_coredatamodel.cpp
+++ b/src/core/gt_coredatamodel.cpp
@@ -295,6 +295,8 @@ GtCoreDatamodel::saveProject(GtProject* project)
     // check session
     if (m_session)
     {
+        emit projectAboutToBeSaved(project);
+
         // save project data of given project
         retval = m_session->saveProjectData(project);
 

--- a/src/core/gt_coredatamodel.h
+++ b/src/core/gt_coredatamodel.h
@@ -378,11 +378,16 @@ private:
 
 signals:
     /**
+     * @brief Emitted immediately before a project is saved.
+     * @param project Project that is about to be saved.
+     */
+    void projectAboutToBeSaved(GtProject* project);
+
+    /**
      * @brief Emitted after successful project save.
      * @param project Saved project.
      */
     void projectSaved(GtProject* project);
-
 };
 
 template<typename ObjectList, typename GetNameFunc>

--- a/src/gui/gt_datamodel.cpp
+++ b/src/gui/gt_datamodel.cpp
@@ -168,6 +168,8 @@ GtDataModel::saveProject(GtProject *project)
     GtSaveProjectHelper* helper = new GtSaveProjectHelper(project);
     connect(helper, SIGNAL(finished()), SLOT(onProjectDataSaved()));
 
+    emit projectAboutToBeSaved(project);
+
     gtApp->loadingProcedure(helper);
 
     return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the `projectAboutToBeSaved()` signal to `GtCoreDatamodel`. It is emitted immediately before a project is saved, providing the possibility to push the current in-memory state of objects into the data model right before saving.
