### PR TITLE
Removed deprecated member m_taskName

### DIFF
--- a/src/gui/gt_finishedprocessloadinghelper.h
+++ b/src/gui/gt_finishedprocessloadinghelper.h
@@ -68,11 +68,8 @@ private:
     /// pointer to summed diff object (result)
     std::unique_ptr<GtObjectMementoDiff> m_sumDiff;
 
-    /// source object to buil diff
+    /// source object to build diff
     QPointer<GtObject> m_source;
-
-    /// Name of the task: used to give the used command a suitable name
-    [[deprecated("unused")]] QString m_taskName;
 };
 
 #endif // GTFINISHEDPROCESSLOADINGHELPER_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This simply removes the member m_taskName, which is not used anymore and just kept as a placeholder for ABI compatibility.

Closes #1470


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Remove an unused deprecated member from the finished process loading helper and fix a minor comment typo.

Enhancements:
- Remove the deprecated m_taskName member from GtFinishedProcessLoadingHelper now that it is no longer used.

Chores:
- Fix a spelling mistake in a comment in GtFinishedProcessLoadingHelper.