### PR TITLE
Improved performance when jumping to an object in the explorer view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
  - Fixed the explorer and process views not marking the next object as selected when deleting an object. - #1486
+ - Performance improvement when jumping to an object in the explorer widget (e.g. when jumping to the linked object of an object link property). - #1480
 
 ## [2.0.12] - 2026-03-18
 

--- a/src/app/dock_widgets/explorer/gt_explorerdock.cpp
+++ b/src/app/dock_widgets/explorer/gt_explorerdock.cpp
@@ -471,8 +471,8 @@ GtExplorerDock::selectObjectByUuid(const QString& uuid)
     GtObject* object = gtDataModel->objectByUuid(uuid);
     if (!object)
     {
-        gtWarning().verbose()
-            << tr("GtExplorerDock: Requested object uuid not found!");
+        gtWarningId(objectName().toStdString()).verbose()
+            << tr("Requested object uuid not found!");
         return;
     }
 
@@ -482,8 +482,8 @@ GtExplorerDock::selectObjectByUuid(const QString& uuid)
 
     if (!index.isValid())
     {
-        gtWarning().verbose()
-            << tr("GtExplorerDock: Requested object index not found!");
+        gtWarningId(objectName().toStdString())
+            << tr("Cannot select object!");
         return;
     }
 

--- a/src/app/dock_widgets/explorer/gt_explorerdock.cpp
+++ b/src/app/dock_widgets/explorer/gt_explorerdock.cpp
@@ -468,48 +468,28 @@ GtExplorerDock::listElements(QModelIndex const& parent) const
 void
 GtExplorerDock::selectObjectByUuid(const QString& uuid)
 {
-    if (uuid.isEmpty() || !gtApp->currentProject())
+    GtObject* object = gtDataModel->objectByUuid(uuid);
+    if (!object)
     {
+        gtWarning().verbose()
+            << tr("GtExplorerDock: Requested object uuid not found!");
         return;
     }
 
-    QModelIndexList list;
+    QModelIndex index = gtDataModel->indexFromObject(object);
 
-    for(int i = 0; i < m_model->rowCount(); i++)
+    index = mapFromSource(index);
+
+    if (!index.isValid())
     {
-        QModelIndex index = m_model->index(i, 0);
-
-        for (const QModelIndex& i2 : listElements(index))
-        {
-            if (!list.contains(i2))
-            {
-                list.append(i2);
-            }
-        }
+        gtWarning().verbose()
+            << tr("GtExplorerDock: Requested object index not found!");
+        return;
     }
 
-    auto iter = std::find_if(std::begin(list), std::end(list),
-                             [&uuid](const QModelIndex& index)
-    {
-        if (!index.isValid())
-        {
-            return false;
-        }
-
-        return index.data(GtCoreDatamodel::UuidRole).toString() == uuid;
-    });
-
-    if (iter != std::end(list))
-    {
-        if (GtObject* obj = mapToObject(*iter))
-        {
-            m_view->setCurrentIndex(*iter);
-            m_view->scrollTo(*iter);
-            return emit selectedObjectChanged(obj);
-        }
-
-        gtWarning() << tr("Cannot select the requested object");
-    }
+    m_view->setCurrentIndex(index);
+    m_view->scrollTo(index);
+    emit selectedObjectChanged(object);
 }
 
 void

--- a/src/app/dock_widgets/explorer/gt_explorerdock.h
+++ b/src/app/dock_widgets/explorer/gt_explorerdock.h
@@ -156,7 +156,7 @@ private:
 
         index = model->mapFromSource(index);
 
-        return true;
+        return index.isValid();
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improved performance when jumping to an object in the explorer view. Closes #1480 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Improve performance and robustness of selecting objects by UUID in the explorer dock.

Bug Fixes:
- Ensure object selection by UUID fails gracefully when the object or corresponding index cannot be resolved.

Enhancements:
- Replace linear traversal of the explorer model when selecting by UUID with a direct lookup via the shared data model and index mapping.
- Tighten index resolution helper to signal failure by checking index validity instead of always succeeding.

Documentation:
- Document the explorer jump performance improvement in the changelog.