### PR TITLE
Improve const interface for categoryString function of abstractproperty

### DIFF
--- a/src/dataprocessor/property/gt_abstractproperty.cpp
+++ b/src/dataprocessor/property/gt_abstractproperty.cpp
@@ -90,7 +90,7 @@ GtAbstractProperty::setCategory(const QString& cat)
 }
 
 QString
-GtAbstractProperty::categoryToString()
+GtAbstractProperty::categoryString() const
 {
     switch (m_category)
     {
@@ -101,6 +101,12 @@ GtAbstractProperty::categoryToString()
     default:
         return QObject::tr("Main");
     }
+}
+
+QString
+GtAbstractProperty::categoryToString()
+{
+    return categoryString();
 }
 
 const QList<GtAbstractProperty*>&

--- a/src/dataprocessor/property/gt_abstractproperty.cpp
+++ b/src/dataprocessor/property/gt_abstractproperty.cpp
@@ -103,12 +103,6 @@ GtAbstractProperty::categoryString() const
     }
 }
 
-QString
-GtAbstractProperty::categoryToString()
-{
-    return categoryString();
-}
-
 const QList<GtAbstractProperty*>&
 GtAbstractProperty::properties() const
 {

--- a/src/dataprocessor/property/gt_abstractproperty.h
+++ b/src/dataprocessor/property/gt_abstractproperty.h
@@ -130,7 +130,7 @@ public:
      * @brief categoryToString
      * @return
      */
-    [[deprecated("Use categoryString() instead.")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use categoryString() instead")
     inline QString categoryToString()
     {
         return categoryString();

--- a/src/dataprocessor/property/gt_abstractproperty.h
+++ b/src/dataprocessor/property/gt_abstractproperty.h
@@ -128,7 +128,6 @@ public:
 
     /**
      * @brief categoryToString
-     * @param cat
      * @return
      */
     [[deprecated("Use categoryString() instead.")]]

--- a/src/dataprocessor/property/gt_abstractproperty.h
+++ b/src/dataprocessor/property/gt_abstractproperty.h
@@ -132,7 +132,10 @@ public:
      * @return
      */
     [[deprecated("Use categoryString() instead.")]]
-    QString categoryToString();
+    inline QString categoryToString()
+    {
+        return categoryString();
+    }
 
     /**
      * @brief properties

--- a/src/dataprocessor/property/gt_abstractproperty.h
+++ b/src/dataprocessor/property/gt_abstractproperty.h
@@ -121,10 +121,17 @@ public:
     void setCategory(const QString& cat);
 
     /**
+     * @brief categoryString
+     * @return category string of the property
+     */
+    QString categoryString() const;
+
+    /**
      * @brief categoryToString
      * @param cat
      * @return
      */
+    [[deprecated("Use categoryString() instead.")]]
     QString categoryToString();
 
     /**

--- a/src/gui/dock_widgets/properties/gt_propertymodel.cpp
+++ b/src/gui/dock_widgets/properties/gt_propertymodel.cpp
@@ -767,7 +767,7 @@ GtPropertyModel::addProperty(GtAbstractProperty* prop)
 {
     using namespace std;
 
-    QString catId = prop->categoryToString();
+    QString catId = prop->categoryString();
     GtPropertyCategoryItem* cat = nullptr;
 
     auto catIter = std::find_if(begin(m_properties), end(m_properties),

--- a/tests/unittests/datamodel/test_gt_property.cpp
+++ b/tests/unittests/datamodel/test_gt_property.cpp
@@ -83,8 +83,6 @@ TEST(TestGtProperty, categoryString)
 
     /// check default category
     EXPECT_STREQ(boolProp->categoryString().toStdString().c_str(), "Main");
-    /// check identical result in deprecated function
-    EXPECT_STREQ(boolProp->categoryToString().toStdString().c_str(), "Main");
 
     EXPECT_TRUE(boolProp->category() ==
                 GtAbstractProperty::PropertyCategory::Main);
@@ -93,8 +91,6 @@ TEST(TestGtProperty, categoryString)
 
     /// check identical result in deprecated function
     EXPECT_STREQ(boolProp->categoryString().toStdString().c_str(),
-                 "MyFancyCategory");
-    EXPECT_STREQ(boolProp->categoryToString().toStdString().c_str(),
                  "MyFancyCategory");
 
     EXPECT_TRUE(boolProp->category() ==

--- a/tests/unittests/datamodel/test_gt_property.cpp
+++ b/tests/unittests/datamodel/test_gt_property.cpp
@@ -75,3 +75,28 @@ TEST(TestGtProperty, makeComplexProperty)
     EXPECT_TRUE(hiddenProp->isHidden());
     EXPECT_TRUE(hiddenProp->isReadOnly());
 }
+
+TEST(TestGtProperty, categoryString)
+{
+    auto factory = gt::makeBoolProperty(true);
+    std::unique_ptr<GtAbstractProperty> boolProp(factory("bla"));
+
+    /// check default category
+    EXPECT_STREQ(boolProp->categoryString().toStdString().c_str(), "Main");
+    /// check identical result in deprecated function
+    EXPECT_STREQ(boolProp->categoryToString().toStdString().c_str(), "Main");
+
+    EXPECT_TRUE(boolProp->category() ==
+                GtAbstractProperty::PropertyCategory::Main);
+
+    boolProp->setCategory("MyFancyCategory");
+
+    /// check identical result in deprecated function
+    EXPECT_STREQ(boolProp->categoryString().toStdString().c_str(),
+                 "MyFancyCategory");
+    EXPECT_STREQ(boolProp->categoryToString().toStdString().c_str(),
+                 "MyFancyCategory");
+
+    EXPECT_TRUE(boolProp->category() ==
+                GtAbstractProperty::PropertyCategory::Custom);
+}


### PR DESCRIPTION
As suggested by @mariusalexander the categoryToString function is deprecated and a categoryString function which is const is implemented as a replacment

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Deprecate the old non-const property category string accessor in favor of a new const-safe interface and update usages accordingly.

Enhancements:
- Introduce a const-qualified categoryString() accessor on GtAbstractProperty for retrieving the category as a string while keeping the existing categoryToString() as a deprecated wrapper.
- Update property model code to use the new categoryString() accessor instead of the deprecated categoryToString().