### PR TITLE
Added missing compat library to cmake config

### DIFF
--- a/cmake/GTlabConfig.cmake
+++ b/cmake/GTlabConfig.cmake
@@ -11,6 +11,9 @@ set(GTLAB_QT_VERSION_MAJOR @QT_VERSION_MAJOR@)
 
 # Require the same Qt major version for consumers
 find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS Core Gui Xml Widgets Network PrintSupport)
+if (QT_VERSION_MAJOR EQUAL 6)
+  find_dependency(Qt6Core5Compat REQUIRED)
+endif()
 find_dependency(GTlabLogging)
 find_dependency(GenH5)
 


### PR DESCRIPTION
Closes #1481


## Description

When GTlab is built with Qt6 it creates a faulty Config file. As a result, consuming module cannot configure, since the target Qt6::Qt5Compat is unknown - but linked by the Dataprocess target.

## How Has This Been Tested?

1. Built GTlab + installed it with Qt6
2. Built a module (basictools) with Qt6 against it

It now works


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Build:
- Add Qt6Core5Compat as a required dependency in the generated GTlab CMake config when building against Qt6.