### PR TITLE
Improve connection editor to check compatibility of object link and double properties

### DIFF
--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -20,6 +20,8 @@
 #include "gt_processconnectionitem.h"
 #include "gt_processpropertyportentity.h"
 #include "gt_stringmonitoringproperty.h"
+#include "gt_objectlinkproperty.h"
+#include "gt_doubleproperty.h"
 
 #include "gt_colors.h"
 
@@ -33,6 +35,55 @@ bool areStringClassesCompatible(const QString& classA, const QString& classB)
             classB == GT_CLASSNAME(GtStringProperty)) ||
            (classA == GT_CLASSNAME(GtStringProperty) &&
             classB == GT_CLASSNAME(GtStringMonitoringProperty));
+}
+
+/**
+ * @brief checks if the units of the properties are compatible
+ * @return true in case of identical si units or if one of the properties has
+ * no or nondimension unit (to avoid problems with python defined values)
+ */
+bool areUnitCompatible(const GtAbstractProperty* prop,
+                       const GtAbstractProperty* prop2)
+{
+    if (prop->siUnit().isEmpty() || prop->siUnit() == "-") return true;
+
+    if (prop2->siUnit().isEmpty() || prop2->siUnit() == "-") return true;
+
+
+    return prop->siUnit() == prop2->siUnit();
+}
+
+/**
+ * @brief checks if the possible object link targets are matchable
+ * @return true if there is a compatibility in at least one possible class
+ * This is meant to catch early problems in completly
+ *  uncompatible link definitions
+ */
+bool areObjectLinksCompatible(const GtAbstractProperty* prop,
+                              const GtAbstractProperty* prop2)
+{
+    if (!prop || !prop2) return false;
+
+    auto* olp = qobject_cast<const GtObjectLinkProperty*>(prop);
+    auto* olp2 = qobject_cast<const GtObjectLinkProperty*>(prop2);
+
+    if (!olp || !olp2) return false;
+
+    QStringList list1 = olp->allowedClasses();
+
+    for (auto& s1 : list1)
+    {
+        if (olp2->isAllowed(s1)) return true;
+    }
+
+    QStringList list2 = olp2->allowedClasses();
+
+    for (auto& s2 : list2)
+    {
+        if (olp->isAllowed(s2)) return true;
+    }
+
+    return false;
 }
 
 }
@@ -172,35 +223,17 @@ bool
 GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
 {
     // check port
-    if (!port)
-    {
-        return false;
-    }
+    if (!port) return false;
 
-    if (port == this)
-    {
-        return false;
-    }
+    if (port == this) return false;
 
-    if (port->portType() == portType())
-    {
-        return false;
-    }
+    if (port->portType() == portType()) return false;
 
     if (m_type == GtProcessPropertyPortEntity::INPUT_PORT)
     {
-        if (isConnected())
-        {
-            return false;
-        }
+        if (isConnected()) return false;
     }
-    else
-    {
-        if (port->isConnected())
-        {
-            return false;
-        }
-    }
+    else if (port->isConnected()) return false;
 
     if (propertyValue().typeName() != port->propertyValue().typeName())
     {
@@ -216,9 +249,24 @@ GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
         }
     }
 
-    if (parentComponentUuid() == port->parentComponentUuid())
+    if (parentComponentUuid() == port->parentComponentUuid()) return false;
+
+    if (propertyClassName() == GT_CLASSNAME(GtObjectLinkProperty) &&
+        port->propertyClassName() == GT_CLASSNAME(GtObjectLinkProperty))
     {
-        return false;
+        const GtAbstractProperty* prop = m_item->property();
+        const GtAbstractProperty* prop2 = port->m_item->property();
+
+        if (!areObjectLinksCompatible(prop, prop2)) return false;
+    }
+
+    if (propertyClassName() == GT_CLASSNAME(GtDoubleProperty) &&
+        port->propertyClassName() == GT_CLASSNAME(GtDoubleProperty))
+    {
+        const GtAbstractProperty* prop = m_item->property();
+        const GtAbstractProperty* prop2 = port->m_item->property();
+
+        if (!areUnitCompatible(prop, prop2)) return false;
     }
 
     return true;

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -255,7 +255,7 @@ GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
     if (propertyClassName() == GT_CLASSNAME(GtObjectLinkProperty) &&
         port->propertyClassName() == GT_CLASSNAME(GtObjectLinkProperty))
     {
-        if (!m_item || port->m_item) return false;
+        if (!m_item || !port->m_item) return false;
 
         const GtAbstractProperty* prop = m_item->property();
         const GtAbstractProperty* prop2 = port->m_item->property();
@@ -266,7 +266,7 @@ GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
     if (propertyClassName() == GT_CLASSNAME(GtDoubleProperty) &&
         port->propertyClassName() == GT_CLASSNAME(GtDoubleProperty))
     {
-        if (!m_item || port->m_item) return false;
+        if (!m_item || !port->m_item) return false;
 
         const GtAbstractProperty* prop = m_item->property();
         const GtAbstractProperty* prop2 = port->m_item->property();

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -45,10 +45,11 @@ bool areStringClassesCompatible(const QString& classA, const QString& classB)
 bool areUnitCompatible(const GtAbstractProperty* prop,
                        const GtAbstractProperty* prop2)
 {
+    if (!prop || !prop2) return false;
+
     if (prop->siUnit().isEmpty() || prop->siUnit() == "-") return true;
 
     if (prop2->siUnit().isEmpty() || prop2->siUnit() == "-") return true;
-
 
     return prop->siUnit() == prop2->siUnit();
 }
@@ -254,6 +255,8 @@ GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
     if (propertyClassName() == GT_CLASSNAME(GtObjectLinkProperty) &&
         port->propertyClassName() == GT_CLASSNAME(GtObjectLinkProperty))
     {
+        if (!m_item || port->m_item) return false;
+
         const GtAbstractProperty* prop = m_item->property();
         const GtAbstractProperty* prop2 = port->m_item->property();
 
@@ -263,6 +266,8 @@ GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
     if (propertyClassName() == GT_CLASSNAME(GtDoubleProperty) &&
         port->propertyClassName() == GT_CLASSNAME(GtDoubleProperty))
     {
+        if (!m_item || port->m_item) return false;
+
         const GtAbstractProperty* prop = m_item->property();
         const GtAbstractProperty* prop2 = port->m_item->property();
 

--- a/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
@@ -424,3 +424,9 @@ GtProcessConnectionItem::itemById(const QString& uuid, const QString& propId)
 
     return nullptr;
 }
+
+QPointer<GtAbstractProperty>
+GtProcessConnectionItem::property() const
+{
+    return m_property;
+}

--- a/src/app/mdi_items/process_env/gt_processconnectionitem.h
+++ b/src/app/mdi_items/process_env/gt_processconnectionitem.h
@@ -99,6 +99,10 @@ public:
     GtProcessConnectionItem* itemById(const QString& uuid,
                                       const QString& propId);
 
+
+
+    QPointer<GtAbstractProperty> property() const;
+
 private:
     /// Pointer to process component
     QPointer<GtProcessComponent> m_component;

--- a/src/app/mdi_items/process_env/gt_processconnectionitem.h
+++ b/src/app/mdi_items/process_env/gt_processconnectionitem.h
@@ -99,8 +99,10 @@ public:
     GtProcessConnectionItem* itemById(const QString& uuid,
                                       const QString& propId);
 
-
-
+    /**
+     * @brief returns the related proptery
+     * @return a qpointer of the related property
+     */
     QPointer<GtAbstractProperty> property() const;
 
 private:

--- a/src/app/mdi_items/process_env/gt_processconnectionscene.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectionscene.cpp
@@ -229,10 +229,7 @@ QList<GtProcessPropertyPortEntity*>
 GtProcessConnectionScene::validPorts(GtProcessPropertyPortEntity* activePort)
 {
     // check active port
-    if (!activePort)
-    {
-        return QList<GtProcessPropertyPortEntity*>();
-    }
+    if (!activePort) return {};
 
     QList<GtProcessPropertyPortEntity*> retval =
             findItems<GtProcessPropertyPortEntity*>();


### PR DESCRIPTION
The connection editor allows connections between properties of the same type. Sometimes it might be helpfull to make more restirctions. 
Therefore in the PR the connection of object links checks if object links are at least in one class compatible.
Additionally double properties checks for the same unit. This is ignored if at least one of the units is None or Nonedimensional to avoid problems with values from python-process elements

## Description
- checks are extended for the mentioned configurations
- the process connection item added a public getter to the related abstract property

## How Has This Been Tested?
Manual GUI tests in larger process setups


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Improve process connection validation by enforcing compatibility checks for object link and double properties when connecting ports.

New Features:
- Restrict connections between object link properties to those with at least one compatible target class.
- Restrict connections between double properties to those sharing the same unit, while allowing unitless or nondimensional values for interoperability with Python-defined elements.

Enhancements:
- Expose the associated abstract property from process connection items via a new public getter.
- Simplify connection and valid-port checks with early returns in the process connection scene and port entity logic.