### PR TITLE
Add REUSE license check to GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,19 @@ on:
 
 jobs:
 
+  check_license:
+    name: "License compliance"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install REUSE tool
+      run: python3 -m pip install reuse
+
+    - name: Run REUSE lint
+      run: reuse lint
+
   build_and_test:
     name: "Build and test"
     strategy:


### PR DESCRIPTION
## Description

This change adds a public GitHub Actions job that runs `reuse lint` as a license compliance check.

The goal is to mirror an existing internal CI safeguard in the public GitHub workflow so that REUSE/SPDX compliance is validated consistently for public pull requests and pushes as well. The corresponding license check already exists in the internal GitLab pipeline (`check-license`), and this change brings the public CI closer to that setup.

## How Has This Been Tested?

The workflow definition was reviewed against the existing internal GitLab job and added as a lightweight standalone job in `.github/workflows/ci.yml`.

The underlying license compliance check is already used internally via GitLab CI.

## Checklist:
- [ ] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [x] The number of code quality warnings is not increasing.
