### PR TITLE
Improve object selection dialog filtering performance on large projects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,8 @@ ColumnLimit: 80
 PointerAlignment: Left
 MaxEmptyLinesToKeep: 2
 
+AllowShortIfStatementsOnASingleLine: WithoutElse
+
 
 # classes
 BreakConstructorInitializers: AfterColon 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Module updater get process model files to have the opportunity to modify process elements for new versions - #1414
 
 ### Fixed
+ - Improved performance of the object selection dialog filtering on large projects, especially during incremental search with broad type filters - #1454
  - Fixed alphabetically sorting of Shortcuts in Preference View #482
 
 ## [2.0.11] - 2025-04-03

--- a/src/core/gt_objectfiltermodel.cpp
+++ b/src/core/gt_objectfiltermodel.cpp
@@ -23,6 +23,7 @@ void
 GtObjectFilterModel::setFilterData(const QStringList& val)
 {
     m_filterData = val;
+    m_filterLookup = QSet<QString>(m_filterData.begin(), m_filterData.end());
     invalidate();
 }
 
@@ -64,8 +65,5 @@ GtObjectFilterModel::flags(const QModelIndex& index) const
 bool
 GtObjectFilterModel::acceptsRow(const char* ident) const
 {
-    return std::any_of(std::cbegin(m_filterData), std::cend(m_filterData),
-                       [qident = QString{ident}](const QString& str){
-        return qident == str;
-    });
+    return m_filterLookup.contains(QString::fromLatin1(ident));
 }

--- a/src/core/gt_objectfiltermodel.h
+++ b/src/core/gt_objectfiltermodel.h
@@ -16,6 +16,8 @@
 
 #include "gt_treefiltermodel.h"
 
+#include <QSet>
+
 /**
  * @brief The GtObjectFilterModel class
  */
@@ -56,6 +58,9 @@ protected:
 private:
     /// Filter data.
     QStringList m_filterData;
+
+    /// Hashed lookup for allowed class names.
+    QSet<QString> m_filterLookup;
 
     /**
      * @brief acceptRow

--- a/src/gui/tools/gt_objectselectiondialog.cpp
+++ b/src/gui/tools/gt_objectselectiondialog.cpp
@@ -9,8 +9,9 @@
  *  Tel.: +49 2203 601 2907
  */
 
-#include <QVBoxLayout>
 #include <QPushButton>
+#include <QVBoxLayout>
+
 
 #include "gt_icons.h"
 #include "gt_treeview.h"
@@ -24,9 +25,10 @@
 
 namespace
 {
-void expandVisibleBranches(QTreeView* treeView, const QAbstractItemModel* model,
-                           const QModelIndex& parent)
+int expandVisibleBranches(QTreeView* treeView, const QAbstractItemModel* model,
+                          const QModelIndex& parent)
 {
+    int expandedCount = 0;
     int rowCount = model->rowCount(parent);
 
     for (int row = 0; row < rowCount; ++row)
@@ -39,8 +41,11 @@ void expandVisibleBranches(QTreeView* treeView, const QAbstractItemModel* model,
         }
 
         treeView->setExpanded(child, true);
-        expandVisibleBranches(treeView, model, child);
+        ++expandedCount;
+        expandedCount += expandVisibleBranches(treeView, model, child);
     }
+
+    return expandedCount;
 }
 }
 

--- a/src/gui/tools/gt_objectselectiondialog.cpp
+++ b/src/gui/tools/gt_objectselectiondialog.cpp
@@ -185,7 +185,11 @@ GtObjectSelectionDialog::onDoubleClicked(const QModelIndex& index)
 void
 GtObjectSelectionDialog::filterData(const QString& val)
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     bool hadSearchText = !m_filterModel->filterRegExp().isEmpty();
+#else
+    bool hadSearchText = !m_filterModel->filterRegularExpression().pattern().isEmpty();
+#endif
 
     m_treeView->setUpdatesEnabled(false);
 
@@ -194,7 +198,11 @@ GtObjectSelectionDialog::filterData(const QString& val)
         m_treeView->collapseAll();
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     m_filterModel->setFilterRegExp(val);
+#else
+    m_filterModel->setFilterRegularExpression(val);
+#endif
 
     if (!val.isEmpty())
     {

--- a/src/gui/tools/gt_objectselectiondialog.cpp
+++ b/src/gui/tools/gt_objectselectiondialog.cpp
@@ -25,6 +25,8 @@
 
 namespace
 {
+constexpr int MaxAutoExpandMatches = 10;
+
 int expandVisibleBranches(QTreeView* treeView, const QAbstractItemModel* model,
                           const QModelIndex& parent)
 {
@@ -46,6 +48,41 @@ int expandVisibleBranches(QTreeView* treeView, const QAbstractItemModel* model,
     }
 
     return expandedCount;
+}
+
+int countEnabledMatches(const QAbstractItemModel* model,
+                        const QModelIndex& parent,
+                        int maxCount)
+{
+    int matches = 0;
+    int rowCount = model->rowCount(parent);
+
+    for (int row = 0; row < rowCount; ++row)
+    {
+        QModelIndex child = model->index(row, 0, parent);
+
+        if (!child.isValid())
+        {
+            continue;
+        }
+
+        if (model->flags(child) & Qt::ItemIsEnabled)
+        {
+            ++matches;
+            if (matches > maxCount)
+            {
+                return matches;
+            }
+        }
+
+        matches += countEnabledMatches(model, child, maxCount - matches);
+        if (matches > maxCount)
+        {
+            return matches;
+        }
+    }
+
+    return matches;
 }
 }
 
@@ -157,10 +194,25 @@ GtObjectSelectionDialog::GtObjectSelectionDialog(GtObject* root,
 }
 
 void
+GtObjectSelectionDialog::applyDefaultExpansion()
+{
+    int enabledMatches = countEnabledMatches(m_filterModel,
+                                             m_treeView->rootIndex(),
+                                             MaxAutoExpandMatches);
+    if (enabledMatches <= MaxAutoExpandMatches)
+    {
+        expandVisibleBranches(m_treeView, m_filterModel, m_treeView->rootIndex());
+        return;
+    }
+
+    m_treeView->expandToDepth(0);
+}
+
+void
 GtObjectSelectionDialog::setFilterData(const QStringList& filter)
 {
     m_filterModel->setFilterData(filter);
-    m_treeView->expandToDepth(0);
+    applyDefaultExpansion();
 }
 
 GtObject*
@@ -210,7 +262,7 @@ GtObjectSelectionDialog::filterData(const QString& val)
     }
     else if (hadSearchText)
     {
-        m_treeView->expandToDepth(0);
+        applyDefaultExpansion();
     }
 
     m_treeView->setUpdatesEnabled(true);

--- a/src/gui/tools/gt_objectselectiondialog.cpp
+++ b/src/gui/tools/gt_objectselectiondialog.cpp
@@ -22,6 +22,28 @@
 
 #include "gt_objectselectiondialog.h"
 
+namespace
+{
+void expandVisibleBranches(QTreeView* treeView, const QAbstractItemModel* model,
+                           const QModelIndex& parent)
+{
+    int rowCount = model->rowCount(parent);
+
+    for (int row = 0; row < rowCount; ++row)
+    {
+        QModelIndex child = model->index(row, 0, parent);
+
+        if (!child.isValid() || model->rowCount(child) == 0)
+        {
+            continue;
+        }
+
+        treeView->setExpanded(child, true);
+        expandVisibleBranches(treeView, model, child);
+    }
+}
+}
+
 GtObjectSelectionDialog::GtObjectSelectionDialog(GtObject* root,
                                                  QWidget* parent) :
     GtDialog(parent),
@@ -158,22 +180,26 @@ GtObjectSelectionDialog::onDoubleClicked(const QModelIndex& index)
 void
 GtObjectSelectionDialog::filterData(const QString& val)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     bool hadSearchText = !m_filterModel->filterRegExp().isEmpty();
-    m_filterModel->setFilterRegExp(val);
-#else
-    bool hadSearchText = !m_filterModel->filterRegularExpression().pattern().isEmpty();
-    m_filterModel->setFilterRegularExpression(val);
-#endif
 
-    bool hasSearchText = !val.isEmpty();
+    m_treeView->setUpdatesEnabled(false);
 
-    if (hasSearchText && !hadSearchText)
+    if (!val.isEmpty())
     {
-        m_treeView->expandAll();
+        m_treeView->collapseAll();
     }
-    else if (!hasSearchText && hadSearchText)
+
+    m_filterModel->setFilterRegExp(val);
+
+    if (!val.isEmpty())
+    {
+        expandVisibleBranches(m_treeView, m_filterModel, m_treeView->rootIndex());
+    }
+    else if (hadSearchText)
     {
         m_treeView->expandToDepth(0);
     }
+
+    m_treeView->setUpdatesEnabled(true);
+    m_treeView->viewport()->update();
 }

--- a/src/gui/tools/gt_objectselectiondialog.cpp
+++ b/src/gui/tools/gt_objectselectiondialog.cpp
@@ -36,6 +36,7 @@ GtObjectSelectionDialog::GtObjectSelectionDialog(GtObject* root,
 
     m_treeView = new GtTreeView(this);
     m_treeView->setFrameStyle(QTreeView::NoFrame);
+    m_treeView->setUniformRowHeights(true);
     lay->addWidget(m_treeView);
 
     auto* btnLay = new QHBoxLayout;
@@ -74,8 +75,6 @@ GtObjectSelectionDialog::GtObjectSelectionDialog(GtObject* root,
 
     connect(m_treeView, SIGNAL(doubleClicked(QModelIndex)),
             SLOT(onDoubleClicked(QModelIndex)));
-    connect(searchWidget, SIGNAL(textEdited(QString)),
-            SLOT(filterData(QString)));
     connect(searchWidget, SIGNAL(textChanged(QString)),
             SLOT(filterData(QString)));
     connect(m_treeView, SIGNAL(searchRequest()), searchWidget,
@@ -134,7 +133,7 @@ void
 GtObjectSelectionDialog::setFilterData(const QStringList& filter)
 {
     m_filterModel->setFilterData(filter);
-    m_treeView->expandAll();
+    m_treeView->expandToDepth(0);
 }
 
 GtObject*
@@ -164,5 +163,4 @@ GtObjectSelectionDialog::filterData(const QString& val)
 #else
     m_filterModel->setFilterRegularExpression(val);
 #endif
-    m_treeView->expandAll();
 }

--- a/src/gui/tools/gt_objectselectiondialog.cpp
+++ b/src/gui/tools/gt_objectselectiondialog.cpp
@@ -159,8 +159,21 @@ void
 GtObjectSelectionDialog::filterData(const QString& val)
 {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    bool hadSearchText = !m_filterModel->filterRegExp().isEmpty();
     m_filterModel->setFilterRegExp(val);
 #else
+    bool hadSearchText = !m_filterModel->filterRegularExpression().pattern().isEmpty();
     m_filterModel->setFilterRegularExpression(val);
 #endif
+
+    bool hasSearchText = !val.isEmpty();
+
+    if (hasSearchText && !hadSearchText)
+    {
+        m_treeView->expandAll();
+    }
+    else if (!hasSearchText && hadSearchText)
+    {
+        m_treeView->expandToDepth(0);
+    }
 }

--- a/src/gui/tools/gt_objectselectiondialog.cpp
+++ b/src/gui/tools/gt_objectselectiondialog.cpp
@@ -37,10 +37,7 @@ int expandVisibleBranches(QTreeView* treeView, const QAbstractItemModel* model,
     {
         QModelIndex child = model->index(row, 0, parent);
 
-        if (!child.isValid() || model->rowCount(child) == 0)
-        {
-            continue;
-        }
+        if (!child.isValid() || model->rowCount(child) == 0) continue;
 
         treeView->setExpanded(child, true);
         ++expandedCount;
@@ -61,25 +58,16 @@ int countEnabledMatches(const QAbstractItemModel* model,
     {
         QModelIndex child = model->index(row, 0, parent);
 
-        if (!child.isValid())
-        {
-            continue;
-        }
+        if (!child.isValid()) continue;
 
         if (model->flags(child) & Qt::ItemIsEnabled)
         {
             ++matches;
-            if (matches > maxCount)
-            {
-                return matches;
-            }
+            if (matches > maxCount) return matches;
         }
 
         matches += countEnabledMatches(model, child, maxCount - matches);
-        if (matches > maxCount)
-        {
-            return matches;
-        }
+        if (matches > maxCount) return matches;
     }
 
     return matches;

--- a/src/gui/tools/gt_objectselectiondialog.h
+++ b/src/gui/tools/gt_objectselectiondialog.h
@@ -52,6 +52,8 @@ public:
     GtObject* currentObject();
 
 private:
+    void applyDefaultExpansion();
+
     /// Root object.
     QPointer<GtObject> m_root;
 
@@ -66,6 +68,7 @@ private:
 
     /// Tree view.
     GtTreeView* m_treeView;
+
 
 private slots:
     /**

--- a/tests/unittests/core/test_gt_objectfiltermodel.cpp
+++ b/tests/unittests/core/test_gt_objectfiltermodel.cpp
@@ -1,0 +1,64 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#include <gtest/gtest.h>
+
+#include "gt_objectfiltermodel.h"
+#include "gt_objectgroup.h"
+#include "gt_objectmodel.h"
+#include "gt_styledmodel.h"
+
+#include "datamodel/test_propertycontainerobject.h"
+
+class ExposedObjectFilterModel : public GtObjectFilterModel
+{
+public:
+    using GtObjectFilterModel::flags;
+};
+
+TEST(TestGtObjectFilterModel, keepsAncestorPathVisibleAndDisablesNonMatchingAncestors)
+{
+    GtObjectGroup root;
+    root.setObjectName("root");
+
+    auto* parent = new GtObjectGroup;
+    parent->setObjectName("alpha");
+    ASSERT_TRUE(root.appendChild(parent));
+
+    auto* child = new TestObject;
+    child->setObjectName("project");
+    ASSERT_TRUE(parent->appendChild(child));
+
+    GtObjectModel srcModel;
+    srcModel.setRootObject(&root);
+
+    GtStyledModel styledModel;
+    styledModel.setSourceModel(&srcModel);
+
+    ExposedObjectFilterModel filterModel;
+    EXPECT_EQ(filterModel.flags(QModelIndex()), Qt::ItemFlags{});
+    filterModel.setSourceModel(&styledModel);
+    filterModel.setFilterData({"TestObject"});
+    filterModel.setFilterRegExp("pr");
+
+    QModelIndex srcRootIndex = srcModel.indexFromObject(&root);
+    QModelIndex styledRootIndex = styledModel.mapFromSource(srcRootIndex);
+    QModelIndex filterRootIndex = filterModel.mapFromSource(styledRootIndex);
+
+    ASSERT_TRUE(filterRootIndex.isValid());
+    ASSERT_EQ(filterModel.rowCount(filterRootIndex), 1);
+
+    QModelIndex parentIndex = filterModel.index(0, 0, filterRootIndex);
+    ASSERT_TRUE(parentIndex.isValid());
+    EXPECT_EQ(filterModel.data(parentIndex).toString(), QString("alpha"));
+    EXPECT_EQ(filterModel.rowCount(parentIndex), 1);
+    EXPECT_FALSE(filterModel.flags(parentIndex) & Qt::ItemIsEnabled);
+
+    QModelIndex childIndex = filterModel.index(0, 0, parentIndex);
+    ASSERT_TRUE(childIndex.isValid());
+    EXPECT_EQ(filterModel.data(childIndex).toString(), QString("project"));
+    EXPECT_TRUE(filterModel.flags(childIndex) & Qt::ItemIsEnabled);
+}

--- a/tests/unittests/core/test_gt_objectfiltermodel.cpp
+++ b/tests/unittests/core/test_gt_objectfiltermodel.cpp
@@ -42,7 +42,11 @@ TEST(TestGtObjectFilterModel, keepsAncestorPathVisibleAndDisablesNonMatchingAnce
     EXPECT_EQ(filterModel.flags(QModelIndex()), Qt::ItemFlags{});
     filterModel.setSourceModel(&styledModel);
     filterModel.setFilterData({"TestObject"});
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     filterModel.setFilterRegExp("pr");
+#else
+    filterModel.setFilterRegularExpression("pr");
+#endif
 
     QModelIndex srcRootIndex = srcModel.indexFromObject(&root);
     QModelIndex styledRootIndex = styledModel.mapFromSource(srcRootIndex);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

  This PR improves filtering performance in GtObjectSelectionDialog for large projects.

  The main speedup comes from changing the filter/update order in the dialog:

  - collapse the tree before applying a new search filter.
  - then expand only the visible branches afterwards
  - small result sets stay automatically expanded (i.e. if less than 11 results are found, the view keeps expanded)

  This avoids refiltering an already expanded large tree, which was the main reason incremental search became very slow after the first typed character.

  Additional small improvements:

  - use a hashed lookup for allowed object types in GtObjectFilterModel
  - remove duplicate search-trigger connections
  - enable uniform row heights for the dialog tree view

  A small unit test was also added for GtObjectFilterModel to cover the new core-side behavior.

 Fixes #1454.

## How Has This Been Tested?

  - manually tested on large projects with runtime instrumentation
  - verified that the dominant cost dropped from refiltering an expanded tree to acceptable collapse/expand work
  - verified that matches stay visible in the hierarchy while filtering
  - added and ran TestGtObjectFilterModel.*

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [x] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.
