### PR TITLE
Cleanup of mdi actions which are related to elements of other modules

### DIFF
--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -39,6 +39,11 @@
 #include "gt_algorithms.h"
 #include "gt_maintoolbar.h"
 #include "gt_iconbrowser.h"
+#include "gt_mementoviewer.h"
+#include "gt_stateviewer.h"
+#include "gt_examplesmdiwidget.h"
+#include "gt_sessionviewer.h"
+#include "gt_startuppage.h"
 
 #include <QDir>
 #include <QKeyEvent>
@@ -515,7 +520,7 @@ GtMainWin::showProjectWizard()
         if (!gtDataModel->newProject(project, true))
         {
             delete project;
-            gtError() << "Created project can not be added to session. Abort";
+            gtError() << tr("Created project can not be added to session. Abort");
             return;
         }
         else
@@ -557,7 +562,7 @@ GtMainWin::importProject()
     }
     else
     {
-        gtWarning() << "Cannot open the project";
+        gtWarning() << tr("Cannot open the project");
     }
 }
 
@@ -672,30 +677,16 @@ GtMainWin::updatePerspectiveList()
 }
 
 void
-GtMainWin::openMapEditor()
-{
-    gtMdiLauncher->open("GtMapEditor");
-}
-
-void
 GtMainWin::openMementoViewer()
 {
-    gtMdiLauncher->open("GtMementoViewer");
+    gtMdiLauncher->open(GT_CLASSNAME(GtMementoViewer));
 }
 
-void
-GtMainWin::openPreDesignPlot()
-{
-    if (!gtMdiLauncher->open("GtdPreDesignPlot"))
-    {
-        gtWarning() << tr("Could not open pre design plot!");
-    }
-}
 
 void
 GtMainWin::openSessionViewer()
 {
-    if (!gtMdiLauncher->open("GtSessionViewer"))
+    if (!gtMdiLauncher->open(GT_CLASSNAME(GtSessionViewer)))
     {
         gtWarning() << tr("Could not open session viewer!");
     }
@@ -704,7 +695,7 @@ GtMainWin::openSessionViewer()
 void
 GtMainWin::openStateViewer()
 {
-    if (!gtMdiLauncher->open("GtStateViewer"))
+    if (!gtMdiLauncher->open(GT_CLASSNAME(GtStateViewer)))
     {
         gtWarning() << tr("Could not open state viewer!");
     }
@@ -713,7 +704,7 @@ GtMainWin::openStateViewer()
 void
 GtMainWin::openExamplesWidget()
 {
-    if (!gtMdiLauncher->open("GtExamplesMdiWidget"))
+    if (!gtMdiLauncher->open(GT_CLASSNAME(GtExamplesMdiWidget)))
     {
         gtWarning() << tr("Could not open examples viewer!");
     }
@@ -840,7 +831,8 @@ GtMainWin::printCurrentMdiItem()
     }
     else
     {
-        QMessageBox::information(nullptr, "Print error", "No view open!",
+        QMessageBox::information(nullptr, tr("Print error"),
+                                 tr("No view open!"),
                                  QMessageBox::Ok);
     }
 }
@@ -1106,7 +1098,7 @@ GtMainWin::initAfterStartup()
     // open startup page
     if (gtApp->settings()->showStartupPage())
     {
-        gtMdiLauncher->open("GtStartupPage");
+        gtMdiLauncher->open(GT_CLASSNAME(GtStartupPage));
     }
 
     // search for updates

--- a/src/app/gt_mainwin.h
+++ b/src/app/gt_mainwin.h
@@ -184,11 +184,6 @@ private slots:
     void openMementoViewer();
 
     /**
-     * @brief Just a test method
-     */
-    void openPreDesignPlot();
-
-    /**
      * @brief openSessionViewer
      */
     void openSessionViewer();

--- a/src/app/gt_mainwin.h
+++ b/src/app/gt_mainwin.h
@@ -179,11 +179,6 @@ private slots:
     void updatePerspectiveList();
 
     /**
-     * @brief openMapEditor
-     */
-    void openMapEditor();
-
-    /**
      * @brief openMementoViewer
      */
     void openMementoViewer();


### PR DESCRIPTION
There are several hard coded MDI names in the GtMainWin.
Some of them are even not part of the core repo. This should be fixed to make the code more robust.

## Description
- The strings of the class names are replaced by the GT_CLASSNAME-Macro.
  This helps to avoid unexpected behaviour in case of implementation changes
- The elements for editors of other modules were removed. They should not be part of the core main window, as the names may change and they were even not used anymore here.
- Some tr()- statements were added where missing

## How Has This Been Tested?
Manual in the GUI.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Refine main window MDI handling and messaging to rely on class macros and remove obsolete actions.

Bug Fixes:
- Localize previously hard-coded error and information messages in the main window.

Enhancements:
- Replace hard-coded MDI class name strings with the GT_CLASSNAME macro for core viewers and startup page to make MDI launching more robust against implementation changes.
- Remove the unused map editor action from the main window API and implementation.
- Update UI message boxes to use translatable strings for print and project-related errors.