### PR TITLE
[WIP] Qt Advanced Docking System (ADS) integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,14 @@ if (BUILD_WITH_COVERAGE)
     append_coverage_compiler_flags()
 endif(BUILD_WITH_COVERAGE)
 
+find_package(qtadvanceddocking-qt5 REQUIRED)
+
 if (NOT DEFINED VCPKG_TARGET_TRIPLET)
     include(GetDependencies)
 endif()
 
 if (NOT BUILD_SHARED_LIBS)
-    message(WARNING "Static library builds of GTlab are not yet fully supported.") 
+    message(WARNING "Static library builds of GTlab are not yet fully supported.")
 endif()
 
 if (NOT TARGET GTlab::Logging)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -212,6 +212,7 @@ target_include_directories(GTlab PRIVATE
     dock_widgets/labels
 )
 
+
 target_link_libraries(GTlab
     PRIVATE
     Qt${QT_VERSION_MAJOR}::Widgets
@@ -219,6 +220,7 @@ target_link_libraries(GTlab
     Qt${QT_VERSION_MAJOR}::QuickWidgets
     Qt${QT_VERSION_MAJOR}::QuickControls2
     Qt${QT_VERSION_MAJOR}::Test
+    ads::qtadvanceddocking-qt5
     GTlabDataProcessor
     GTlabCore
     GTlabGui

--- a/src/app/dock_widgets/output/gt_outputdock.cpp
+++ b/src/app/dock_widgets/output/gt_outputdock.cpp
@@ -271,7 +271,6 @@ GtOutputDock::GtOutputDock()
     m_logView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     m_logView->setSizeAdjustPolicy(GtTableView::AdjustToContents);
     m_logView->setShowGrid(false);
-    m_logView->setFrameStyle(QFrame::NoFrame);
     m_logView->setModel(m_model);
 
     // stretch the last section

--- a/src/app/dock_widgets/properties/gt_propertiesdock.cpp
+++ b/src/app/dock_widgets/properties/gt_propertiesdock.cpp
@@ -88,8 +88,6 @@ GtPropertiesDock::GtPropertiesDock() : m_obj(nullptr)
 
     frame->setAutoFillBackground(true);
 
-    m_treeView->setFrameStyle(QTreeView::NoFrame);
-
     setWidget(frame);
 
     connect(m_treeView, SIGNAL(searchRequest()), m_search,

--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -44,6 +44,7 @@
 #include "gt_examplesmdiwidget.h"
 #include "gt_sessionviewer.h"
 #include "gt_startuppage.h"
+#include "gt_perspective.h"
 
 #include <QDir>
 #include <QKeyEvent>
@@ -83,6 +84,8 @@ GtMainWin::GtMainWin(QWidget* parent) : QMainWindow(parent),
 
     ui->centralwidget->setParent(nullptr);
     auto* manager = new ads::CDockManager(this);
+    manager->setObjectName(QStringLiteral("DockManager"));
+    manager->setConfigFlag(ads::CDockManager::DockAreaHasTabsMenuButton, false);
 
     auto* area = new ads::CDockWidget(manager, QStringLiteral("Home"));
     area->setWidget(ui->centralwidget);
@@ -439,6 +442,10 @@ GtMainWin::resizeEvent(QResizeEvent *event)
 void
 GtMainWin::setupDockWidgets()
 {
+#if USE_ALTERNATIVE_DOCKING_SYSTEM
+    auto* manager = (ads::CDockManager*)(this->centralWidget());
+    assert(manager);
+#endif
     foreach (const QString& id, gtMdiLauncher->dockWidgetIds())
     {
         const QMetaObject& metaObj = gtMdiLauncher->dockWidget(id);
@@ -448,13 +455,11 @@ GtMainWin::setupDockWidgets()
         if (legacyDock)
         {
 #if USE_ALTERNATIVE_DOCKING_SYSTEM
-            auto* manager = (ads::CDockManager*)(this->centralWidget());
-
             auto* dock = new ads::CDockWidget(manager, legacyDock->objectName());
             dock->setIcon(legacyDock->getIcon());
             dock->setWidget(legacyDock);
+            dock->setObjectName(legacyDock->objectName());
             auto* area = manager->addDockWidget(static_cast<ads::DockWidgetArea>(legacyDock->getDockWidgetArea()), dock);
-
             legacyDock->setTitleBarWidget(new QWidget());
             legacyDock->setFeatures(QDockWidget::NoDockWidgetFeatures);
 
@@ -844,15 +849,33 @@ GtMainWin::onPerspectiveAction(QObject* widget)
 void
 GtMainWin::loadPerspectiveSettings(const QString& /*id*/)
 {
-    QPair<QByteArray, QByteArray> persData = gtApp->loadPerspectiveData();
-    restoreGeometry(persData.first);
-    restoreState(persData.second);
+    GtPerspective* perspective = gtApp->perspective();
+    if (!perspective) return;
+
+    restoreGeometry(perspective->loadGeometry());
+#if USE_ALTERNATIVE_DOCKING_SYSTEM
+    auto* manager = (ads::CDockManager*)(this->centralWidget());
+    assert(manager);
+    constexpr int version = 0;
+    manager->restoreState(perspective->loadDockState(), version);
+#endif
+    restoreState(perspective->loadState());
 }
 
 void
 GtMainWin::savePerspectiveSettings()
 {
-    gtApp->savePerspectiveData(saveGeometry(), saveState());
+    GtPerspective* perspective = gtApp->perspective();
+    if (!perspective) return;
+
+    perspective->saveGeometry(saveGeometry());
+#if USE_ALTERNATIVE_DOCKING_SYSTEM
+    auto* manager = (ads::CDockManager*)(this->centralWidget());
+    assert(manager);
+    constexpr int version = 0;
+    perspective->saveDockState(manager->saveState(version));
+#endif
+    perspective->saveState(saveState());
 }
 
 void

--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -62,6 +62,14 @@
 
 #include <algorithm>
 
+#define USE_ALTERNATIVE_DOCKING_SYSTEM 1
+
+#if USE_ALTERNATIVE_DOCKING_SYSTEM
+#include <qtadvanceddocking-qt5/DockManager.h>
+#include <qtadvanceddocking-qt5/DockWidget.h>
+#include <qtadvanceddocking-qt5/DockAreaWidget.h>
+#endif
+
 GtMainWin::GtMainWin(QWidget* parent) : QMainWindow(parent),
     ui(new Ui::GtMainWin),
     m_cornerWidget(new GtCornerWidget(this)),
@@ -70,10 +78,25 @@ GtMainWin::GtMainWin(QWidget* parent) : QMainWindow(parent),
     m_processQueue(nullptr),
     m_mainWindowToolbar(new GtMainToolbar(this))
 {
+#if USE_ALTERNATIVE_DOCKING_SYSTEM
+    ui->setupUi(this);
+
+    ui->centralwidget->setParent(nullptr);
+    auto* manager = new ads::CDockManager(this);
+
+    auto* area = new ads::CDockWidget(QStringLiteral("Home"));
+    area->setWidget(ui->centralwidget);
+    manager->setCentralWidget(area);
+
+    setupDockWidgets();
+#else
     // dock widget have to be initialized before setup the ui
     setupDockWidgets();
 
     ui->setupUi(this);
+
+    setCentralWidget(ui->centralwidget);
+#endif
 
     // hide some stuff
     ui->menuUpdate_available->menuAction()->setVisible(false);
@@ -420,16 +443,59 @@ GtMainWin::setupDockWidgets()
     {
         const QMetaObject& metaObj = gtMdiLauncher->dockWidget(id);
 
-        GtDockWidget* dock = qobject_cast<GtDockWidget*>(metaObj.newInstance());
+        GtDockWidget* legacyDock = qobject_cast<GtDockWidget*>(metaObj.newInstance());
 
-        if (dock)
+        if (legacyDock)
         {
-            dock->setWindowTitle(dock->objectName());
-            dock->setFeatures(QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable);
-            addDockWidget(dock->getDockWidgetArea(), dock);
+#if USE_ALTERNATIVE_DOCKING_SYSTEM
+            auto* manager = (ads::CDockManager*)(this->centralWidget());
 
-            // add dockwidgets to map and initialize actions with null pointer
-            m_dockWidgets.insert(dock, nullptr);
+            auto* dock = new ads::CDockWidget(legacyDock->objectName());
+            dock->setIcon(legacyDock->getIcon());
+            dock->setWidget(legacyDock);
+            manager->addDockWidget((ads::DockWidgetArea)legacyDock->getDockWidgetArea(), dock);
+
+            legacyDock->setTitleBarWidget(new QWidget());
+            legacyDock->setFeatures(QDockWidget::NoDockWidgetFeatures);
+
+            dock->setFrameShape(QFrame::NoFrame);
+
+            for (auto* child : dock->findChildren<QFrame*>())
+            {
+                child->setFrameShape(QFrame::NoFrame);
+            }
+
+            using DockWidget = ads::CDockWidget;
+#else
+            legacyDock->setWindowTitle(dock->objectName());
+            legacyDock->setFeatures(QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable);
+            addDockWidget(legacyDock->getDockWidgetArea(), legacyDock);
+
+            using DockWidget = GtDockWidget;
+            auto* dock = legacyDock;
+#endif
+            connect(this, &GtMainWin::guiInitialized, dock, [this, legacyDock, dock](){
+
+                // add entries to menu
+                QAction* action = ui->menuDock_Widgets->addAction(dock->windowTitle());
+                action->setIcon(dock->windowIcon());
+                action->setCheckable(true);
+                action->setChecked(dock->isVisible());
+
+                connect(dock, &DockWidget::visibilityChanged,
+                        action, [action](bool isVisible){
+                    if (action->isChecked() != isVisible)
+                    {
+                        action->setChecked(isVisible);
+                    }
+                });
+                connect(action, &QAction::triggered,
+                        dock, [action, dock](){
+                    dock->setVisible(action->isChecked());
+                });
+
+                legacyDock->initAfterStartup();
+            });
         }
     }
 }
@@ -1094,6 +1160,7 @@ GtMainWin::initAfterStartup()
     {
         return;
     }
+    m_firstTimeShowEvent = false;
 
     // open startup page
     if (gtApp->settings()->showStartupPage())
@@ -1108,26 +1175,6 @@ GtMainWin::initAfterStartup()
     }
 
     emit guiInitialized();
-
-    // initialize dock widgets
-    gt::for_each_key (m_dockWidgets, [this](GtDockWidget* e)
-    {
-        // add entries to menu
-        QAction* dockAct =
-            ui->menuDock_Widgets->addAction(e->windowTitle());
-        dockAct->setCheckable(true);
-        dockAct->setChecked(e->isVisible());
-
-        m_dockWidgets[e] = dockAct;
-
-        connect(e, SIGNAL(visibilityChanged(bool)),
-                SLOT(onDockVisibilityChange(bool)));
-        connect(dockAct, SIGNAL(triggered(bool)), SLOT(onDockActionClicked()));
-
-        e->initAfterStartup();
-    });
-
-    m_firstTimeShowEvent = false;
 }
 
 void
@@ -1156,62 +1203,6 @@ GtMainWin::onObjectSelected(GtObject* /* obj */ )
 }
 
 void
-GtMainWin::onDockVisibilityChange(bool /*val*/)
-{
-    GtDockWidget* dock = qobject_cast<GtDockWidget*>(sender());
-
-    if (!dock)
-    {
-        return;
-    }
-
-    if (!m_dockWidgets.contains(dock))
-    {
-        return;
-    }
-
-    QAction* act = m_dockWidgets.value(dock);
-
-    if (!act)
-    {
-        return;
-    }
-
-    bool isVisible = false;
-
-    if ((dock->isVisible() || !tabifiedDockWidgets(dock).isEmpty()))
-    {
-        isVisible = true;
-    }
-
-    if (act->isChecked() == isVisible)
-    {
-        return;
-    }
-
-    act->setChecked(isVisible);
-}
-
-void
-GtMainWin::onDockActionClicked()
-{
-    QAction* action = qobject_cast<QAction*>(sender());
-
-    if (!action)
-    {
-        return;
-    }
-
-    gt::for_each_key(m_dockWidgets, [this, action](GtDockWidget* e)
-    {
-        if (m_dockWidgets.value(e) == action)
-        {
-            e->setVisible(action->isChecked());
-        }
-    });
-}
-
-void
 GtMainWin::onWidgetStructureClicked()
 {
     gtDebug() << "widget structure...";
@@ -1236,7 +1227,7 @@ GtMainWin::onEditorWindowActive(int editorIndex)
     {
         // all windows closed
         m_mainWindowToolbar->setEditorActions({});
-        currentMdiItemPrintable(false);
+        emit currentMdiItemPrintable(false);
         return;
     }
 
@@ -1250,7 +1241,7 @@ void
 GtMainWin::setTheme(bool /*dark*/)
 {
     gt::gui::applyThemeToApplication();
-    gt::gui::applyThemeToWidget(ui->mdiArea);
+    gt::gui::applyThemeToWidget(centralWidget());
 
     // update all standalone widgets (i.e. windows)
     QWidgetList const& windows = QApplication::topLevelWidgets();

--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -84,7 +84,7 @@ GtMainWin::GtMainWin(QWidget* parent) : QMainWindow(parent),
     ui->centralwidget->setParent(nullptr);
     auto* manager = new ads::CDockManager(this);
 
-    auto* area = new ads::CDockWidget(QStringLiteral("Home"));
+    auto* area = new ads::CDockWidget(manager, QStringLiteral("Home"));
     area->setWidget(ui->centralwidget);
     manager->setCentralWidget(area);
 
@@ -450,17 +450,24 @@ GtMainWin::setupDockWidgets()
 #if USE_ALTERNATIVE_DOCKING_SYSTEM
             auto* manager = (ads::CDockManager*)(this->centralWidget());
 
-            auto* dock = new ads::CDockWidget(legacyDock->objectName());
+            auto* dock = new ads::CDockWidget(manager, legacyDock->objectName());
             dock->setIcon(legacyDock->getIcon());
             dock->setWidget(legacyDock);
-            manager->addDockWidget((ads::DockWidgetArea)legacyDock->getDockWidgetArea(), dock);
+            auto* area = manager->addDockWidget(static_cast<ads::DockWidgetArea>(legacyDock->getDockWidgetArea()), dock);
 
             legacyDock->setTitleBarWidget(new QWidget());
             legacyDock->setFeatures(QDockWidget::NoDockWidgetFeatures);
 
-            dock->setFrameShape(QFrame::NoFrame);
+            // style buttons more appropriately
+            for (auto* child : area->findChildren<QPushButton*>(QStringLiteral("tabCloseButton")))
+            {
+                child->setFlat(true);
+                child->resize(child->height(), child->height());
+            }
 
-            for (auto* child : dock->findChildren<QFrame*>())
+            // remove frames
+            dock->setFrameShape(QFrame::NoFrame);
+            for (auto* child : dock->findChildren<QFrame*>(QStringLiteral("dockWidgetScrollArea"), Qt::FindDirectChildrenOnly))
             {
                 child->setFrameShape(QFrame::NoFrame);
             }

--- a/src/app/gt_mainwin.cpp
+++ b/src/app/gt_mainwin.cpp
@@ -467,7 +467,7 @@ GtMainWin::setupDockWidgets()
 
             using DockWidget = ads::CDockWidget;
 #else
-            legacyDock->setWindowTitle(dock->objectName());
+            legacyDock->setWindowTitle(legacyDock->objectName());
             legacyDock->setFeatures(QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable);
             addDockWidget(legacyDock->getDockWidgetArea(), legacyDock);
 

--- a/src/app/gt_mainwin.h
+++ b/src/app/gt_mainwin.h
@@ -94,9 +94,6 @@ private:
     /// First time show event indicator
     bool m_firstTimeShowEvent;
 
-    /// List of initialized dock widgets
-    QMap<GtDockWidget*, QAction*> m_dockWidgets;
-
     /// Pointer to Process Queue Widget
     QPointer<GtProcessQueueWidget> m_processQueue;
 
@@ -334,19 +331,6 @@ private slots:
      * @param obj Currently selected object.
      */
     void onObjectSelected(GtObject* obj);
-
-    /**
-     * @brief Called on dock widget visibility change to change menu action
-     * checked state.
-     * @param val New dock widget visibility.
-     */
-    void onDockVisibilityChange(bool val);
-
-    /**
-     * @brief Called after one dock widget action was clicked to show or hide
-     * the corresponding dock widget.
-     */
-    void onDockActionClicked();
 
     /**
      * @brief onWidgetStructureClicked

--- a/src/app/gt_mainwin.h
+++ b/src/app/gt_mainwin.h
@@ -216,7 +216,7 @@ private slots:
      * @brief perspectiveChanged
      * @param id
      */
-    void loadPerspectiveSettings(const QString& id = QString());
+    void loadPerspectiveSettings(const QString& id = {});
 
     /**
      * @brief savePerspectiveSettings

--- a/src/app/mdi_items/examples/gt_examplegraphicalitem.cpp
+++ b/src/app/mdi_items/examples/gt_examplegraphicalitem.cpp
@@ -97,7 +97,6 @@ GtExampleGraphicalItem::GtExampleGraphicalItem(GtExamplesEntry data,
     QFont fnt("Helvetica", 9);
     fnt.setBold(true);
 
-    nameLabel->setFrameStyle(QFrame::NoFrame);
     nameLabel->setStyleSheet("background-color: rgba(0,0,0,0%);"
                              "border: 0px solid gray");
     nameLabel->setFrameStyle(QFrame::NoFrame);

--- a/src/gui/gt_application.cpp
+++ b/src/gui/gt_application.cpp
@@ -339,6 +339,18 @@ GtApplication::duplicatePerspective(const QString& source,
     return GtPerspective::duplicatePerspective(source, target);
 }
 
+GtPerspective*
+GtApplication::perspective()
+{
+    return m_perspective.get();
+}
+
+const GtPerspective*
+GtApplication::perspective() const
+{
+    return m_perspective.get();
+}
+
 void
 GtApplication::savePerspectiveData(const QByteArray& geometry,
                                    const QByteArray& state)
@@ -351,7 +363,7 @@ GtApplication::savePerspectiveData(const QByteArray& geometry,
 }
 
 QPair<QByteArray, QByteArray>
-GtApplication::loadPerspectiveData()
+GtApplication::loadPerspectiveData() const
 {
     if (m_perspective)
     {

--- a/src/gui/gt_application.h
+++ b/src/gui/gt_application.h
@@ -121,9 +121,14 @@ public:
      */
     bool duplicatePerspective(const QString& source, const QString& target);
 
+    GtPerspective* perspective();
+
+    GtPerspective const* perspective() const;
+
     /**
      * @brief savePerspective
      */
+    GT_DEPRECATED_REMOVED_IN(2, 2, "use `perspective()` instead")
     void savePerspectiveData(const QByteArray& geometry,
                              const QByteArray& state);
 
@@ -131,7 +136,8 @@ public:
      * @brief loadPerspectiveData
      * @return
      */
-    QPair<QByteArray, QByteArray> loadPerspectiveData();
+    GT_DEPRECATED_REMOVED_IN(2, 2, "use `perspective()` instead")
+    QPair<QByteArray, QByteArray> loadPerspectiveData() const;
 
     /**
      * @brief initShortCuts - intializaion of the short-cuts based

--- a/src/gui/gt_mdiitem.h
+++ b/src/gui/gt_mdiitem.h
@@ -109,6 +109,7 @@ public:
       * @brief subWin
       * @return
       */
+    GT_DEPRECATED_REMOVED_IN(2, 2, "No replacement planned.")
     QWidget* subWin();
 
     /**

--- a/src/gui/gt_perspective.cpp
+++ b/src/gui/gt_perspective.cpp
@@ -141,6 +141,35 @@ GtPerspective::saveGeometry(const QByteArray& data)
 }
 
 void
+GtPerspective::saveDockState(const QByteArray& data)
+{
+    QString path = gtApp->roamingPath() + QDir::separator() +
+                   QStringLiteral("perspective");
+
+    QDir dir(path);
+
+    if (!dir.exists())
+    {
+        gtError() << tr("roaming path not found!");
+        return;
+    }
+
+    QString persFilename = objectName() + QStringLiteral(".dock_state");
+
+    QFile file(dir.absoluteFilePath(persFilename));
+
+    if (!file.open(QIODevice::WriteOnly))
+    {
+        gtError() << tr("could not create perspective file!");
+        return;
+    }
+
+    file.write(data);
+
+    file.close();
+}
+
+void
 GtPerspective::saveState(const QByteArray& data)
 {
     QString path = gtApp->roamingPath() + QDir::separator() +
@@ -170,7 +199,7 @@ GtPerspective::saveState(const QByteArray& data)
 }
 
 QByteArray
-GtPerspective::loadGeometry()
+GtPerspective::loadGeometry() const
 {
     QString path = gtApp->roamingPath() + QDir::separator() +
                    QStringLiteral("perspective");
@@ -201,7 +230,38 @@ GtPerspective::loadGeometry()
 }
 
 QByteArray
-GtPerspective::loadState()
+GtPerspective::loadDockState() const
+{
+    QString path = gtApp->roamingPath() + QDir::separator() +
+                   QStringLiteral("perspective");
+
+    QDir dir(path);
+
+    if (!dir.exists())
+    {
+        gtFatal() << tr("roaming path not found!");
+        return QByteArray();
+    }
+
+    QString persFilename = objectName() + QStringLiteral(".dock_state");
+
+    QFile file(dir.absoluteFilePath(persFilename));
+
+    if (!file.open(QIODevice::ReadOnly))
+    {
+        gtError() << tr("Could not create perspective file!");
+        return QByteArray();
+    }
+
+    QByteArray data = file.readAll();
+
+    file.close();
+
+    return data;
+}
+
+QByteArray
+GtPerspective::loadState() const
 {
     QString path = gtApp->roamingPath() + QDir::separator() +
                    QStringLiteral("perspective");

--- a/src/gui/gt_perspective.h
+++ b/src/gui/gt_perspective.h
@@ -15,6 +15,8 @@
 
 #include "gt_object.h"
 
+#include <QDir>
+
 /**
  * @brief The GtPerspective class
  */
@@ -24,6 +26,41 @@ class GT_GUI_EXPORT GtPerspective : public GtObject
 
 public:
 
+    /**
+     * @brief saveGeometry
+     * @param data
+     */
+    void saveGeometry(const QByteArray& data);
+
+    /**
+     * @brief saveState
+     * @param data
+     */
+    void saveDockState(const QByteArray& data);
+
+    /**
+     * @brief saveState
+     * @param data
+     */
+    void saveState(const QByteArray& data);
+
+    /**
+     * @brief loadGeometry
+     * @return
+     */
+    QByteArray loadGeometry() const;
+
+    /**
+     * @brief saveState
+     * @param data
+     */
+    QByteArray loadDockState() const;
+
+    /**
+     * @brief loadState
+     * @return
+     */
+    QByteArray loadState() const;
 
 protected:
     /**
@@ -53,30 +90,6 @@ protected:
      */
     static bool duplicatePerspective(const QString& source,
                                      const QString& target);
-
-    /**
-     * @brief saveGeometry
-     * @param data
-     */
-    void saveGeometry(const QByteArray& data);
-
-    /**
-     * @brief saveState
-     * @param data
-     */
-    void saveState(const QByteArray& data);
-
-    /**
-     * @brief loadGeometry
-     * @return
-     */
-    QByteArray loadGeometry();
-
-    /**
-     * @brief loadState
-     * @return
-     */
-    QByteArray loadState();
 
     /**
      * @brief emptyFile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a draft PR, attempting to integrate the Qt-ADS library into GTlab to provide advanced docking features and better UX. Currently no ABI/API changes are needed.

Qt-ADS (LGPL license): https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System

Related to #462 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Integrate Qt Advanced Docking System as an alternative docking backend and adjust main window initialization to support it.

New Features:
- Provide optional integration of qtadvanceddocking-qt5 to manage dock widgets and central content.
- Add dynamic menu-driven visibility control for both legacy and ADS-based dock widgets using a unified code path.

Enhancements:
- Simplify dock widget visibility handling by removing custom visibility/action sync slots and wiring actions directly via lambdas.
- Apply application theming to the main window's central widget instead of the legacy MDI area to align with the new docking setup.
- Clean up redundant frame styling on several widgets now managed by the new docking system.

Build:
- Add qtadvanceddocking-qt5 as a required package and link dependency in the CMake configuration.