### PR TITLE
Deprecate 'Custom' unit category

### DIFF
--- a/src/dataprocessor/gt_version.h
+++ b/src/dataprocessor/gt_version.h
@@ -82,4 +82,31 @@
     GT_REMOVAL_GUARD(maj, min, msg);       \
     GT_DEPRECATED_ATTR(maj, min, msg)
 
+// Warning suppression helpers for narrow compatibility shims.
+#if defined(_MSC_VER)
+    #define _GT_WARNING_PUSH_DEPRECATED __pragma(warning(push))
+    #define _GT_WARNING_POP_DEPRECATED  __pragma(warning(pop))
+    #define _GT_WARNING_DISABLE_DEPRECATED __pragma(warning(disable : 4996))
+#elif defined(__clang__)
+    #define _GT_WARNING_PUSH_DEPRECATED _Pragma("clang diagnostic push")
+    #define _GT_WARNING_POP_DEPRECATED  _Pragma("clang diagnostic pop")
+    #define _GT_WARNING_DISABLE_DEPRECATED \
+        _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif defined(__GNUC__)
+    #define _GT_WARNING_PUSH_DEPRECATED _Pragma("GCC diagnostic push")
+    #define _GT_WARNING_POP_DEPRECATED  _Pragma("GCC diagnostic pop")
+    #define _GT_WARNING_DISABLE_DEPRECATED \
+        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#else
+    #define GT_WARNING_PUSH_DEPRECATED
+    #define GT_WARNING_POP_DEPRECATED
+    #define GT_WARNING_DISABLE_DEPRECATED
+#endif
+
+#define GT_SUPPRESS_DEPRECATED_BEGIN \
+    _GT_WARNING_PUSH_DEPRECATED;        \
+    _GT_WARNING_DISABLE_DEPRECATED
+
+#define GT_SUPPRESS_DEPRECATED_END _GT_WARNING_POP_DEPRECATED
+
 #endif // GT_VERSION_H

--- a/src/dataprocessor/property/gt_unit.cpp
+++ b/src/dataprocessor/property/gt_unit.cpp
@@ -70,6 +70,12 @@ GtUnit::siUnit(Category c)
         return QString(QChar(0x03A9)); // omega
     case Category::Impedance:
         return QString(QChar(0x03A9)); // omega
+    case Category::HeatTransferCapability:
+        return QStringLiteral("W/K");
+    case Category::HeatTransferCoefficient:
+        return QStringLiteral("W/(m^2*K)");
+    case Category::ThermalConductivity:
+        return QStringLiteral("W/(m*K)");
     case Category::EnergyDensity:
         return QStringLiteral("J/kg");
     case Category::PowerDensity:

--- a/src/dataprocessor/property/gt_unit.cpp
+++ b/src/dataprocessor/property/gt_unit.cpp
@@ -156,6 +156,12 @@ GtUnit::categoryToString(Category c)
         return QStringLiteral("Resistance");
     case Category::Impedance:
         return QStringLiteral("Impedance");
+    case Category::HeatTransferCapability:
+        return QStringLiteral("Heat Transfer Capability");
+    case Category::HeatTransferCoefficient:
+        return QStringLiteral("Heat Transfer Coefficient");
+    case Category::ThermalConductivity:
+        return QStringLiteral("Thermal Conductivity");
     case Category::MassMomentInertia:
         return QObject::tr("Mass Moment of Inertia");
     case Category::EnergyDensity:

--- a/src/dataprocessor/property/gt_unit.cpp
+++ b/src/dataprocessor/property/gt_unit.cpp
@@ -7,6 +7,13 @@
 #include "gt_unit.h"
 #include <QObject>
 
+namespace
+{
+GT_SUPPRESS_DEPRECATED_BEGIN
+constexpr GtUnit::Category kDeprecatedCustomUnitCategory = GtUnit::Category::Custom;
+GT_SUPPRESS_DEPRECATED_END
+} // namespace
+
 QString
 GtUnit::siUnit(Category c)
 {
@@ -14,7 +21,7 @@ GtUnit::siUnit(Category c)
     {
     case Category::Area:
         return QStringLiteral("m^2");
-    case Category::Custom:
+    case kDeprecatedCustomUnitCategory:
         return QStringLiteral("-");
     case Category::Default:
         return QStringLiteral("-");
@@ -102,7 +109,7 @@ GtUnit::categoryToString(Category c)
     {
     case Category::Area:
         return QObject::tr("Area");
-    case Category::Custom:
+    case kDeprecatedCustomUnitCategory:
         return QObject::tr("Custom");
     case Category::Default:
         return QObject::tr("Default");

--- a/src/dataprocessor/property/gt_unit.h
+++ b/src/dataprocessor/property/gt_unit.h
@@ -52,6 +52,9 @@ public:
                    Current,
                    Resistance,
                    Impedance,
+                   HeatTransferCapability,
+                   HeatTransferCoefficient,
+                   ThermalConductivity,
                    /// non physical units
                    NonDimensionalPercentage = 64,
                    NonDimensional,

--- a/src/dataprocessor/property/gt_unit.h
+++ b/src/dataprocessor/property/gt_unit.h
@@ -43,7 +43,7 @@ public:
                    EnergyDensity,
                    PowerDensity,
                    PowerTempArea,
-                   Custom,
+                   Custom [[deprecated("Do not use Custom. It is not a valid unit category.")]],
                    MassMomentInertia,
                    VGVGradients,
                    VGVGradientsPow2,

--- a/src/dataprocessor/property/gt_unit.h
+++ b/src/dataprocessor/property/gt_unit.h
@@ -10,6 +10,7 @@
 #include "gt_datamodel_exports.h"
 
 #include <QString>
+#include "gt_version.h"
 
 class GT_DATAMODEL_EXPORT GtUnit
 {
@@ -43,7 +44,7 @@ public:
                    EnergyDensity,
                    PowerDensity,
                    PowerTempArea,
-                   Custom [[deprecated("Do not use Custom. It is not a valid unit category.")]],
+                   Custom GT_DEPRECATED_ATTR(2, 2, "Do not use Custom. It is not a valid unit category."),
                    MassMomentInertia,
                    VGVGradients,
                    VGVGradientsPow2,

--- a/src/dataprocessor/property/gt_unit.h
+++ b/src/dataprocessor/property/gt_unit.h
@@ -63,6 +63,7 @@ public:
                    /// no unit
                    None = 128
                   };
+    GT_REMOVAL_GUARD(2, 2, "Remove deprecated Custom category above!")
 
     GtUnit() = delete;
     ~GtUnit() = delete;

--- a/src/dataprocessor/property/gt_unitconverter.h
+++ b/src/dataprocessor/property/gt_unitconverter.h
@@ -580,6 +580,51 @@ void GtUnitConverter<T>::initialize()
 
     m_factorMap.insert(GtUnit::DataSize, dataSizeFac);
 
+    /** Heat Transfer Capcability **/
+    QMap<QString, double> heatTransfCap;
+    heatTransfCap["W/K"] = powerFac["W"] / temperatureFac["K"];
+    heatTransfCap["kW/K"] = powerFac["kW"] / temperatureFac["K"];
+    heatTransfCap["MW/K"] = powerFac["MW"] / temperatureFac["K"];
+    heatTransfCap["GW/K"] = powerFac["GW"] / temperatureFac["K"];
+    m_factorMap.insert(GtUnit::HeatTransferCapability, heatTransfCap);
+
+    /** Heat Transfer Coefficient **/
+    QMap<QString, double> heatTransfCof;
+    heatTransfCof["W/(m^2*K)"] = powerFac["W"]  / (areaFac["m^2"] * temperatureFac["K"]);
+    heatTransfCof["kW/(m^2*K)"] = powerFac["kW"] / (areaFac["m^2"] * temperatureFac["K"]);
+    heatTransfCof["MW/(m^2*K)"] = powerFac["MW"] / (areaFac["m^2"] * temperatureFac["K"]);
+    heatTransfCof["GW/(m^2*K)"] = powerFac["GW"] / (areaFac["m^2"] * temperatureFac["K"]);
+
+    heatTransfCof["W/(mm^2*K)"] = powerFac["W"]  / (areaFac["mm^2"] * temperatureFac["K"]);
+    heatTransfCof["kW/(mm^2*K)"] = powerFac["kW"] / (areaFac["mm^2"] * temperatureFac["K"]);
+    heatTransfCof["MW/(mm^2*K)"] = powerFac["MW"] / (areaFac["mm^2"] * temperatureFac["K"]);
+    heatTransfCof["GW/(mm^2*K)"] = powerFac["GW"] / (areaFac["mm^2"] * temperatureFac["K"]);
+
+    heatTransfCof["W/(cm^2*K)"] = powerFac["W"]  / (areaFac["cm^2"] * temperatureFac["K"]);
+    heatTransfCof["kW/(cm^2*K)"] = powerFac["kW"] / (areaFac["cm^2"] * temperatureFac["K"]);
+    heatTransfCof["MW/(cm^2*K)"] = powerFac["MW"] / (areaFac["cm^2"] * temperatureFac["K"]);
+    heatTransfCof["GW/(cm^2*K)"] = powerFac["GW"] / (areaFac["cm^2"] * temperatureFac["K"]);
+    m_factorMap.insert(GtUnit::HeatTransferCoefficient, heatTransfCof);
+    m_factorMap.insert(GtUnit::PowerTempArea, heatTransfCof);
+
+    /** Thermal conductivity **/
+    QMap<QString, double> thermalCond;
+    thermalCond["W/(m*K)"] = powerFac["W"]  / (lengthFac["m"] * temperatureFac["K"]);
+    thermalCond["kW/(m*K)"] = powerFac["kW"] / (lengthFac["m"] * temperatureFac["K"]);
+    thermalCond["MW/(m*K)"] = powerFac["MW"] / (lengthFac["m"] * temperatureFac["K"]);
+    thermalCond["GW/(m*K)"] = powerFac["GW"] / (lengthFac["m"] * temperatureFac["K"]);
+
+    thermalCond["W/(mm*K)"] = powerFac["W"]  / (lengthFac["mm"] * temperatureFac["K"]);
+    thermalCond["kW/(mm*K)"] = powerFac["kW"] / (lengthFac["mm"] * temperatureFac["K"]);
+    thermalCond["MW/(mm*K)"] = powerFac["MW"] / (lengthFac["mm"] * temperatureFac["K"]);
+    thermalCond["GW/(mm*K)"] = powerFac["GW"] / (lengthFac["mm"] * temperatureFac["K"]);
+
+    thermalCond["W/(cm*K)"] = powerFac["W"]  / (lengthFac["cm"] * temperatureFac["K"]);
+    thermalCond["kW/(cm*K)"] = powerFac["kW"] / (lengthFac["cm"] * temperatureFac["K"]);
+    thermalCond["MW/(cm*K)"] = powerFac["MW"] / (lengthFac["cm"] * temperatureFac["K"]);
+    thermalCond["GW/(cm*K)"] = powerFac["GW"] / (lengthFac["cm"] * temperatureFac["K"]);
+    m_factorMap.insert(GtUnit::ThermalConductivity, thermalCond);
+
 
     /** Non Dimensional Percentage **/
 

--- a/src/dataprocessor/property/gt_unitconverter.h
+++ b/src/dataprocessor/property/gt_unitconverter.h
@@ -149,7 +149,7 @@ T GtUnitConverter<T>::To(GtUnit::Category category,
 
 template<class T>
 void GtUnitConverter<T>::initialize()
-{
+{ 
     /** LENGTH **/
 
     QMap<QString, double> lengthFac;

--- a/src/dataprocessor/property/gt_unitconverter.h
+++ b/src/dataprocessor/property/gt_unitconverter.h
@@ -773,7 +773,12 @@ void GtUnitConverter<T>::initialize()
 
 
 
+    // Keep the deprecated category registered for backwards compatibility
+    // until the 2.2 removal, without leaking deprecation warnings into every
+    // translation unit that includes this header.
+    GT_SUPPRESS_DEPRECATED_BEGIN;
     m_factorMap.insert(GtUnit::Custom, customFac);
+    GT_SUPPRESS_DEPRECATED_END;
 }
 
 

--- a/tests/modules/datamodel_interface/data/test_dmi_data.cpp
+++ b/tests/modules/datamodel_interface/data/test_dmi_data.cpp
@@ -36,7 +36,16 @@ TestDmiData::TestDmiData() :
                          GtUnit::Resistance, 1.0),
     m_electricImpedance("Impedance", "Impedance",
                         "Impedance value to use in Example",
-                        GtUnit::Impedance, 1.0)
+                        GtUnit::Impedance, 1.0),
+    m_heatTransferCapability("heatTransferCapability", "heatTransferCapability",
+                             "heatTransferCapability value to use in Example",
+                      GtUnit::HeatTransferCapability, 1.0),
+    m_heatTransferCoefficient("heatTransferCoefficient", "heatTransferCoefficient",
+                         "heatTransferCoefficient value to use in Example",
+                         GtUnit::HeatTransferCoefficient, 1.0),
+    m_thermalConductivity("thermalConductivity", "thermalConductivity",
+                        "thermalConductivity to use in Example",
+                        GtUnit::ThermalConductivity, 1.0)
 {
     setObjectName("Internal_Data");
     setFlag(UserDeletable);
@@ -100,4 +109,9 @@ TestDmiData::TestDmiData() :
     registerProperty(m_electricCurrent);
     registerProperty(m_electricResistance);
     registerProperty(m_electricImpedance);
+
+    registerProperty(m_heatTransferCapability);
+    registerProperty(m_heatTransferCoefficient);
+    registerProperty(m_thermalConductivity);
+
 }

--- a/tests/modules/datamodel_interface/data/test_dmi_data.h
+++ b/tests/modules/datamodel_interface/data/test_dmi_data.h
@@ -53,6 +53,9 @@ private:
     GtDoubleProperty m_electricCurrent;
     GtDoubleProperty m_electricResistance;
     GtDoubleProperty m_electricImpedance;
+    GtDoubleProperty m_heatTransferCapability;
+    GtDoubleProperty m_heatTransferCoefficient;
+    GtDoubleProperty m_thermalConductivity;
 };
 
 #endif // TESTDMICLASS_H

--- a/tests/unittests/datamodel/test_gt_unitconverter.cpp
+++ b/tests/unittests/datamodel/test_gt_unitconverter.cpp
@@ -4184,3 +4184,150 @@ TEST_F(TestGtUnitConverter, convertImpedanceFrom)
     ASSERT_DOUBLE_EQ(valMOmega, 14000000);
 }
 
+/// HeatTransferCapability
+TEST_F(TestGtUnitConverter, convertHeatTransferCapability)
+{
+    GtUnit::Category cat = GtUnit::HeatTransferCapability;
+
+    QString siUnit = GtUnit::siUnit(cat);
+    QString catString = GtUnit::categoryToString(cat);
+
+    // check default si unit
+    ASSERT_STREQ(siUnit.toStdString().c_str(),
+                 QString("W/K").toStdString().c_str());
+
+    // check default string
+    ASSERT_STREQ(catString.toStdString().c_str(), "Heat Transfer Capability");
+}
+
+TEST_F(TestGtUnitConverter, convertHeatTransferCapabilityTo)
+{
+    GtUnit::Category cat = GtUnit::HeatTransferCapability;
+
+    // input
+    double val = 1.3;
+    bool check = false;
+
+    // convert
+    double value = m_conv->To(cat, "kW/K", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 0.0013);
+
+    value = m_conv->To(cat, "MW/K", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 0.0000013);
+
+    value = m_conv->To(cat, "GW/K", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 0.0000000013);
+}
+
+TEST_F(TestGtUnitConverter, convertHeatTransferCapabilityFrom)
+{
+    GtUnit::Category cat = GtUnit::HeatTransferCapability;
+
+    // input
+    double val = 14.;
+    bool check = false;
+
+    // convert
+    double value = m_conv->from(cat, "kW/K", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 14000.);
+
+    value = m_conv->from(cat, "MW/K", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 14000000.);
+
+    value = m_conv->from(cat, "GW/K", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 14000000000.);
+}
+
+/// HeatTransferCoefficient
+TEST_F(TestGtUnitConverter, convertHeatTransferCoefficient)
+{
+    GtUnit::Category cat = GtUnit::HeatTransferCoefficient;
+
+    QString siUnit = GtUnit::siUnit(cat);
+    QString catString = GtUnit::categoryToString(cat);
+
+    // check default si unit
+    ASSERT_STREQ(siUnit.toStdString().c_str(),
+                 QString("W/(m^2*K)").toStdString().c_str());
+
+    // check default string
+    ASSERT_STREQ(catString.toStdString().c_str(), "Heat Transfer Coefficient");
+}
+
+TEST_F(TestGtUnitConverter, convertHeatTransferCoefficientTo)
+{
+    GtUnit::Category cat = GtUnit::HeatTransferCoefficient;
+
+    // input
+    double val = 1.3;
+    bool check = false;
+
+    // convert
+    double value = m_conv->To(cat, "kW/(m^2*K)", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 0.0013);
+}
+
+TEST_F(TestGtUnitConverter, convertHeatTransferCoefficientFrom)
+{
+    GtUnit::Category cat = GtUnit::HeatTransferCoefficient;
+
+    // input
+    double val = 14.;
+    bool check = false;
+
+    // convert
+    double value = m_conv->from(cat, "kW/(m^2*K)", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 14000.);
+}
+
+/// HeatTransferCoefficient
+TEST_F(TestGtUnitConverter, convertThermalConductivity)
+{
+    GtUnit::Category cat = GtUnit::ThermalConductivity;
+
+    QString siUnit = GtUnit::siUnit(cat);
+    QString catString = GtUnit::categoryToString(cat);
+
+    // check default si unit
+    ASSERT_STREQ(siUnit.toStdString().c_str(),
+                 QString("W/(m*K)").toStdString().c_str());
+
+    // check default string
+    ASSERT_STREQ(catString.toStdString().c_str(), "Thermal Conductivity");
+}
+
+TEST_F(TestGtUnitConverter, convertThermalConductivityTo)
+{
+    GtUnit::Category cat = GtUnit::ThermalConductivity;
+
+    // input
+    double val = 1.3;
+    bool check = false;
+
+    // convert
+    double value = m_conv->To(cat, "kW/(m*K)", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 0.0013);
+}
+
+TEST_F(TestGtUnitConverter, convertThermalConductivityFrom)
+{
+    GtUnit::Category cat = GtUnit::ThermalConductivity;
+
+    // input
+    double val = 14.;
+    bool check = false;
+
+    // convert
+    double value = m_conv->from(cat, "kW/(m*K)", val, &check);
+    ASSERT_TRUE(check);
+    ASSERT_DOUBLE_EQ(value, 14000.);
+}

--- a/tests/unittests/datamodel/test_gt_unitconverter.cpp
+++ b/tests/unittests/datamodel/test_gt_unitconverter.cpp
@@ -4331,3 +4331,34 @@ TEST_F(TestGtUnitConverter, convertThermalConductivityFrom)
     ASSERT_TRUE(check);
     ASSERT_DOUBLE_EQ(value, 14000.);
 }
+
+/// Custom - this test is added for code coverage
+TEST_F(TestGtUnitConverter, convert_deprecated_custom)
+{
+    GtUnit::Category cat = GtUnit::Custom;
+
+    QString siUnit = GtUnit::siUnit(cat);
+    QString catString = GtUnit::categoryToString(cat);
+
+    // check default si unit
+    ASSERT_STREQ(siUnit.toStdString().c_str(), "-");
+
+    // check default string
+    ASSERT_STREQ(catString.toStdString().c_str(), "Custom");
+}
+
+/// Default
+TEST_F(TestGtUnitConverter, convert_default)
+{
+    GtUnit::Category cat = GtUnit::Default;
+
+    QString siUnit = GtUnit::siUnit(cat);
+    QString catString = GtUnit::categoryToString(cat);
+
+    // check default si unit
+    ASSERT_STREQ(siUnit.toStdString().c_str(), "-");
+
+    // check default string
+    ASSERT_STREQ(catString.toStdString().c_str(), "Default");
+}
+


### PR DESCRIPTION
The unit type custom is a mess.
There are a lot of unit conversion registered which have nothing in common. 
Overall the unit-type should be avoided.

Therefore a first step is to mark the enum entry as deprecated.
I spoke with users of "GtUnit::Custom" and for their needs to replace it with a more meaningfull alternative.

This alternatives are meant to be added by this PR aswell

## Description
- Mark GtUnit::Custom as deprecated to avoid further usage
- Add more unit types to handle heat transfer and related topics

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.


Note:
Overall I think it would be beneficial to start a unit-interface. For more usecases of GTlab the number of needed units will be increasing. Currently unit definitions can only be added to the core
