### PR TITLE
Reduce code doubling in GtProcessComponentSettingsButton

### DIFF
--- a/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.cpp
+++ b/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.cpp
@@ -20,12 +20,44 @@
 #include "gt_project.h"
 #include "gt_task.h"
 #include "gt_calculator.h"
-#include "gt_command.h"
 #include "gt_extendedtaskdata.h"
 #include "gt_stylesheets.h"
 #include "gt_icons.h"
 
 #include "gt_processcomponentsettingsbutton.h"
+
+namespace {
+    GtCustomProcessWizard* calcWizard(GtCalculator* calc)
+    {
+        if (!calc) return nullptr;
+
+        GtCalculatorData calcData =
+            gtCalculatorFactory->calculatorData(
+                calc->metaObject()->className());
+
+        auto* eData = dynamic_cast<GtExtendedCalculatorDataImpl*>(
+            calcData.get());
+
+        if (!eData) return nullptr;
+
+        return eData->wizard;
+    }
+
+    GtCustomProcessWizard* taskWizard(GtTask* task)
+    {
+        if (!task) return nullptr;
+
+        GtTaskData taskData = gtTaskFactory->taskData(
+            task->metaObject()->className());
+
+        auto* eData = dynamic_cast<GtExtendedTaskDataImpl*>(taskData.get());
+
+        if (!eData) return nullptr;
+
+        return eData->wizard;
+    }
+}
+
 
 GtProcessComponentSettingsButton::GtProcessComponentSettingsButton() :
     m_pc(nullptr), m_task(nullptr)
@@ -56,17 +88,11 @@ GtProcessComponentSettingsButton::setProcessComponent(GtProcessComponent* pc)
 
     updateState();
 
-    if (!m_pc)
-    {
-        return;
-    }
+    if (!m_pc) return;
 
     m_task = m_pc->rootTask();
 
-    if (!m_task)
-    {
-        return;
-    }
+    if (!m_task) return;
 
     connect(m_task.data(), SIGNAL(destroyed(QObject*)), SLOT(updateState()));
     connect(m_task.data(), SIGNAL(stateChanged(GtProcessComponent::STATE)),
@@ -76,43 +102,40 @@ GtProcessComponentSettingsButton::setProcessComponent(GtProcessComponent* pc)
 bool
 GtProcessComponentSettingsButton::hasCustomWizard()
 {
-    if (!m_pc)
+    return processComponentWizard(m_pc) != nullptr;
+}
+
+GtCustomProcessWizard*
+GtProcessComponentSettingsButton::processComponentWizard(
+    GtProcessComponent* pc)
+{
+    if (auto* calc = qobject_cast<GtCalculator*>(pc))
     {
-        return false;
+        return calcWizard(calc);
+    }
+    else if (auto* task = qobject_cast<GtTask*>(m_pc))
+    {
+        return taskWizard(task);
     }
 
-    if (GtCalculator* calc = qobject_cast<GtCalculator*>(m_pc))
-    {
-        GtCalculatorData calcData =
-            gtCalculatorFactory->calculatorData(
-                calc->metaObject()->className());
+    return nullptr;
+}
 
-        GtExtendedCalculatorDataImpl* eData =
-            dynamic_cast<GtExtendedCalculatorDataImpl*>(
-                calcData.get());
+void
+GtProcessComponentSettingsButton::setProcessComponentByProvider(
+    GtProcessComponent* pc, GtAbstractProcessProvider* provider)
+{
+    if (!provider) return;
 
-        if (eData && eData->wizard)
-        {
-            return true;
-        }
-    }
-    else if (GtTask* task = qobject_cast<GtTask*>(m_pc))
-    {
-        GtTaskData taskData =
-            gtTaskFactory->taskData(
-                task->metaObject()->className());
+    GtObjectMemento memento = provider->componentData();
 
-        GtExtendedTaskDataImpl* eData =
-            dynamic_cast<GtExtendedTaskDataImpl*>(
-                taskData.get());
+    if (memento.isNull()) return;
 
-        if (eData && eData->wizard)
-        {
-            return true;
-        }
-    }
+    auto command = gtApp->makeCommand(pc, pc->objectName() +
+                                      tr(" configuration changed"));
+    Q_UNUSED(command)
 
-    return false;
+    pc->fromMemento(memento);
 }
 
 void
@@ -148,86 +171,34 @@ GtProcessComponentSettingsButton::updateState()
 void
 GtProcessComponentSettingsButton::openProcessComponentWizard()
 {
-    if (!m_pc)
+    if (!m_pc) return;
+
+    if (!m_pc->isReady()) return;
+
+    if (auto* calc = qobject_cast<GtCalculator*>(m_pc))
     {
-        return;
-    }
-
-    if (!m_pc->isReady())
-    {
-        return;
-    }
-
-    if (GtCalculator* calc = qobject_cast<GtCalculator*>(m_pc))
-    {
-        GtCalculatorData calcData =
-            gtCalculatorFactory->calculatorData(
-                calc->metaObject()->className());
-
-        GtExtendedCalculatorDataImpl* eData =
-            dynamic_cast<GtExtendedCalculatorDataImpl*>(
-                calcData.get());
-
-        if (eData && eData->wizard)
+        if (GtCustomProcessWizard* pcWizard = calcWizard(calc))
         {
             GtCalculatorProvider provider(calc);
             GtProcessWizard wizard(gtApp->currentProject(), &provider,
                                    parentWidget());
 
-            if (!wizard.exec())
-            {
-                return;
-            }
+            if (!wizard.exec()) return;
 
-            GtObjectMemento memento = provider.componentData();
-
-            if (memento.isNull())
-            {
-                return;
-            }
-
-            auto command = gtApp->makeCommand(calc,
-                                              calc->objectName() +
-                                              tr(" configuration changed"));
-            Q_UNUSED(command)
-
-            calc->fromMemento(memento);
+            setProcessComponentByProvider(calc, &provider);
         }
     }
-    else if (GtTask* task = qobject_cast<GtTask*>(m_pc))
+    else if (auto* task = qobject_cast<GtTask*>(m_pc))
     {
-        GtTaskData taskData =
-            gtTaskFactory->taskData(
-                task->metaObject()->className());
-
-        GtExtendedTaskDataImpl* eData =
-            dynamic_cast<GtExtendedTaskDataImpl*>(
-                taskData.get());
-
-        if (eData && eData->wizard)
+        if (GtCustomProcessWizard* pcWizard = taskWizard(task))
         {
             GtTaskProvider provider(task);
             GtProcessWizard wizard(gtApp->currentProject(), &provider,
                                    parentWidget());
 
-            if (!wizard.exec())
-            {
-                return;
-            }
+            if (!wizard.exec()) return;
 
-            GtObjectMemento memento = provider.componentData();
-
-            if (memento.isNull())
-            {
-                return;
-            }
-
-            auto command = gtApp->makeCommand(task,
-                                              task->objectName() +
-                                              tr(" configuration changed"));
-            Q_UNUSED(command)
-
-            task->fromMemento(memento);
+            setProcessComponentByProvider(task, &provider);
         }
     }
 }

--- a/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.cpp
+++ b/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.cpp
@@ -27,20 +27,24 @@
 #include "gt_processcomponentsettingsbutton.h"
 
 namespace {
-    GtCustomProcessWizard* calcWizard(GtCalculator* calc)
+    template <class ext_pc_type>
+    GtCustomProcessWizard* pc_wizard(GtAbstractProcessData* abstractPCData)
     {
-        if (!calc) return nullptr;
-
-        GtCalculatorData calcData =
-            gtCalculatorFactory->calculatorData(
-                calc->metaObject()->className());
-
-        auto* eData = dynamic_cast<GtExtendedCalculatorDataImpl*>(
-            calcData.get());
+        auto* eData = dynamic_cast<ext_pc_type>(abstractPCData);
 
         if (!eData) return nullptr;
 
         return eData->wizard;
+    }
+
+    GtCustomProcessWizard* calcWizard(GtCalculator* calc)
+    {
+        if (!calc) return nullptr;
+
+        GtCalculatorData calcData = gtCalculatorFactory->calculatorData(
+                calc->metaObject()->className());
+
+        return pc_wizard<GtExtendedCalculatorDataImpl*>(&*calcData);
     }
 
     GtCustomProcessWizard* taskWizard(GtTask* task)
@@ -50,11 +54,35 @@ namespace {
         GtTaskData taskData = gtTaskFactory->taskData(
             task->metaObject()->className());
 
-        auto* eData = dynamic_cast<GtExtendedTaskDataImpl*>(taskData.get());
+        return pc_wizard<GtExtendedTaskDataImpl*>(&*taskData);
+    }
 
-        if (!eData) return nullptr;
+    /**
+     * @brief sets the memento of a process element by the provider
+     * with an previous check if the wizard of the process element is valid
+     * @param pc - process element
+     * @param parentW - parent widget of the current context for clean
+     * wizard generation
+     */
+    template <class pc_provider, class pc_type>
+    void setProcessComponentByProvider(pc_type* pc, QWidget* parentW)
+    {
+        if (!pc) return;
 
-        return eData->wizard;
+        pc_provider provider(pc);
+        GtProcessWizard wizard(gtApp->currentProject(), &provider, parentW);
+
+        if (!wizard.exec()) return;
+
+        GtObjectMemento memento = provider.componentData();
+
+        if (memento.isNull()) return;
+
+        auto command = gtApp->makeCommand(
+            pc, pc->objectName() + QObject::tr(" configuration changed"));
+        Q_UNUSED(command)
+
+        pc->fromMemento(memento);
     }
 }
 
@@ -102,40 +130,16 @@ GtProcessComponentSettingsButton::setProcessComponent(GtProcessComponent* pc)
 bool
 GtProcessComponentSettingsButton::hasCustomWizard()
 {
-    return processComponentWizard(m_pc) != nullptr;
-}
-
-GtCustomProcessWizard*
-GtProcessComponentSettingsButton::processComponentWizard(
-    GtProcessComponent* pc)
-{
-    if (auto* calc = qobject_cast<GtCalculator*>(pc))
+    if (auto* calc = qobject_cast<GtCalculator*>(m_pc))
     {
-        return calcWizard(calc);
+        return calcWizard(calc) != nullptr;
     }
     else if (auto* task = qobject_cast<GtTask*>(m_pc))
     {
-        return taskWizard(task);
+        return taskWizard(task)!= nullptr;
     }
 
-    return nullptr;
-}
-
-void
-GtProcessComponentSettingsButton::setProcessComponentByProvider(
-    GtProcessComponent* pc, GtAbstractProcessProvider* provider)
-{
-    if (!provider) return;
-
-    GtObjectMemento memento = provider->componentData();
-
-    if (memento.isNull()) return;
-
-    auto command = gtApp->makeCommand(pc, pc->objectName() +
-                                      tr(" configuration changed"));
-    Q_UNUSED(command)
-
-    pc->fromMemento(memento);
+    return false;
 }
 
 void
@@ -177,28 +181,18 @@ GtProcessComponentSettingsButton::openProcessComponentWizard()
 
     if (auto* calc = qobject_cast<GtCalculator*>(m_pc))
     {
-        if (GtCustomProcessWizard* pcWizard = calcWizard(calc))
+        if (calcWizard(calc) != nullptr)
         {
-            GtCalculatorProvider provider(calc);
-            GtProcessWizard wizard(gtApp->currentProject(), &provider,
-                                   parentWidget());
-
-            if (!wizard.exec()) return;
-
-            setProcessComponentByProvider(calc, &provider);
+            setProcessComponentByProvider<GtCalculatorProvider, GtCalculator> (
+                calc, parentWidget());
         }
     }
     else if (auto* task = qobject_cast<GtTask*>(m_pc))
     {
-        if (GtCustomProcessWizard* pcWizard = taskWizard(task))
+        if (taskWizard(task) != nullptr)
         {
-            GtTaskProvider provider(task);
-            GtProcessWizard wizard(gtApp->currentProject(), &provider,
-                                   parentWidget());
-
-            if (!wizard.exec()) return;
-
-            setProcessComponentByProvider(task, &provider);
+            setProcessComponentByProvider<GtTaskProvider, GtTask> (
+                task, parentWidget());
         }
     }
 }

--- a/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.cpp
+++ b/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.cpp
@@ -40,6 +40,7 @@ namespace {
     GtCustomProcessWizard* calcWizard(GtCalculator* calc)
     {
         if (!calc) return nullptr;
+        if (!gtCalculatorFactory) return nullptr;
 
         GtCalculatorData calcData = gtCalculatorFactory->calculatorData(
                 calc->metaObject()->className());
@@ -50,6 +51,7 @@ namespace {
     GtCustomProcessWizard* taskWizard(GtTask* task)
     {
         if (!task) return nullptr;
+        if (!gtTaskFactory) return nullptr;
 
         GtTaskData taskData = gtTaskFactory->taskData(
             task->metaObject()->className());
@@ -151,14 +153,7 @@ GtProcessComponentSettingsButton::updateState()
         return;
     }
 
-    if (!m_pc || !m_pc->isReady())
-    {
-        setEnabled(false);
-    }
-    else
-    {
-        setEnabled(true);
-    }
+    setEnabled(m_pc && m_pc->isReady());
 
     if (qobject_cast<GtCalculator*>(m_pc))
     {

--- a/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.h
+++ b/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.h
@@ -53,23 +53,6 @@ private:
     /// Pointer to root task of process component object
     QPointer<GtTask> m_task;
 
-    /**
-     * @brief Search in the meta data of a process component for its
-     * wizard
-     * @param pc - process component
-     * @return the wizard or a nullptr if no custom wizard is defined
-     */
-    GtCustomProcessWizard* processComponentWizard(GtProcessComponent* pc);
-
-    /**
-     * @brief Sets the memento of a process component based on the
-     * provider and its information.
-     *
-     * @param pc - process component
-     * @param provider - processprovider
-     */
-    void setProcessComponentByProvider(GtProcessComponent* pc,
-                                       GtAbstractProcessProvider* provider);
 private slots:
     /**
      * @brief Updates button state based on process component information.

--- a/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.h
+++ b/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.h
@@ -18,6 +18,9 @@
 
 #include "gt_processcomponent.h"
 
+class GtCustomProcessWizard;
+class GtAbstractProcessProvider;
+
 /**
  * @brief The GtProcessComponentSettingsButton class
  */
@@ -50,6 +53,23 @@ private:
     /// Pointer to root task of process component object
     QPointer<GtTask> m_task;
 
+    /**
+     * @brief Search in the meta data of a process component for its
+     * wizard
+     * @param pc - process component
+     * @return the wizard or a nullptr if no custom wizard is defined
+     */
+    GtCustomProcessWizard* processComponentWizard(GtProcessComponent* pc);
+
+    /**
+     * @brief Sets the memento of a process component based on the
+     * provider and its information.
+     *
+     * @param pc - process component
+     * @param provider - processprovider
+     */
+    void setProcessComponentByProvider(GtProcessComponent* pc,
+                                       GtAbstractProcessProvider* provider);
 private slots:
     /**
      * @brief Updates button state based on process component information.

--- a/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.h
+++ b/src/app/dock_widgets/process/gt_processcomponentsettingsbutton.h
@@ -18,9 +18,6 @@
 
 #include "gt_processcomponent.h"
 
-class GtCustomProcessWizard;
-class GtAbstractProcessProvider;
-
 /**
  * @brief The GtProcessComponentSettingsButton class
  */

--- a/src/core/process_management/gt_abstractprocessdata.h
+++ b/src/core/process_management/gt_abstractprocessdata.h
@@ -12,7 +12,10 @@
 #ifndef GTABSTRACTPROCESSDATA_H
 #define GTABSTRACTPROCESSDATA_H
 
+#include <QString>
+
 #include "gt_core_exports.h"
+#include "gt_versionnumber.h"
 
 class QString;
 
@@ -54,6 +57,26 @@ public:
     /// status variable
     GtAbstractProcessData::DEV_STATUS status;
 
+    /// Process component identification string.
+    QString id;
+
+    /// Process component description.
+    QString description;
+
+    /// Process component author.
+    QString author;
+
+    /// Process component author contact.
+    QString contact;
+
+    /// Process component author company.
+    QString company;
+
+    /// Process component category.
+    QString category;
+
+    /// Process component version.
+    GtVersionNumber version;
 protected:
     /**
      * @brief Constructor.

--- a/src/core/process_management/gt_calculatordata.h
+++ b/src/core/process_management/gt_calculatordata.h
@@ -15,7 +15,6 @@
 #include "gt_core_exports.h"
 
 #include "gt_abstractprocessdata.h"
-#include "gt_versionnumber.h"
 
 #include <QStringList>
 #include <QMetaObject>
@@ -74,27 +73,6 @@ public:
      * @return List of environment variable identification strings
      */
     const QStringList& environmentVariables();
-
-    /// Calculator identification string.
-    QString id;
-
-    /// Calculator description.
-    QString description;
-
-    /// Calculator author.
-    QString author;
-
-    /// Calculator author contact.
-    QString contact;
-
-    /// Calculator author company.
-    QString company;
-
-    /// Calculator category.
-    QString category;
-
-    /// Calculator version.
-    GtVersionNumber version;
 
 private:
     /// Calculator meta data.

--- a/src/core/process_management/gt_taskdata.h
+++ b/src/core/process_management/gt_taskdata.h
@@ -15,7 +15,7 @@
 #include "gt_core_exports.h"
 
 #include "gt_abstractprocessdata.h"
-#include "gt_versionnumber.h"
+
 
 #include <QStringList>
 #include <QMetaObject>
@@ -62,27 +62,6 @@ public:
      * @return
      */
     static GtTaskData newTaskData(const QMetaObject& metaData);
-
-    /// Task identification string.
-    QString id;
-
-    /// Task description.
-    QString description;
-
-    /// Task author.
-    QString author;
-
-    /// Task author contact.
-    QString contact;
-
-    /// Task author company.
-    QString company;
-
-    /// Task category.
-    QString category;
-
-    /// Task version.
-    GtVersionNumber version;
 
 private:
     /// Task meta data.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Reduce some code doublings in the code.
As the TaskData and CalculatorData do not share much functions so some if structures are still needed. 

## Description


## How Has This Been Tested?
Manual checks of the GUI reaction


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Refactor process component settings handling to reduce duplicated logic for calculators and tasks by centralizing wizard lookup and memento application.

Enhancements:
- Introduce shared helper functions to retrieve custom wizards for calculators and tasks and to apply provider data back to process components.
- Simplify null and readiness checks in process component setup and wizard opening to make the control flow more concise.