### PR TITLE
Fixed the explorer and process view not marking the next object as selected when deleting an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+ - Fixed the explorer and process view not marking the next object as selected when deleting an object. - #1486
+
 ## [2.0.12] - 2026-03-18
 
 GTlab 2.0.12 is a release to prepare the migration to GTlab 2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
- - Fixed the explorer and process view not marking the next object as selected when deleting an object. - #1486
+ - Fixed the explorer and process views not marking the next object as selected when deleting an object. - #1486
 
 ## [2.0.12] - 2026-03-18
 

--- a/src/app/dock_widgets/explorer/gt_explorerdock.cpp
+++ b/src/app/dock_widgets/explorer/gt_explorerdock.cpp
@@ -652,6 +652,15 @@ GtExplorerDock::endResetView()
             SIGNAL(currentChanged(QModelIndex,QModelIndex)),
             SLOT(handleKeyboardSelectionChange(QModelIndex,QModelIndex)),
             Qt::UniqueConnection);
+
+    if (m_view->selectionModel()->selection().size() > 0) return;
+
+    GtObject* selectedObj = gtApp->selectedObject();
+    if (!selectedObj) return;
+
+    auto index = gtDataModel->indexFromObject(selectedObj);
+
+    m_view->setCurrentIndex(mapFromSource(index));
 }
 
 void

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -2447,9 +2447,18 @@ GtProcessDock::currentTaskGroupIndexChanged(int index)
 void
 GtProcessDock::endResetView()
 {
-
     updateProcessViewRootIndex();
     resetTaskGroupModel();
+
+    // update selection after reset
+    if (m_view->selectionModel()->selection().size() > 0) return;
+
+    GtObject* selectedObj = gtApp->selectedObject();
+    if (!selectedObj) return;
+
+    auto index = gtDataModel->indexFromObject(selectedObj);
+
+    m_view->setCurrentIndex(mapFromSource(index));
 }
 
 void


### PR DESCRIPTION
Fixed the explorer and process view not marking the next object as selected when deleting an object, causing inconsistencies in the UX. Closes #1486 

This PR target the `2.0.X` version as its an bug fix.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Ensure explorer and process views keep their selection in sync with the globally selected object after model resets, particularly when items are deleted.

Bug Fixes:
- Resolve issue where deleting an object in explorer or process view left no item selected instead of selecting the next object.

Documentation:
- Add unreleased changelog entry describing the selection fix in explorer and process views.