### PR TITLE
Checks for gtApp validity before dark mode is checked

### DIFF
--- a/src/app/dialogs/gt_checkforupdatesdialog.cpp
+++ b/src/app/dialogs/gt_checkforupdatesdialog.cpp
@@ -20,7 +20,7 @@
 #include <QHeaderView>
 #include <QFont>
 
-#include "gt_application.h"
+#include "gt_guiutilities.h"
 #include "gt_updatechecker.h"
 #include "gt_logging.h"
 #include "gt_icons.h"
@@ -161,7 +161,7 @@ GtCheckForUpdatesDialog::updateAvailable()
     m_checkButton->setEnabled(true);
 
     QString fontString = "darkgreen";
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         fontString = "green";
     }
@@ -224,7 +224,7 @@ GtCheckForUpdatesDialog::noUpdateAvailable(int errorCode, const QString& str)
             << "Update check: " << str << " (Error code: " << errorCode << ')';
 
     QString fontString = "darkred";
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         fontString = "red";
     }

--- a/src/app/dialogs/gt_checkforupdatesdialog.cpp
+++ b/src/app/dialogs/gt_checkforupdatesdialog.cpp
@@ -161,7 +161,7 @@ GtCheckForUpdatesDialog::updateAvailable()
     m_checkButton->setEnabled(true);
 
     QString fontString = "darkgreen";
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         fontString = "green";
     }
@@ -224,7 +224,7 @@ GtCheckForUpdatesDialog::noUpdateAvailable(int errorCode, const QString& str)
             << "Update check: " << str << " (Error code: " << errorCode << ')';
 
     QString fontString = "darkred";
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         fontString = "red";
     }

--- a/src/app/mdi_items/examples/gt_examplegraphicalitem.cpp
+++ b/src/app/mdi_items/examples/gt_examplegraphicalitem.cpp
@@ -17,9 +17,9 @@
 #include <QLabel>
 #include <QFile>
 
-#include "gt_application.h"
 #include "gt_examplesentry.h"
 #include "gt_dialog.h"
+#include "gt_guiutilities.h"
 #include "gt_logging.h"
 #include "gt_icons.h"
 
@@ -53,7 +53,7 @@ GtExampleGraphicalItem::GtExampleGraphicalItem(GtExamplesEntry data,
 
     m_picFrame = new QFrame;
 
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         m_picFrame->setStyleSheet(
                     "QWidget { border: 1px solid gray;"

--- a/src/app/mdi_items/examples/gt_examplegraphicalitem.cpp
+++ b/src/app/mdi_items/examples/gt_examplegraphicalitem.cpp
@@ -53,7 +53,7 @@ GtExampleGraphicalItem::GtExampleGraphicalItem(GtExamplesEntry data,
 
     m_picFrame = new QFrame;
 
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         m_picFrame->setStyleSheet(
                     "QWidget { border: 1px solid gray;"

--- a/src/gui/dock_widgets/process/pages/gt_processoverviewmodel.cpp
+++ b/src/gui/dock_widgets/process/pages/gt_processoverviewmodel.cpp
@@ -9,7 +9,7 @@
  *  Tel.: +49 2203 601 2907
  */
 
-#include "gt_application.h"
+#include "gt_guiutilities.h"
 #include "gt_processcategoryitem.h"
 #include "gt_icons.h"
 #include "gt_logging.h"
@@ -104,7 +104,7 @@ GtProcessOverviewModel::data(const QModelIndex& index, int role) const
                 break;
 
             case Qt::BackgroundRole:
-                if (!gtApp->inDarkMode())
+                if (!gt::gui::isApplicationDarkTheme())
                 {
                     return gt::gui::color::main();
                 }
@@ -143,7 +143,7 @@ GtProcessOverviewModel::data(const QModelIndex& index, int role) const
             case Qt::ForegroundRole:
                 if (col == 1)
                 {
-                    if (!gtApp->inDarkMode())
+                    if (!gt::gui::isApplicationDarkTheme())
                     {
                         return gt::gui::color::disabled();
                     }

--- a/src/gui/gt_colors.cpp
+++ b/src/gui/gt_colors.cpp
@@ -38,7 +38,10 @@ QColor
 gt::gui::color::lighten(const QColor& color, int amount)
 {
     constexpr int limit = std::numeric_limits<uint8_t>::max();
-    int offset = (gtApp->inDarkMode() ? -1 : 1) * amount;
+
+    bool dark = gtApp && gtApp->inDarkMode();
+
+    int offset = (dark ? -1 : 1) * amount;
 
     QColor c = color;
     c.setRed(gt::clamp(c.red() + offset, 0, limit));
@@ -87,8 +90,9 @@ gt::gui::color::textHighlight()
 QColor
 gt::gui::color::frame()
 {
+    bool dark = gtApp && gtApp->inDarkMode();
     return lighten(currentTheme().color(QPalette::WindowText),
-                   gtApp->inDarkMode() ? 80 : 110);
+                   dark ? 80 : 110);
 }
 
 QColor
@@ -100,7 +104,7 @@ gt::gui::color::lightFrame()
 QColor
 gt::gui::color::titleLabelBackground()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::black;
     }
@@ -110,7 +114,7 @@ gt::gui::color::titleLabelBackground()
 QColor
 gt::gui::color::infoLabelBackground()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::black;
     }
@@ -127,7 +131,7 @@ gt::gui::color::basicDark()
 QColor
 gt::gui::color::dummyObjectBackground()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor{255, 130, 25};
@@ -140,7 +144,7 @@ gt::gui::color::dummyObjectBackground()
 QColor
 gt::gui::color::newObjectForeground()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return {Qt::green};
     }
@@ -151,7 +155,7 @@ gt::gui::color::newObjectForeground()
 QColor
 gt::gui::color::changedObjectForeground()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(Qt::blue).lighter();
     }
@@ -204,7 +208,7 @@ gt::gui::color::fatalTextBackground()
 QColor
 gt::gui::color::collectionAvailableItemBackground()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor{89, 110, 93};
@@ -231,7 +235,7 @@ gt::gui::color::environmentModelBack()
 QColor
 gt::gui::color::debugText()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(Qt::gray).lighter(120);
     }
@@ -253,7 +257,7 @@ gt::gui::color::setPaintertoGray(QPainter* painter)
         painter->setPen(QPen(QColor(70, 70, 70), 1.5));
         painter->setBrush(Qt::white);
 
-        if (gtApp->inDarkMode())
+        if (gtApp && gtApp->inDarkMode())
         {
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
             painter->setPen(QPen(QColor(170, 170, 170), 1.5));
@@ -281,7 +285,7 @@ gt::gui::color::gridLineMinor()
 QColor
 gt::gui::color::gridLine()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor(25, 25, 25, 255);
@@ -308,7 +312,7 @@ gt::gui::color::gridAxis()
 QColor
 gt::gui::color::code_editor::highlightLine()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor(160, 160, 0);
@@ -321,7 +325,7 @@ gt::gui::color::code_editor::highlightLine()
 QColor
 gt::gui::color::xml_highlight::syntaxChar()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(235, 160, 50);
     }
@@ -332,7 +336,7 @@ gt::gui::color::xml_highlight::syntaxChar()
 QColor
 gt::gui::color::xml_highlight::elementName()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(190, 35, 35);
     }
@@ -343,7 +347,7 @@ gt::gui::color::xml_highlight::elementName()
 QColor
 gt::gui::color::xml_highlight::comment()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::green;
     }
@@ -354,7 +358,7 @@ gt::gui::color::xml_highlight::comment()
 QColor
 gt::gui::color::xml_highlight::attributeName()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::red;
     }
@@ -365,7 +369,7 @@ gt::gui::color::xml_highlight::attributeName()
 QColor
 gt::gui::color::xml_highlight::attributeValue()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(100, 200, 255);
     }
@@ -376,7 +380,7 @@ gt::gui::color::xml_highlight::attributeValue()
 QColor
 gt::gui::color::xml_highlight::error()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::magenta;
     }
@@ -387,7 +391,7 @@ gt::gui::color::xml_highlight::error()
 QColor
 gt::gui::color::xml_highlight::other()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(200, 200, 200);
     }
@@ -452,7 +456,7 @@ gt::gui::color::js_highlight::marker()
 QColor
 gt::gui::color::connection_editor::connection()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::lightGray;
     }
@@ -462,7 +466,7 @@ gt::gui::color::connection_editor::connection()
 QColor
 gt::gui::color::connection_editor::connectionDraft()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(98, 182, 230);
     }
@@ -472,7 +476,7 @@ gt::gui::color::connection_editor::connectionDraft()
 QColor
 gt::gui::color::connection_editor::portBackground()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(69, 130, 162);
     }
@@ -482,7 +486,7 @@ gt::gui::color::connection_editor::portBackground()
 QColor
 gt::gui::color::connection_editor::portHover()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::lightGray;
     }
@@ -492,7 +496,7 @@ gt::gui::color::connection_editor::portHover()
 QColor
 gt::gui::color::connection_editor::connectionHighlight()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::red;
     }
@@ -502,7 +506,7 @@ gt::gui::color::connection_editor::connectionHighlight()
 QColor
 gt::gui::color::plots::activeLine()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(Qt::blue).lighter();
     }
@@ -518,7 +522,7 @@ gt::gui::color::plots::inactiveLine()
 QColor
 gt::gui::color::plots::helpingLine()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(Qt::red).lighter();
     }
@@ -528,7 +532,7 @@ gt::gui::color::plots::helpingLine()
 QColor
 gt::gui::color::plots::marker()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QColor(Qt::red).lighter();
     }
@@ -544,7 +548,7 @@ gt::gui::color::plots::selectedMarker()
 QColor
 gt::gui::color::plots::markerBorder()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return Qt::gray;
     }

--- a/src/gui/gt_colors.cpp
+++ b/src/gui/gt_colors.cpp
@@ -10,7 +10,7 @@
  */
 
 #include "gt_colors.h"
-#include "gt_application.h"
+#include "gt_guiutilities.h"
 #include "gt_palette.h"
 #include "gt_utilities.h"
 
@@ -39,7 +39,7 @@ gt::gui::color::lighten(const QColor& color, int amount)
 {
     constexpr int limit = std::numeric_limits<uint8_t>::max();
 
-    bool dark = gtApp && gtApp->inDarkMode();
+    bool dark = gt::gui::isApplicationDarkTheme();
 
     int offset = (dark ? -1 : 1) * amount;
 
@@ -90,7 +90,7 @@ gt::gui::color::textHighlight()
 QColor
 gt::gui::color::frame()
 {
-    bool dark = gtApp && gtApp->inDarkMode();
+    bool dark = gt::gui::isApplicationDarkTheme();
     return lighten(currentTheme().color(QPalette::WindowText),
                    dark ? 80 : 110);
 }
@@ -104,7 +104,7 @@ gt::gui::color::lightFrame()
 QColor
 gt::gui::color::titleLabelBackground()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::black;
     }
@@ -114,7 +114,7 @@ gt::gui::color::titleLabelBackground()
 QColor
 gt::gui::color::infoLabelBackground()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::black;
     }
@@ -131,7 +131,7 @@ gt::gui::color::basicDark()
 QColor
 gt::gui::color::dummyObjectBackground()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor{255, 130, 25};
@@ -144,7 +144,7 @@ gt::gui::color::dummyObjectBackground()
 QColor
 gt::gui::color::newObjectForeground()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return {Qt::green};
     }
@@ -155,7 +155,7 @@ gt::gui::color::newObjectForeground()
 QColor
 gt::gui::color::changedObjectForeground()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(Qt::blue).lighter();
     }
@@ -208,7 +208,7 @@ gt::gui::color::fatalTextBackground()
 QColor
 gt::gui::color::collectionAvailableItemBackground()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor{89, 110, 93};
@@ -235,7 +235,7 @@ gt::gui::color::environmentModelBack()
 QColor
 gt::gui::color::debugText()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(Qt::gray).lighter(120);
     }
@@ -257,7 +257,7 @@ gt::gui::color::setPaintertoGray(QPainter* painter)
         painter->setPen(QPen(QColor(70, 70, 70), 1.5));
         painter->setBrush(Qt::white);
 
-        if (gtApp && gtApp->inDarkMode())
+        if (gt::gui::isApplicationDarkTheme())
         {
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
             painter->setPen(QPen(QColor(170, 170, 170), 1.5));
@@ -285,7 +285,7 @@ gt::gui::color::gridLineMinor()
 QColor
 gt::gui::color::gridLine()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor(25, 25, 25, 255);
@@ -312,7 +312,7 @@ gt::gui::color::gridAxis()
 QColor
 gt::gui::color::code_editor::highlightLine()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
         return QColor(160, 160, 0);
@@ -325,7 +325,7 @@ gt::gui::color::code_editor::highlightLine()
 QColor
 gt::gui::color::xml_highlight::syntaxChar()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(235, 160, 50);
     }
@@ -336,7 +336,7 @@ gt::gui::color::xml_highlight::syntaxChar()
 QColor
 gt::gui::color::xml_highlight::elementName()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(190, 35, 35);
     }
@@ -347,7 +347,7 @@ gt::gui::color::xml_highlight::elementName()
 QColor
 gt::gui::color::xml_highlight::comment()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::green;
     }
@@ -358,7 +358,7 @@ gt::gui::color::xml_highlight::comment()
 QColor
 gt::gui::color::xml_highlight::attributeName()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::red;
     }
@@ -369,7 +369,7 @@ gt::gui::color::xml_highlight::attributeName()
 QColor
 gt::gui::color::xml_highlight::attributeValue()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(100, 200, 255);
     }
@@ -380,7 +380,7 @@ gt::gui::color::xml_highlight::attributeValue()
 QColor
 gt::gui::color::xml_highlight::error()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::magenta;
     }
@@ -391,7 +391,7 @@ gt::gui::color::xml_highlight::error()
 QColor
 gt::gui::color::xml_highlight::other()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(200, 200, 200);
     }
@@ -456,7 +456,7 @@ gt::gui::color::js_highlight::marker()
 QColor
 gt::gui::color::connection_editor::connection()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::lightGray;
     }
@@ -466,7 +466,7 @@ gt::gui::color::connection_editor::connection()
 QColor
 gt::gui::color::connection_editor::connectionDraft()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(98, 182, 230);
     }
@@ -476,7 +476,7 @@ gt::gui::color::connection_editor::connectionDraft()
 QColor
 gt::gui::color::connection_editor::portBackground()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(69, 130, 162);
     }
@@ -486,7 +486,7 @@ gt::gui::color::connection_editor::portBackground()
 QColor
 gt::gui::color::connection_editor::portHover()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::lightGray;
     }
@@ -496,7 +496,7 @@ gt::gui::color::connection_editor::portHover()
 QColor
 gt::gui::color::connection_editor::connectionHighlight()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::red;
     }
@@ -506,7 +506,7 @@ gt::gui::color::connection_editor::connectionHighlight()
 QColor
 gt::gui::color::plots::activeLine()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(Qt::blue).lighter();
     }
@@ -522,7 +522,7 @@ gt::gui::color::plots::inactiveLine()
 QColor
 gt::gui::color::plots::helpingLine()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(Qt::red).lighter();
     }
@@ -532,7 +532,7 @@ gt::gui::color::plots::helpingLine()
 QColor
 gt::gui::color::plots::marker()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QColor(Qt::red).lighter();
     }
@@ -548,7 +548,7 @@ gt::gui::color::plots::selectedMarker()
 QColor
 gt::gui::color::plots::markerBorder()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return Qt::gray;
     }

--- a/src/gui/gt_guiutilities.cpp
+++ b/src/gui/gt_guiutilities.cpp
@@ -352,3 +352,19 @@ gt::gui::handleObjectKeyEvent(QKeyEvent& event,
 
     shortcutAction(event, obj);
 }
+
+gt::gui::applicationTheme
+gt::gui::theme()
+{
+    if (!gtApp) return applicationTheme::bright;
+
+    if (gtApp->inDarkMode()) return applicationTheme::dark;
+
+    return applicationTheme::bright;
+}
+
+bool
+gt::gui::isApplicationDarkTheme()
+{
+    return theme() == applicationTheme::dark;
+}

--- a/src/gui/gt_guiutilities.h
+++ b/src/gui/gt_guiutilities.h
@@ -14,6 +14,7 @@
 #include <QModelIndex>
 
 #include "gt_gui_exports.h"
+#include "gt_version.h"
 
 class QMenu;
 class QKeyEvent;
@@ -27,6 +28,29 @@ namespace gt
 
 namespace gui
 {
+/**
+ * @brief The theme enum
+ */
+enum class applicationTheme {
+    bright = 0,
+    dark = 1,
+    invalid = 32
+};
+
+/**
+ * @brief return the current theme of the application
+ *
+ * @return the value of the theme enum and bright as default for
+ * invalid or undefined setups
+ */
+GT_GUI_EXPORT gt::gui::applicationTheme theme();
+
+/**
+ * @brief function to check for dark theme
+ * @return true if the current theme of the application is
+ * the basic dark theme
+ */
+GT_GUI_EXPORT bool isApplicationDarkTheme();
 
 /**
  * @brief Appends the actions to the menu.

--- a/src/gui/gt_icons.cpp
+++ b/src/gui/gt_icons.cpp
@@ -10,7 +10,7 @@
  */
 #include "gt_icons.h"
 #include "gt_colors.h"
-#include "gt_application.h"
+#include "gt_guiutilities.h"
 #include "gt_logging.h"
 #include "gt_svgiconengine.h"
 
@@ -646,7 +646,7 @@ gt::gui::icon::processRunningIcon(int progress)
 QString
 gt::gui::pixmap::backgroundPath()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QStringLiteral(":/pixmaps/startup-background_dark.png");
     }
@@ -657,7 +657,7 @@ gt::gui::pixmap::backgroundPath()
 QString
 gt::gui::pixmap::logoString()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return QStringLiteral(":/pixmaps/gt-logo-dark.png");
     }

--- a/src/gui/gt_icons.cpp
+++ b/src/gui/gt_icons.cpp
@@ -646,7 +646,7 @@ gt::gui::icon::processRunningIcon(int progress)
 QString
 gt::gui::pixmap::backgroundPath()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QStringLiteral(":/pixmaps/startup-background_dark.png");
     }
@@ -657,7 +657,7 @@ gt::gui::pixmap::backgroundPath()
 QString
 gt::gui::pixmap::logoString()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return QStringLiteral(":/pixmaps/gt-logo-dark.png");
     }

--- a/src/gui/style/gt_palette.cpp
+++ b/src/gui/style/gt_palette.cpp
@@ -23,7 +23,7 @@
 QPalette
 gt::gui::currentTheme()
 {
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return darkTheme();
     }

--- a/src/gui/style/gt_palette.cpp
+++ b/src/gui/style/gt_palette.cpp
@@ -11,9 +11,9 @@
 #include "gt_palette.h"
 
 #include "gt_colors.h"
+#include "gt_guiutilities.h"
 #include "gt_style.h"
 #include "gt_stylesheets.h"
-#include "gt_application.h"
 
 #include <QSettings>
 #include <QWidget>
@@ -23,7 +23,7 @@
 QPalette
 gt::gui::currentTheme()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return darkTheme();
     }

--- a/src/gui/style/gt_style.cpp
+++ b/src/gui/style/gt_style.cpp
@@ -13,6 +13,7 @@
 #include "gt_icons.h"
 #include "gt_application.h"
 #include "gt_palette.h"
+#include "gt_guiutilities.h"
 
 #include <QStyleFactory>
 #include <QWizard>
@@ -26,7 +27,7 @@ using namespace gt::gui;
 
 GtStyle::GtStyle() :
     QProxyStyle(QStyleFactory::create(
-        gtApp->inDarkMode() ?
+        gt::gui::isApplicationDarkTheme() ?
             QStringLiteral("Fusion") :
 #ifndef Q_OS_WIN
             QStringLiteral("Default")
@@ -218,7 +219,7 @@ public:
     /// Returns the current style
     GtStyle& currentStyle() const
     {
-        const auto currentStyleMode = gtApp->inDarkMode();
+        const auto currentStyleMode = gt::gui::isApplicationDarkTheme();
         const auto styleIter = map.find(currentStyleMode);
 
         // we need to create new styles on the fly, as GtStyle cannot be set to a specific style

--- a/src/gui/style/gt_stylesheets.cpp
+++ b/src/gui/style/gt_stylesheets.cpp
@@ -10,7 +10,7 @@
  */
 
 #include "gt_stylesheets.h"
-#include "gt_application.h"
+#include "gt_guiutilities.h"
 #include "gt_icons.h"
 #include "gt_colors.h"
 #include "gt_svgiconengine.h"
@@ -94,7 +94,7 @@ gt::gui::stylesheet::processRunButton(RunButtonState const& state)
 {
     QColor backgroundColor;
 
-    bool dark = gtApp && gtApp->inDarkMode();
+    bool dark = gt::gui::isApplicationDarkTheme();
 
     switch (state)
     {
@@ -125,7 +125,7 @@ gt::gui::stylesheet::processRunButton(RunButtonState const& state)
 QString
 comboBoxHelper(const QString& width = {})
 {
-    bool dark = gtApp && gtApp->inDarkMode();
+    bool dark = gt::gui::isApplicationDarkTheme();
 
     return QStringLiteral(
             "QComboBox {"
@@ -170,7 +170,7 @@ gt::gui::stylesheet::toolTip()
         "}"
     );
 
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         return style.arg("white", gt::gui::color::highlight().name());
     }
@@ -180,7 +180,7 @@ gt::gui::stylesheet::toolTip()
 QString
 gt::gui::stylesheet::spinbox()
 {
-    bool dark = gtApp && gtApp->inDarkMode();
+    bool dark = gt::gui::isApplicationDarkTheme();
 
     return QStringLiteral(
         "QSpinBox {"

--- a/src/gui/style/gt_stylesheets.cpp
+++ b/src/gui/style/gt_stylesheets.cpp
@@ -94,20 +94,22 @@ gt::gui::stylesheet::processRunButton(RunButtonState const& state)
 {
     QColor backgroundColor;
 
+    bool dark = gtApp && gtApp->inDarkMode();
+
     switch (state)
     {
     case RunButtonState::StopProcess:
-        backgroundColor = gtApp->inDarkMode() ?
+        backgroundColor = dark ?
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
                               QColor(170, 100,  90) : QColor(255, 230, 230);
         break;
     case RunButtonState::QueueProcess:
-        backgroundColor = gtApp->inDarkMode() ?
+        backgroundColor = dark ?
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
                               QColor(190, 170,  90) : QColor(236, 219, 184);
         break;
     case RunButtonState::RunProcess:
-        backgroundColor = gtApp->inDarkMode() ?
+        backgroundColor = dark ?
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
                               QColor(180, 190, 200) : QColor(230, 255, 230);
         break;
@@ -123,6 +125,8 @@ gt::gui::stylesheet::processRunButton(RunButtonState const& state)
 QString
 comboBoxHelper(const QString& width = {})
 {
+    bool dark = gtApp && gtApp->inDarkMode();
+
     return QStringLiteral(
             "QComboBox {"
             " border: 1px solid %1;"
@@ -146,7 +150,7 @@ comboBoxHelper(const QString& width = {})
             " height: 7px;"
             "}"
     ).arg(gt::gui::color::frame().name(),
-          width, gtApp->inDarkMode() ? "_dark" : QString{});
+          width, dark ? "_dark" : QString{});
 }
 
 QString
@@ -166,7 +170,7 @@ gt::gui::stylesheet::toolTip()
         "}"
     );
 
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         return style.arg("white", gt::gui::color::highlight().name());
     }
@@ -176,6 +180,8 @@ gt::gui::stylesheet::toolTip()
 QString
 gt::gui::stylesheet::spinbox()
 {
+    bool dark = gtApp && gtApp->inDarkMode();
+
     return QStringLiteral(
         "QSpinBox {"
         " border: 1px solid %1;"
@@ -209,7 +215,7 @@ gt::gui::stylesheet::spinbox()
         " width: 7px;"
         " height: 7px;"
         "}"
-    ).arg(color::frame().name(), gtApp->inDarkMode() ? "_dark" : QString{});
+    ).arg(color::frame().name(), dark ? "_dark" : QString{});
 }
 
 QString

--- a/src/gui/tools/gt_codeeditor.cpp
+++ b/src/gui/tools/gt_codeeditor.cpp
@@ -13,8 +13,8 @@
 #include <QTextBlock>
 
 #include "gt_codeeditor.h"
+#include "gt_guiutilities.h"
 #include "gt_linenumberarea.h"
-#include "gt_application.h"
 #include "gt_colors.h"
 
 GtCodeEditor::GtCodeEditor(QWidget* parent) : QPlainTextEdit(parent)
@@ -177,7 +177,7 @@ GtCodeEditor::lineNumberAreaPaintEvent(QPaintEvent* event)
 {
     QPainter painter(m_lineNumberArea);
 
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         painter.fillRect(event->rect(), Qt::darkGray);
     }

--- a/src/gui/tools/gt_codeeditor.cpp
+++ b/src/gui/tools/gt_codeeditor.cpp
@@ -177,7 +177,7 @@ GtCodeEditor::lineNumberAreaPaintEvent(QPaintEvent* event)
 {
     QPainter painter(m_lineNumberArea);
 
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         painter.fillRect(event->rect(), Qt::darkGray);
     }

--- a/src/gui/tools/gt_grid.cpp
+++ b/src/gui/tools/gt_grid.cpp
@@ -234,7 +234,7 @@ GtGrid::paintRuler(GtRuler* ruler)
 
     Qt::GlobalColor c = Qt::black;
 
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         c = Qt::white;
     }

--- a/src/gui/tools/gt_grid.cpp
+++ b/src/gui/tools/gt_grid.cpp
@@ -12,8 +12,8 @@
 #include <QPainter>
 #include "gt_grid.h"
 #include "gt_graphicsview.h"
+#include "gt_guiutilities.h"
 #include "gt_ruler.h"
-#include "gt_application.h"
 #include "gt_colors.h"
 #include "gt_logging.h"
 #include <QtMath>
@@ -234,7 +234,7 @@ GtGrid::paintRuler(GtRuler* ruler)
 
     Qt::GlobalColor c = Qt::black;
 
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         c = Qt::white;
     }

--- a/src/gui/tools/gt_pyhighlighter.cpp
+++ b/src/gui/tools/gt_pyhighlighter.cpp
@@ -149,19 +149,7 @@ GtPyHighlighter::onThemeChanged()
 void
 GtPyHighlighter::initializeStyles()
 {
-    if (!gtApp->inDarkMode())
-    {
-        basicStyles.insert("keyword", getTextCharFormat("blue"));
-        basicStyles.insert("operator", getTextCharFormat("red"));
-        basicStyles.insert("brace", getTextCharFormat("darkGray"));
-        basicStyles.insert("defclass", getTextCharFormat("black", "bold"));
-        basicStyles.insert("string", getTextCharFormat("magenta"));
-        basicStyles.insert("string2", getTextCharFormat("darkMagenta"));
-        basicStyles.insert("comment", getTextCharFormat("darkGreen", "italic"));
-        basicStyles.insert("self", getTextCharFormat("black", "italic"));
-        basicStyles.insert("numbers", getTextCharFormat("brown"));
-    }
-    else
+    if (gtApp && gtApp->inDarkMode())
     {
         basicStyles.insert("keyword", getTextCharFormat("violet"));
         basicStyles.insert("operator", getTextCharFormat("white"));
@@ -172,6 +160,18 @@ GtPyHighlighter::initializeStyles()
         basicStyles.insert("comment", getTextCharFormat("gray", "italic"));
         basicStyles.insert("self", getTextCharFormat("white", "italic"));
         basicStyles.insert("numbers", getTextCharFormat("yellow"));
+    }
+    else
+    {
+        basicStyles.insert("keyword", getTextCharFormat("blue"));
+        basicStyles.insert("operator", getTextCharFormat("red"));
+        basicStyles.insert("brace", getTextCharFormat("darkGray"));
+        basicStyles.insert("defclass", getTextCharFormat("black", "bold"));
+        basicStyles.insert("string", getTextCharFormat("magenta"));
+        basicStyles.insert("string2", getTextCharFormat("darkMagenta"));
+        basicStyles.insert("comment", getTextCharFormat("darkGreen", "italic"));
+        basicStyles.insert("self", getTextCharFormat("black", "italic"));
+        basicStyles.insert("numbers", getTextCharFormat("brown"));
     }
 }
 

--- a/src/gui/tools/gt_pyhighlighter.cpp
+++ b/src/gui/tools/gt_pyhighlighter.cpp
@@ -10,7 +10,7 @@
  */
 
 #include "gt_pyhighlighter.h"
-#include "gt_application.h"
+#include "gt_guiutilities.h"
 
 GtPyHighlighter::GtPyHighlighter(QTextDocument* parent) :
     QSyntaxHighlighter(parent),
@@ -149,7 +149,7 @@ GtPyHighlighter::onThemeChanged()
 void
 GtPyHighlighter::initializeStyles()
 {
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         basicStyles.insert("keyword", getTextCharFormat("violet"));
         basicStyles.insert("operator", getTextCharFormat("white"));

--- a/src/gui/tools/gt_ruler.cpp
+++ b/src/gui/tools/gt_ruler.cpp
@@ -12,7 +12,7 @@
 #include "gt_ruler.h"
 #include "gt_graphicsview.h"
 #include "gt_grid.h"
-#include "gt_application.h"
+#include "gt_guiutilities.h"
 
 GtRuler::GtRuler(Qt::Orientation o) :
     m_orientation(o),
@@ -40,7 +40,7 @@ GtRuler::paintEvent(QPaintEvent* e)
 {
     Qt::GlobalColor c = Qt::black;
 
-    if (gtApp && gtApp->inDarkMode())
+    if (gt::gui::isApplicationDarkTheme())
     {
         c = Qt::white;
     }

--- a/src/gui/tools/gt_ruler.cpp
+++ b/src/gui/tools/gt_ruler.cpp
@@ -40,7 +40,7 @@ GtRuler::paintEvent(QPaintEvent* e)
 {
     Qt::GlobalColor c = Qt::black;
 
-    if (gtApp->inDarkMode())
+    if (gtApp && gtApp->inDarkMode())
     {
         c = Qt::white;
     }


### PR DESCRIPTION
As mentioned in a bug report for gtApp-nullptr there might be crashes in several parts of the code.
This should be reduced by additional checks in various GUI classes

## Description
Before the dark mode is requested the check for the validity of the gtApp pointer is checked. If it is not valid the bright mode is selected

## How Has This Been Tested?
Manual 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Guard dark mode dependent GUI logic against null gtApp to avoid crashes and default to light mode when the application instance is unavailable.

Bug Fixes:
- Prevent potential null-pointer dereferences when querying dark mode state across color, stylesheet, icon, dialog, and tool components by checking gtApp validity first.

Enhancements:
- Default various GUI themes, palettes, and syntax highlighting styles to light mode when gtApp is not available while preserving dark mode behavior when it is.