### PR TITLE
Parallel execution in a test task

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -51,6 +51,7 @@ set(headers
     process_management/gt_calculatordata.h
     process_management/gt_taskrunner.h
     process_management/gt_loop.h
+    process_management/gt_doetask.h
     process_management/gt_doublemonitoringproperty.h
     process_management/gt_intmonitoringproperty.h
     process_management/gt_monitoringdata.h
@@ -160,6 +161,7 @@ set(sources
     process_management/gt_calculatordata.cpp
     process_management/gt_taskrunner.cpp
     process_management/gt_loop.cpp
+    process_management/gt_doetask.cpp
     process_management/gt_doublemonitoringproperty.cpp
     process_management/gt_intmonitoringproperty.cpp
     process_management/gt_monitoringdata.cpp
@@ -258,6 +260,7 @@ target_link_libraries(GTlabCore
     PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Concurrent
     GTlab::DataProcessor
 )
 

--- a/src/core/process_management/gt_abstractrunnable.cpp
+++ b/src/core/process_management/gt_abstractrunnable.cpp
@@ -28,6 +28,24 @@ GtAbstractRunnable::linkedObjects() const
 }
 
 void
+GtAbstractRunnable::setLinkedObjects(const QList<GtObject*>& objects)
+{
+    m_linkedObjects = objects;
+}
+
+void
+GtAbstractRunnable::addLinkedObject(GtObject* object)
+{
+    m_linkedObjects.append(object);
+}
+
+void
+GtAbstractRunnable::setInputData(const QList<GtObjectMemento>& data)
+{
+    m_inputData = data;
+}
+
+void
 GtAbstractRunnable::appendSourceData(const GtObjectMemento& memento)
 {
     m_inputData << memento;
@@ -38,12 +56,6 @@ GtAbstractRunnable::appendSourceData(const GtObjectMemento& memento)
     //    {
     //        m_outputData.insert(uuid, memento);
     //    }
-}
-
-const QList<GtObjectMemento>&
-GtAbstractRunnable::outputData() const
-{
-    return m_outputData;
 }
 
 bool
@@ -76,4 +88,28 @@ bool
 GtAbstractRunnable::successful()
 {
     return m_successfulRun;
+}
+
+void
+GtAbstractRunnable::setDOEContext(const DOEContext& context)
+{
+    m_doeContext = context;
+}
+
+GtAbstractRunnable::DOEContext
+GtAbstractRunnable::doeContext() const
+{
+    return m_doeContext;
+}
+
+const QList<GtObjectMemento>&
+GtAbstractRunnable::inputData() const
+{
+    return m_inputData;
+}
+
+const QList<GtObjectMemento>&
+GtAbstractRunnable::outputData() const
+{
+    return m_outputData;
 }

--- a/src/core/process_management/gt_abstractrunnable.h
+++ b/src/core/process_management/gt_abstractrunnable.h
@@ -49,16 +49,40 @@ public:
     const QList<GtObject*>& linkedObjects() const;
 
     /**
+     * @brief setLinkedObjects
+     * @param objects
+     */
+    void setLinkedObjects(const QList<GtObject*>& objects);
+
+    /**
+     * @brief addLinkedObject
+     * @param object
+     */
+    void addLinkedObject(GtObject* object);
+
+    /**
      * @brief appendSourceData
      * @param memento
      */
     void appendSourceData(const GtObjectMemento& memento);
 
     /**
+     * @brief setInputData
+     * @param data
+     */
+    void setInputData(const QList<GtObjectMemento>& data);
+
+    /**
      * @brief sourceData
      * @return
      */
     const QList<GtObjectMemento>& outputData() const;
+
+    /**
+     * @brief inputData
+     * @return
+     */
+    const QList<GtObjectMemento>& inputData() const;
 
     /**
      * @brief Appends additional process component to runnable queue.
@@ -99,6 +123,30 @@ public:
      * @return
      */
     bool successful();
+
+    /**
+     * @brief DOE execution context structure
+     * Contains metadata for tracking parallel execution runs
+     */
+    struct DOEContext
+    {
+        int iteration{0};
+        int runIndex{0};
+        int totalRuns{0};
+        QString runId;
+    };
+
+    /**
+     * @brief setDOEContext
+     * @param context
+     */
+    void setDOEContext(const DOEContext& context);
+
+    /**
+     * @brief doeContext
+     * @return
+     */
+    DOEContext doeContext() const;
 
     /**
      * @brief Returns datamodel object based on given object uuid. If no
@@ -175,6 +223,9 @@ protected:
 
     ///
     bool m_successfulRun;
+
+    /// DOE execution context for parallel runs
+    DOEContext m_doeContext;
 
 signals:
     /**

--- a/src/core/process_management/gt_calculator.cpp
+++ b/src/core/process_management/gt_calculator.cpp
@@ -210,7 +210,7 @@ GtCalculator::setExecModeLocal()
 }
 
 const QString&
-GtCalculator::executionLabel()
+GtCalculator::executionLabel() const
 {
     return pimpl->labelProperty.get();
 }
@@ -219,6 +219,34 @@ void
 GtCalculator::setExecutionLabel(const QString& label)
 {
     pimpl->labelProperty.setVal(label);
+}
+
+GtAbstractRunnable::DOEContext
+GtCalculator::doeContext() const
+{
+    if (!runnable())
+    {
+        return {}; // Empty context
+    }
+
+    return runnable()->doeContext();
+}
+
+QString
+GtCalculator::executionLabelWithIndex() const
+{
+    auto ctx = doeContext();
+
+    if (ctx.totalRuns <= 1)
+    {
+        return executionLabel(); // Kein Tracking nötig
+    }
+
+    // Append run index to label
+    return QString("%1 [Run %2/%3]")
+        .arg(executionLabel())
+        .arg(ctx.runIndex + 1)  // 1-based for display
+        .arg(ctx.totalRuns);
 }
 
 bool

--- a/src/core/process_management/gt_calculator.h
+++ b/src/core/process_management/gt_calculator.h
@@ -11,6 +11,7 @@
 #ifndef GTCALCULATOR_H
 #define GTCALCULATOR_H
 
+#include "gt_abstractrunnable.h"
 #include "gt_core_exports.h"
 #include "gt_labelproperty.h"
 #include "gt_modeproperty.h"
@@ -114,13 +115,26 @@ public:
      * @brief Returns current execution identification label.
      * @return Identification label.
      */
-    const QString& executionLabel();
+    const QString& executionLabel() const;
 
     /**
      * @brief Sets current execution identification label.
      * @param label - New Identification label.
      */
     void setExecutionLabel(const QString& label);
+
+    /**
+     * @brief Returns DOE execution context.
+     * @return DOE context structure.
+     */
+    GtAbstractRunnable::DOEContext doeContext() const;
+
+    /**
+     * @brief Returns execution label with run index for parallel execution.
+     * Appends "[Run X/Y]" to the label if totalRuns > 1.
+     * @return Labeled execution label.
+     */
+    QString executionLabelWithIndex() const;
 
     /**
      * @brief Returns true if run should be marked as failed if warning flag

--- a/src/core/process_management/gt_doetask.cpp
+++ b/src/core/process_management/gt_doetask.cpp
@@ -1,0 +1,176 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ *
+ *  Created on: 16.07.2026
+ *  Author: Code Generation
+ */
+
+#include "gt_doetask.h"
+#include "gt_runnable.h"
+#include <QThreadPool>
+#include "gt_abstractrunnable.h"
+#include "gt_calculator.h"
+#include "gt_processcomponent.h"
+
+GtDOETask::GtDOETask()
+    : m_doeRunCount(QStringLiteral("doeRunCount"),
+                   tr("Number of DOE Runs"),
+                   tr("Total number of parallel DOE execution runs"),
+                   gt::Boundaries<int>::makeLower(1), 100)
+    , m_maxParallelRuns(QStringLiteral("maxParallelRuns"),
+                        tr("Maximum Parallel Runs"),
+                        tr("Maximum number of parallel execution channels"),
+                        gt::Boundaries<int>::makeLower(1),
+                        QThreadPool::globalInstance()->maxThreadCount())
+{
+    setObjectName(QStringLiteral("DOE Task"));
+
+    enableMaxIterationProperty();
+    enableCurrentIterationMonitoring();
+
+    registerProperty(m_doeRunCount, tr("DOE Settings"));
+    registerProperty(m_maxParallelRuns, tr("Execution"));
+}
+
+int
+GtDOETask::doeRunCount() const
+{
+    return m_doeRunCount.getVal();
+}
+
+void
+GtDOETask::setDoeRunCount(int count)
+{
+    m_doeRunCount.setVal(count);
+}
+
+int
+GtDOETask::maxParallelRuns() const
+{
+    return m_maxParallelRuns.getVal();
+}
+
+void
+GtDOETask::setMaxParallelRuns(int count)
+{
+    m_maxParallelRuns.setVal(count);
+}
+
+bool
+GtDOETask::runIteration()
+{
+    return runChildElementsParallel();
+}
+
+bool
+GtDOETask::runChildElementsParallel()
+{
+    int iteration = currentIterationStep();
+    int totalRuns = doeRunCount();
+    int maxParallel = maxParallelRuns();
+
+    // increment current iteration step
+    m_currentIter.setVal(m_currentIter.getVal() + 1);
+
+    if (totalRuns <= 0)
+    {
+        return false;
+    }
+
+    QList<GtAbstractRunnable*> runnables = prepareChildRunnables(iteration, totalRuns, maxParallel);
+
+    if (runnables.isEmpty())
+    {
+        return false;
+    }
+
+    bool success = executeRunnablesParallel(runnables, maxParallel);
+
+    foreach (GtAbstractRunnable* r, runnables)
+    {
+        delete r;
+    }
+
+    return success;
+}
+
+QList<GtAbstractRunnable*>
+GtDOETask::prepareChildRunnables(int iteration, int totalRuns, int maxParallel)
+{
+    Q_UNUSED(maxParallel)
+
+    QList<GtAbstractRunnable*> runnables;
+
+    QList<GtProcessComponent*> childs = processComponents();
+
+    for (int i = 0; i < totalRuns; ++i)
+    {
+        auto* runnable = new GtRunnable();
+        setupChildContext(runnable, iteration, i, totalRuns);
+
+        foreach (GtProcessComponent* comp, childs)
+        {
+            auto* compCopy = qobject_cast<GtProcessComponent*>(comp->clone());
+            if (compCopy)
+            {
+                runnable->appendProcessComponent(compCopy);
+            }
+        }
+
+        runnable->setAutoDelete(false);
+        runnables.append(runnable);
+    }
+
+    return runnables;
+}
+
+bool
+GtDOETask::executeRunnablesParallel(QList<GtAbstractRunnable*>& runnables, int maxParallel)
+{
+    QThreadPool* threadPool = QThreadPool::globalInstance();
+
+    if (!threadPool)
+    {
+        return false;
+    }
+
+    threadPool->setMaxThreadCount(qMin(maxParallel, runnables.size()));
+
+    foreach (GtAbstractRunnable* r, runnables)
+    {
+        threadPool->start(r);
+    }
+
+    threadPool->waitForDone();
+
+    bool success = true;
+
+    foreach (GtAbstractRunnable* r, runnables)
+    {
+        if (!r->successful())
+        {
+            success = false;
+            break;
+        }
+    }
+
+    return success;
+}
+
+void
+GtDOETask::setupChildContext(GtAbstractRunnable* runnable, int iteration, int runIndex, int totalRuns)
+{
+    if (!runnable)
+    {
+        return;
+    }
+
+    GtAbstractRunnable::DOEContext context;
+    context.iteration = iteration;
+    context.runIndex = runIndex;
+    context.totalRuns = totalRuns;
+
+    runnable->setDOEContext(context);
+}

--- a/src/core/process_management/gt_doetask.h
+++ b/src/core/process_management/gt_doetask.h
@@ -1,0 +1,43 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ *
+ *  Created on: 16.07.2026
+ *  Author: Code Generation
+ */
+
+#ifndef GTDOETASK_H
+#define GTDOETASK_H
+
+#include "gt_core_exports.h"
+#include "gt_task.h"
+#include "gt_intproperty.h"
+
+class GT_CORE_EXPORT GtDOETask : public GtTask
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE GtDOETask();
+
+    bool runIteration() override;
+
+    int doeRunCount() const;
+    void setDoeRunCount(int count);
+
+    int maxParallelRuns() const;
+    void setMaxParallelRuns(int count);
+
+    bool runChildElementsParallel();
+
+private:
+    GtIntProperty m_doeRunCount;
+    GtIntProperty m_maxParallelRuns;
+
+    QList<GtAbstractRunnable*> prepareChildRunnables(int iteration, int totalRuns, int maxParallel);
+    bool executeRunnablesParallel(QList<GtAbstractRunnable*>& runnables, int maxParallel);
+    void setupChildContext(GtAbstractRunnable* runnable, int iteration, int runIndex, int totalRuns);
+};
+
+#endif // GTDOETASK_H

--- a/src/core/process_management/gt_processcomponent.cpp
+++ b/src/core/process_management/gt_processcomponent.cpp
@@ -189,6 +189,27 @@ GtProcessComponent::setProgress(int progress)
     emit progressStateChanged(pimpl->progress);
 }
 
+const QPointer<GtAbstractRunnable>&
+GtProcessComponent::publicRunnable() const
+{
+    return runnable();
+}
+
+GtProcessComponent&
+GtProcessComponent::publicSetRunnable(QPointer<GtAbstractRunnable> p)
+{
+    return setRunnable(p);
+}
+
+void
+GtProcessComponent::setInputDataToRunnable(const QList<GtObjectMemento>& data)
+{
+    if (QPointer<GtAbstractRunnable> r = runnable())
+    {
+        r->setInputData(data);
+    }
+}
+
 QList<GtAbstractProperty*>
 GtProcessComponent::monitoringProperties()
 {

--- a/src/core/process_management/gt_processcomponent.h
+++ b/src/core/process_management/gt_processcomponent.h
@@ -284,6 +284,25 @@ public slots:
      */
     void setProgress(int progress);
 
+    /**
+     * @brief publicRunnable - Access to protected runnable() for subclasses
+     * @return
+     */
+    const QPointer<GtAbstractRunnable>& publicRunnable() const;
+
+    /**
+     * @brief publicSetRunnable - Access to protected setRunnable() for subclasses
+     * @param p
+     * @return
+     */
+    GtProcessComponent& publicSetRunnable(QPointer<GtAbstractRunnable> p);
+
+    /**
+     * @brief setInputDataToRunnable - Set input data to attached runnable
+     * @param data
+     */
+    void setInputDataToRunnable(const QList<GtObjectMemento>& data);
+
 protected:
     /**
      * @brief Constructor

--- a/src/core/process_management/gt_task.cpp
+++ b/src/core/process_management/gt_task.cpp
@@ -16,9 +16,15 @@
 #include "gt_objectlinkproperty.h"
 #include "gt_objectpathproperty.h"
 #include "gt_processrunnerglobals.h"
+#include "gt_objectmemento.h"
+#include "gt_objectfactory.h"
 
 #include <QDebug>
 #include <QThreadPool>
+#include <QFuture>
+#include <QFutureSynchronizer>
+#include <QtConcurrent/QtConcurrent>
+#include <QDir>
 
 #include <algorithm>
 
@@ -315,6 +321,13 @@ GtTask::maxIterationSteps() const
     return m_maxIter;
 }
 
+void
+GtTask::setMaxIteration(int maxIterations)
+{
+    enableMaxIterationProperty();
+    m_maxIter = maxIterations;
+}
+
 int
 GtTask::currentIterationStep() const
 {
@@ -541,11 +554,11 @@ GtTask::collectPropertyConnectionHelper(QList<GtPropertyConnection*>& list,
 bool
 GtTask::childHasWarnings() const
 {
-    auto const childs = findDirectChildren<GtProcessComponent*>();
+    auto const childs = this->findDirectChildren<GtProcessComponent*>();
     return std::any_of(std::begin(childs), std::end(childs),
-                       [](const GtProcessComponent* child) {
-        return child->currentState() == WARN_FINISHED;
-    });
+                        [](const GtProcessComponent* child) {
+         return child->currentState() == WARN_FINISHED;
+     });
 }
 
 void

--- a/src/core/process_management/gt_task.h
+++ b/src/core/process_management/gt_task.h
@@ -118,6 +118,7 @@ public:
      * @return Max. number of iteration steps.
      */
     int maxIterationSteps() const;
+    void setMaxIteration(int maxIterations);
 
     /**
      * @brief Returns current iteration step.

--- a/src/core/process_management/gt_taskfactory.cpp
+++ b/src/core/process_management/gt_taskfactory.cpp
@@ -17,6 +17,7 @@
 #include "gt_processdata.h"
 #include "gt_taskdata.h"
 #include "gt_parameterloop.h"
+#include "gt_doetask.h"
 
 #include "gt_taskfactory.h"
 
@@ -55,6 +56,13 @@ GtTaskFactory::GtTaskFactory(QObject* parent) : QObject(parent)
                                     "between start and end value");
     parameterLoop->status = GtTaskDataImpl::RELEASE;
     GtTaskFactory::registerTaskData(parameterLoop);
+
+    GtTaskData doeTask = GT_TASK_DATA(GtDOETask);
+    doeTask->id = QStringLiteral("Parallel Test");
+    doeTask->version = GtVersionNumber(0,1);
+    doeTask->description = tr("Parallel test");
+    doeTask->status = GtTaskDataImpl::RELEASE;
+    GtTaskFactory::registerTaskData(doeTask);
 }
 
 

--- a/tests/unittests/calculators/test_gt_doetask.cpp
+++ b/tests/unittests/calculators/test_gt_doetask.cpp
@@ -1,0 +1,162 @@
+// /* GTlab - Gas Turbine laboratory
+//  *
+//  * SPDX-License-Identifier: MPL-2.0+
+//  * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+//  * Source File: test_gt_doetask.cpp
+//  */
+
+// #include "gtest/gtest.h"
+
+// #include <QDir>
+// #include <QMetaObject>
+
+// #include "core/test_gt_processtestclasses.h"
+
+// #include "gt_doetask.h"
+// #include "gt_runnable.h"
+// #include "gt_doubleproperty.h"
+// #include "gt_object.h"
+// #include "gt_objectmemento.h"
+// #include "gt_objectlinkproperty.h"
+// #include "gt_objectpathproperty.h"
+// #include "gt_task.h"
+// #include "gt_calculator.h"
+
+// class TestDOERunnable : public GtRunnable
+// {
+// public:
+//     void run() override
+//     {
+//     }
+// };
+
+// class SimpleCalculator : public GtCalculator
+// {
+// public:
+//     SimpleCalculator()
+//     {
+//         m_valueProp = new GtDoubleProperty("value", "Value");
+//         registerProperty(*m_valueProp);
+//     }
+
+//     ~SimpleCalculator() override
+//     {
+//         delete m_valueProp;
+//     }
+
+//     bool run() override
+//     {
+//         m_valueProp->setVal(m_valueProp->get() + 1.0);
+//         return true;
+//     }
+
+//     GtDoubleProperty* valueProp()
+//     {
+//         return m_valueProp;
+//     }
+
+// private:
+//     GtDoubleProperty* m_valueProp;
+// };
+
+// TEST(DOETaskTest, BasicParallelExecution)
+// {
+//     TestDOERunnable* runnable = new TestDOERunnable();
+//     runnable->setAutoDelete(false);
+
+//     GtObject* obj = new GtObject();
+//     obj->setUuid("test-uuid-001");
+//     runnable->addLinkedObject(obj);
+
+//     GtObjectMemento memento(obj, true);
+//     runnable->appendSourceData(memento);
+
+//     GtDOETask task;
+//     task.publicSetRunnable(runnable);
+
+//     SimpleCalculator* calc1 = new SimpleCalculator();
+//     calc1->setExecutionLabel("Calculator 1");
+//     task.appendChild(calc1);
+
+//     SimpleCalculator* calc2 = new SimpleCalculator();
+//     calc2->setExecutionLabel("Calculator 2");
+//     task.appendChild(calc2);
+
+//     EXPECT_EQ(task.processComponents().count(), 2);
+
+//     bool result = task.runIteration();
+
+//     EXPECT_TRUE(result);
+
+//     EXPECT_DOUBLE_EQ(calc1->valueProp()->get(), 1.0);
+//     EXPECT_DOUBLE_EQ(calc2->valueProp()->get(), 1.0);
+
+//     EXPECT_EQ(task.currentIterationStep(), 1);
+// }
+
+// TEST(DOETaskTest, DOEContextTracking)
+// {
+//     TestDOERunnable* runnable = new TestDOERunnable();
+//     runnable->setAutoDelete(false);
+
+//     GtObject* obj = new GtObject();
+//     obj->setUuid("test-uuid-002");
+//     runnable->addLinkedObject(obj);
+
+//     GtObjectMemento memento(obj, true);
+//     runnable->appendSourceData(memento);
+
+//     GtDOETask task;
+//     task.publicSetRunnable(runnable);
+
+//     SimpleCalculator* calc1 = new SimpleCalculator();
+//     calc1->setExecutionLabel("Calculator 1");
+//     task.appendChild(calc1);
+
+//     SimpleCalculator* calc2 = new SimpleCalculator();
+//     calc2->setExecutionLabel("Calculator 2");
+//     task.appendChild(calc2);
+
+//     bool result = task.runIteration();
+
+//     EXPECT_TRUE(result);
+
+//     EXPECT_EQ(calc1->doeContext().totalRuns, 2);
+//     EXPECT_EQ(calc1->doeContext().runIndex, 0);
+//     EXPECT_EQ(calc1->doeContext().iteration, 1);
+
+//     EXPECT_EQ(calc2->doeContext().totalRuns, 2);
+//     EXPECT_EQ(calc2->doeContext().runIndex, 1);
+//     EXPECT_EQ(calc2->doeContext().iteration, 1);
+
+//     EXPECT_EQ(calc1->doeContext().runId, "iter-1-run-0");
+//     EXPECT_EQ(calc2->doeContext().runId, "iter-1-run-1");
+// }
+
+// TEST(DOETaskTest, MultipleIterations)
+// {
+//     TestDOERunnable* runnable = new TestDOERunnable();
+//     runnable->setAutoDelete(false);
+
+//     GtObject* obj = new GtObject();
+//     obj->setUuid("test-uuid-003");
+//     runnable->addLinkedObject(obj);
+
+//     GtObjectMemento memento(obj, true);
+//     runnable->appendSourceData(memento);
+
+//     GtDOETask task;
+//     task.publicSetRunnable(runnable);
+//     task.setMaxIteration(3);
+
+//     SimpleCalculator* calc = new SimpleCalculator();
+//     calc->setExecutionLabel("Calculator");
+//     task.appendChild(calc);
+
+//     bool result = task.runIteration();
+
+//     EXPECT_TRUE(result);
+//     EXPECT_EQ(task.currentIterationStep(), 3);
+
+//     EXPECT_DOUBLE_EQ(calc->valueProp()->get(), 3.0);
+// }


### PR DESCRIPTION
Currently this PR is a sandbox for some tests for parallel execution in tasks

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Add infrastructure and a dedicated DOE task to support parallel execution of child process components with contextual run metadata and improved runnable/task configuration.

New Features:
- Introduce DOEContext metadata in GtAbstractRunnable and propagate it to calculators for labeling parallel runs
- Add public accessors on GtProcessComponent to expose and configure the attached runnable, including passing input data
- Add configuration for maximum iteration steps and parallel run counts to tasks via new DOE task type
- Implement GtDOETask to execute child process components in parallel using cloned runnables and a thread pool

Enhancements:
- Extend GtAbstractRunnable with APIs for managing linked objects and input data
- Make GtCalculator executionLabel const-correct and add a helper to include run indices for parallel executions
- Register the new DOE task in GtTaskFactory for discovery and use