### PR TITLE
Add GitHub Actions Linux coverage job with Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,59 @@ jobs:
         name: doc-devel
         path: |
           docs/html
+
+  coverage_linux:
+    name: "Coverage (linux)"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install dependencies (linux)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build lcov
+
+        wget https://gtlab.de/builddeps/hdf5-1.12.1-linux.tar.gz
+        mkdir -p $HOME/build_deps
+        tar xf hdf5-1.12.1-linux.tar.gz -C $HOME/build_deps
+        echo "HDF5_DIR=$HOME/build_deps/hdf5-1.12.1-linux/share/cmake/hdf5" >> $GITHUB_ENV
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '5.15.2'
+
+    - name: Configure
+      run: |
+        cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_UNITTESTS=ON \
+          -DBUILD_TESTMODULES=ON \
+          -DBUILD_WITH_COVERAGE=ON \
+          -DGTLAB_COVERAGE_LCOV_ARGS="--ignore-errors mismatch,mismatch,unused"
+
+    - name: Build and run coverage target
+      run: |
+        cmake --build build --target test-coverage
+
+    - name: Upload coverage report artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-lcov-info
+        path: build/test-coverage.info
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: build/test-coverage.info
+        flags: linux
+        name: linux-lcov
+        disable_search: true
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ option(BUILD_WITH_HDF5 "Build with hdf5 support" ON)
 option(BUILD_UNITTESTS "Build the unit tests" OFF)
 option(BUILD_WITH_COVERAGE "Build with code coverage (linux only)" OFF)
 option(BUILD_TESTMODULES "Build the test modules" OFF)
+set(GTLAB_COVERAGE_LCOV_ARGS ""
+    CACHE STRING "Additional arguments passed to lcov for the test-coverage target")
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -123,10 +125,14 @@ if (BUILD_UNITTESTS AND BUILD_WITH_COVERAGE)
       set(DEVTOOLS_DIR_EXCLUDE "${GTLAB_DEVTOOLS_DIR}/*")
     endif()
 
+    separate_arguments(GTLAB_COVERAGE_LCOV_ARGS_LIST NATIVE_COMMAND
+                       "${GTLAB_COVERAGE_LCOV_ARGS}")
+
     setup_target_for_coverage_lcov(
             NAME test-coverage
             EXECUTABLE GTlabUnitTest
-            EXCLUDE "tests/*" "build*" "/usr/*" "/opt/*" ${DEVTOOLS_DIR_EXCLUDE}
+            LCOV_ARGS ${GTLAB_COVERAGE_LCOV_ARGS_LIST}
+            EXCLUDE "tests/*" "build*" "src/gui/*" "/usr/*" "/opt/*" ${DEVTOOLS_DIR_EXCLUDE}
             BASE_DIRECTORY "${PROJECT_SOURCE_DIR}")
 endif()
 


### PR DESCRIPTION
  ## Description

  This PR adds a dedicated Linux coverage job to GitHub Actions and uploads the generated LCOV report to Codecov.

  It also makes additional lcov arguments configurable via GTLAB_COVERAGE_LCOV_ARGS and excludes src/gui/* from the generated coverage report, since that part of the codebase
  is not practical to cover reliably with the current unit test setup.

  ## How Has This Been Tested?

  - configured and ran the Linux coverage workflow
  - verified that the workflow generates build/test-coverage.info
  - verified that the coverage target runs successfully with the configured lcov arguments

  ## Checklist:

  - [ ] A test for the new functionality was added (if applicable).
  - [ ] All tests run without failure.
  - [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
  - [x] The new code complies with the GTlab's style guide.
  - [x] New interface methods / functions are exported via EXPORT. Non-interface functions are NOT exported.
  - [ ] The number of code quality warnings is not increasing.
