### PR TITLE
add optional process execution info to GtCoreProcessExecutor::runTask()

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -62,6 +62,7 @@ set(headers
     process_management/gt_parameterloop.h
     process_management/gt_calculatorhelperfactory.h
     process_management/gt_stringmonitoringproperty.h
+    process_management/gt_processexecutioninfo.h
     process_management/process_runner/commands/gt_processrunnercommand.h
     process_management/process_runner/commands/gt_processrunnernotification.h
     process_management/process_runner/commands/gt_processrunnerresponse.h
@@ -171,6 +172,7 @@ set(sources
     process_management/gt_parameterloop.cpp
     process_management/gt_calculatorhelperfactory.cpp
     process_management/gt_stringmonitoringproperty.cpp
+    process_management/gt_processexecutioninfo.cpp
     process_management/process_runner/commands/gt_processrunnercommand.cpp
     process_management/process_runner/commands/gt_processrunnernotification.cpp
     process_management/process_runner/commands/gt_processrunnerresponse.cpp

--- a/src/core/gt_coreapplication.cpp
+++ b/src/core/gt_coreapplication.cpp
@@ -41,6 +41,7 @@
 #include "gt_moduleinterface.h"
 #include "gt_taskgroup.h"
 #include "gt_processdata.h"
+#include "gt_processexecutioninfo.h"
 
 #include <gt_logdest.h>
 
@@ -86,6 +87,7 @@ GtCoreApplication::GtCoreApplication(QCoreApplication* parent, AppMode batch) :
     // register data classes of core lib here
     gtObjectFactory->registerClass(GT_METADATA(GtProcessData));
     gtObjectFactory->registerClass(GT_METADATA(GtTaskGroup));
+    gtObjectFactory->registerClass(GT_METADATA(GtProcessExecutionInfo));
 }
 
 GtCoreApplication::~GtCoreApplication()

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -70,7 +70,7 @@ GtCoreProcessExecutor::setCoreExecutorFlags(Flags flags)
 
 bool
 GtCoreProcessExecutor::runTask(GtTask* task)
-{    
+{
     return runTask(task, nullptr);
 }
 

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -45,7 +45,7 @@ struct GtCoreProcessExecutor::Impl
     QPointer<GtRunnable> currentRunnable;
 
     /// store proc run info per task
-    QHash<GtTask*, GtProcessExecutionInfo*> processExecInfo;
+    QHash<GtTask*, QPointer<GtProcessExecutionInfo>> processExecInfo;
 };
 
 GtCoreProcessExecutor::GtCoreProcessExecutor(QObject* parent, Flags flags) :
@@ -157,6 +157,7 @@ bool
 GtCoreProcessExecutor::terminateAllTasks()
 {
     m_queue.clear();
+    pimpl->processExecInfo.clear();
 
     return !taskCurrentlyRunning() || terminateTask(m_current);
 }
@@ -224,6 +225,7 @@ GtCoreProcessExecutor::queueTask(GtTask* task, GtProcessExecutionInfo* procExcIn
 
     m_queue.append(task);
 
+    cleanupProcessExecutionMapping();
     if (procExcInfo!=Q_NULLPTR)
     {
         procExcInfo->setProcessState(GtProcessComponent::QUEUED);
@@ -244,7 +246,15 @@ GtCoreProcessExecutor::removeFromQueue(GtTask *task)
     {
         m_queue.removeAll(task);
 
-        if (task) task->setStateRecursively(GtTask::NONE);
+        if (task)
+        {
+            task->setStateRecursively(GtTask::NONE);
+        }
+
+        if(processExecutionInfo(task))
+        {
+            pimpl->processExecInfo.remove(task);
+        }
 
         emit queueChanged();
     }
@@ -324,9 +334,10 @@ GtCoreProcessExecutor::execute()
 
         connect(runner, &QObject::destroyed, &eventLoop, &QEventLoop::quit);
 
-        if(pimpl->processExecInfo.contains(m_current))
+        auto procExecInfo = processExecutionInfo(m_current);
+        if(procExecInfo)
         {
-            pimpl->processExecInfo[m_current]->setStartTimeNow();
+            procExecInfo->setStartTimeNow();
         }
 
         // run
@@ -410,12 +421,10 @@ GtCoreProcessExecutor::handleTaskFinishedHelper(
         }
 
 
-        if(pimpl->processExecInfo.contains(task))
+        auto procExecInfo = processExecutionInfo(task);
+        if(procExecInfo)
         {
-            auto _x = pimpl->processExecInfo[task];
-            _x->setProcessState(task->currentState());
-            _x->setDataDiffToMerge(sumDiff);
-            _x->setEndTimeNow();
+            procExecInfo->setDataDiffToMerge(sumDiff);
         }
 
     }
@@ -429,10 +438,6 @@ GtCoreProcessExecutor::handleTaskFinishedHelper(
     }
 
 
-    if(pimpl->processExecInfo.contains(task))
-    {
-        pimpl->processExecInfo.remove(task);
-    }
 
     gtDebugId(GT_EXEC_ID).medium() << __FUNCTION__ << "end";
 }
@@ -511,6 +516,31 @@ GtCoreProcessExecutor::setupTaskRunner()
     return runner;
 }
 
+GtProcessExecutionInfo*
+GtCoreProcessExecutor::processExecutionInfo(GtTask *task)
+{
+    if (task && pimpl->processExecInfo.contains(task))
+    {
+        return pimpl->processExecInfo[task];
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
+void GtCoreProcessExecutor::cleanupProcessExecutionMapping()
+{
+    for(auto key : pimpl->processExecInfo.keys())
+    {
+        if (pimpl->processExecInfo[key].isNull())
+        {
+            pimpl->processExecInfo.remove(key);
+        }
+    }
+}
+
+
 void
 GtCoreProcessExecutor::onTaskRunnerFinished()
 {
@@ -563,6 +593,17 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
     gtInfoId(GT_EXEC_ID).medium()
         << tr("----> Task finished (took %1 ms to merge) <----")
                .arg(timer.elapsed());
+
+
+
+    auto procExecInfo = processExecutionInfo(finishedTask);
+    if (procExecInfo)
+    {
+        procExecInfo->setProcessState(finishedTask->currentState());
+        procExecInfo->setEndTimeNow();
+        pimpl->processExecInfo.remove(finishedTask);
+    }
+    cleanupProcessExecutionMapping();
 
     // reset source
     m_source.clear();

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -21,6 +21,7 @@
 #include "gt_objectmementodiff.h"
 #include "gt_coreapplication.h"
 #include "gt_taskrunner.h"
+#include "gt_processexecutioninfo.h"
 
 #include "gt_coreprocessexecutor.h"
 
@@ -42,6 +43,9 @@ struct GtCoreProcessExecutor::Impl
 
     /// Pointer to current runnable
     QPointer<GtRunnable> currentRunnable;
+
+    /// store proc run info per task
+    QHash<GtTask*, GtProcessExecutionInfo*> processExecInfo;
 };
 
 GtCoreProcessExecutor::GtCoreProcessExecutor(QObject* parent, Flags flags) :
@@ -66,10 +70,15 @@ GtCoreProcessExecutor::setCoreExecutorFlags(Flags flags)
 
 bool
 GtCoreProcessExecutor::runTask(GtTask* task)
+{    
+    return runTask(task, nullptr);
+}
+
+bool GtCoreProcessExecutor::runTask(GtTask *task, GtProcessExecutionInfo *procExcInfo)
 {
     gtDebugId(GT_EXEC_ID).medium() << __FUNCTION__;
 
-    if (!queueTask(task))
+    if (!queueTask(task, procExcInfo))
     {
         return false;
     }
@@ -179,6 +188,12 @@ GtCoreProcessExecutor::queue() const
 bool
 GtCoreProcessExecutor::queueTask(GtTask* task)
 {
+    return queueTask(task, nullptr);
+}
+
+bool
+GtCoreProcessExecutor::queueTask(GtTask* task, GtProcessExecutionInfo* procExcInfo)
+{
     if (!task)
     {
         gtErrorId(GT_EXEC_ID)
@@ -208,6 +223,15 @@ GtCoreProcessExecutor::queueTask(GtTask* task)
     task->resetMonitoringProperties();
 
     m_queue.append(task);
+
+    if (procExcInfo!=Q_NULLPTR)
+    {
+        procExcInfo->setProcessState(GtProcessComponent::QUEUED);
+        procExcInfo->setQueuedTimeNow();
+        pimpl->processExecInfo[task] = procExcInfo;
+    }
+
+
     emit queueChanged();
 
     return true;
@@ -300,6 +324,11 @@ GtCoreProcessExecutor::execute()
 
         connect(runner, &QObject::destroyed, &eventLoop, &QEventLoop::quit);
 
+        if(pimpl->processExecInfo.contains(m_current))
+        {
+            pimpl->processExecInfo[m_current]->setStartTimeNow();
+        }
+
         // run
         runner->run();
 
@@ -379,6 +408,16 @@ GtCoreProcessExecutor::handleTaskFinishedHelper(
             gtWarningId(GT_EXEC_ID) << tr("Failed to apply memento diff!");
             ok = false;
         }
+
+
+        if(pimpl->processExecInfo.contains(task))
+        {
+            auto _x = pimpl->processExecInfo[task];
+            _x->setProcessState(task->currentState());
+            _x->setDataDiffToMerge(sumDiff);
+            _x->setEndTimeNow();
+        }
+
     }
 
     if (!ok)
@@ -387,6 +426,12 @@ GtCoreProcessExecutor::handleTaskFinishedHelper(
                 << tr("Data changes from the task '%1' could not be merged "
                       "back into datamodel!").arg(task->objectName());
         task->setState(GtProcessComponent::FAILED);
+    }
+
+
+    if(pimpl->processExecInfo.contains(task))
+    {
+        pimpl->processExecInfo.remove(task);
     }
 
     gtDebugId(GT_EXEC_ID).medium() << __FUNCTION__ << "end";

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -74,6 +74,7 @@ public:
      * @param process GtdProcess
      */
     bool runTask(GtTask* task);
+
     bool runTask(GtTask* task, GtProcessExecutionInfo* procExcInfo);
 
     /**
@@ -217,6 +218,18 @@ protected:
      * @return Task runner pointer (null if setup failed)
      */
     GtTaskRunner* setupTaskRunner();
+
+    /**
+     * @brief Return the GtProcessExecutionInfo for a task is available
+     * @return the GtProcessExecutionInfo (null is not available)
+     */
+    GtProcessExecutionInfo* processExecutionInfo(GtTask* task);
+
+    /**
+     * @brief Removes mappings to objects which are no longer available
+     */
+    void cleanupProcessExecutionMapping();
+
 
 private:
 

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -13,6 +13,7 @@
 
 #include "gt_core_exports.h"
 #include "gt_object.h"
+#include "gt_processexecutioninfo.h"
 
 #include <QObject>
 #include <QPointer>
@@ -73,6 +74,7 @@ public:
      * @param process GtdProcess
      */
     bool runTask(GtTask* task);
+    bool runTask(GtTask* task, GtProcessExecutionInfo* procExcInfo);
 
     /**
      * @brief Executes the next task in the queue. No task must be running.
@@ -125,6 +127,7 @@ public:
      * @return Success
      */
     bool queueTask(GtTask* task);
+    bool queueTask(GtTask* task, GtProcessExecutionInfo* procExcInfo);
 
     /**
      * @brief Removes the task from the queue

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -71,10 +71,17 @@ public:
 
     /**
      * @brief Runs a process if the queue is free
-     * @param process GtdProcess
+     * @param task GtTask
      */
     bool runTask(GtTask* task);
 
+    /**
+     * @brief Runs a process if the queue is free,
+     * the caller of runTask maintains ownership of the GtProcessExecutionInfo
+     * and has to take care of lifetime management
+     * @param task GtTask
+     * @param procExcInfo GtProcessExecutionInfo
+     */
     bool runTask(GtTask* task, GtProcessExecutionInfo* procExcInfo);
 
     /**
@@ -128,6 +135,14 @@ public:
      * @return Success
      */
     bool queueTask(GtTask* task);
+
+    /**
+     * @brief Queues a task,
+     * the caller of queueTask maintains ownership of the GtProcessExecutionInfo
+     * and has to take care of lifetime management
+     * @param task GtTask
+     * @param procExcInfo GtProcessExecutionInfo
+     */
     bool queueTask(GtTask* task, GtProcessExecutionInfo* procExcInfo);
 
     /**

--- a/src/core/process_management/gt_processexecutioninfo.cpp
+++ b/src/core/process_management/gt_processexecutioninfo.cpp
@@ -1,7 +1,7 @@
 /* GTlab - Gas Turbine laboratory
  *
  * SPDX-License-Identifier: MPL-2.0+
- * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
  * Source File: gt_processexecutioninfo.cpp
  *
  *  Created on: 10.04.2026

--- a/src/core/process_management/gt_processexecutioninfo.cpp
+++ b/src/core/process_management/gt_processexecutioninfo.cpp
@@ -1,0 +1,157 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ * Source File: gt_processexecutioninfo.cpp
+ *
+ *  Created on: 10.04.2026
+ *  Author: Matthias Schuff (SG-VTM)
+ *  Tel.:
+ */
+#include "gt_processexecutioninfo.h"
+#include "gt_doubleproperty.h"
+#include "gt_objectmementodiff.h"
+#include "gt_processcomponent.h"
+#include "gt_enumproperty.h"
+
+#include <QDateTime>
+#include <QDomDocument>
+
+
+struct GtProcessExecutionInfo::Impl
+{
+    Impl()
+    {
+        queuedTime.setReadOnly(true);
+        queuedTime.setOptional(true);
+        queuedTime.setActive(false);
+
+        startTime.setReadOnly(true);
+        startTime.setOptional(true);
+        startTime.setActive(false);
+
+        endTime.setReadOnly(true);
+        endTime.setOptional(true);
+        endTime.setActive(false);
+
+        processState.setReadOnly(true);
+        dataDiffToMerge.setReadOnly(true);
+    }
+
+    GtDoubleProperty queuedTime{"queuedTime", "Queued Time", "", GtUnit::Time, -1.0};
+    GtDoubleProperty startTime{"startTime", "Start Time", "", GtUnit::Time, -1.0};
+    GtDoubleProperty endTime{"endTime", "End Time", "", GtUnit::Time, -1.0};
+    GtEnumProperty<GtProcessComponent::STATE> processState{"processState", "Process State", ""};
+    GtStringProperty dataDiffToMerge{"dataDiffToMerge", "Data To Merge", ""};
+};
+
+GtProcessExecutionInfo::GtProcessExecutionInfo():
+    pimpl(std::make_unique<Impl>())
+{
+    registerProperty(pimpl->queuedTime);
+    registerProperty(pimpl->startTime);
+    registerProperty(pimpl->endTime);
+    registerProperty(pimpl->processState);
+    registerProperty(pimpl->dataDiffToMerge);
+}
+
+const double GtProcessExecutionInfo::queuedTime()
+{
+    return pimpl->queuedTime.getVal();
+}
+
+void GtProcessExecutionInfo::setQueuedTime(double queuedTime)
+{
+    pimpl->queuedTime = queuedTime;
+    pimpl->queuedTime.setActive(true);
+}
+
+void GtProcessExecutionInfo::setQueuedTimeNow()
+{
+    setQueuedTime(QDateTime::currentMSecsSinceEpoch()/1000.);
+}
+
+const double GtProcessExecutionInfo::startTime()
+{
+    return pimpl->startTime.getVal();
+}
+
+void GtProcessExecutionInfo::setStartTime(double startTime)
+{
+    pimpl->startTime = startTime;
+    pimpl->startTime.setActive(true);
+}
+
+void GtProcessExecutionInfo::setStartTimeNow()
+{
+    setStartTime(QDateTime::currentMSecsSinceEpoch()/1000.);
+}
+
+const double GtProcessExecutionInfo::endTime()
+{
+    return pimpl->endTime.getVal();
+}
+
+void GtProcessExecutionInfo::setEndTime(double endTime)
+{
+    pimpl->endTime.setVal(endTime);
+    pimpl->endTime.setActive(true);
+}
+
+void GtProcessExecutionInfo::setEndTimeNow()
+{
+    setEndTime(QDateTime::currentMSecsSinceEpoch()/1000.);
+}
+
+const GtProcessComponent::STATE GtProcessExecutionInfo::processState()
+{
+    return pimpl->processState.getVal();
+}
+
+void GtProcessExecutionInfo::setProcessState(GtProcessComponent::STATE state)
+{
+    pimpl->processState.setVal(state);
+}
+
+const GtObjectMementoDiff GtProcessExecutionInfo::dataDiffToMerge()
+{
+    GtObjectMementoDiff diff;
+
+    // QDomDocument reader setContent in GtObjectMementoDiff
+    // constructor accepts only one <object> on hightest level
+    QString str = "<mementodifflist>\n"+pimpl->dataDiffToMerge.getVal()+"\n</mementodifflist>";
+
+    QDomDocument doc;
+    doc.setContent(str);
+
+    QDomElement root = doc.documentElement();
+    QDomNodeList diffs = root.childNodes();
+    for (int i = 0; i < diffs.size(); ++i) {
+        QDomNode node = diffs.at(i);
+
+        QDomDocument tempDoc;
+        QDomNode imported = tempDoc.importNode(node, true);
+        tempDoc.appendChild(imported);
+
+        GtObjectMementoDiff tempDiff{tempDoc.toByteArray()};
+        diff.appendDiff(tempDiff);
+    }
+    return diff;
+}
+
+void GtProcessExecutionInfo::setDataDiffToMerge(const GtObjectMementoDiff &dataDiffToMerge)
+{
+    pimpl->dataDiffToMerge.setVal(QString::fromUtf8(dataDiffToMerge.toByteArray()));
+}
+
+GtProcessExecutionInfo::~GtProcessExecutionInfo() = default;
+
+void GtProcessExecutionInfo::listEnumOptions()
+{
+    QMetaEnum metaEnum = pimpl->processState.getMetaEnum();
+    for (int i = 0; i < metaEnum.keyCount(); ++i) {
+        const char* key = metaEnum.key(i);
+        int value = metaEnum.value(i);
+        qDebug().noquote() << key << "=" << value;
+    }
+}

--- a/src/core/process_management/gt_processexecutioninfo.cpp
+++ b/src/core/process_management/gt_processexecutioninfo.cpp
@@ -55,14 +55,14 @@ GtProcessExecutionInfo::GtProcessExecutionInfo():
     registerProperty(pimpl->dataDiffToMerge);
 }
 
-const double GtProcessExecutionInfo::queuedTime()
+double GtProcessExecutionInfo::queuedTime() const
 {
     return pimpl->queuedTime.getVal();
 }
 
 void GtProcessExecutionInfo::setQueuedTime(double queuedTime)
 {
-    pimpl->queuedTime = queuedTime;
+    pimpl->queuedTime.setVal(queuedTime);
     pimpl->queuedTime.setActive(true);
 }
 
@@ -71,14 +71,14 @@ void GtProcessExecutionInfo::setQueuedTimeNow()
     setQueuedTime(QDateTime::currentMSecsSinceEpoch()/1000.);
 }
 
-const double GtProcessExecutionInfo::startTime()
+double GtProcessExecutionInfo::startTime() const
 {
     return pimpl->startTime.getVal();
 }
 
 void GtProcessExecutionInfo::setStartTime(double startTime)
 {
-    pimpl->startTime = startTime;
+    pimpl->startTime.setVal(startTime);
     pimpl->startTime.setActive(true);
 }
 
@@ -87,7 +87,7 @@ void GtProcessExecutionInfo::setStartTimeNow()
     setStartTime(QDateTime::currentMSecsSinceEpoch()/1000.);
 }
 
-const double GtProcessExecutionInfo::endTime()
+double GtProcessExecutionInfo::endTime() const
 {
     return pimpl->endTime.getVal();
 }
@@ -103,7 +103,7 @@ void GtProcessExecutionInfo::setEndTimeNow()
     setEndTime(QDateTime::currentMSecsSinceEpoch()/1000.);
 }
 
-const GtProcessComponent::STATE GtProcessExecutionInfo::processState()
+const GtProcessComponent::STATE GtProcessExecutionInfo::processState() const
 {
     return pimpl->processState.getVal();
 }
@@ -113,7 +113,7 @@ void GtProcessExecutionInfo::setProcessState(GtProcessComponent::STATE state)
     pimpl->processState.setVal(state);
 }
 
-const GtObjectMementoDiff GtProcessExecutionInfo::dataDiffToMerge()
+GtObjectMementoDiff GtProcessExecutionInfo::dataDiffToMerge() const
 {
     GtObjectMementoDiff diff;
 

--- a/src/core/process_management/gt_processexecutioninfo.h
+++ b/src/core/process_management/gt_processexecutioninfo.h
@@ -1,0 +1,50 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ * Source File: gt_processexecutioninfo.h
+ *
+ *  Created on: 10.04.2026
+ *  Author: Matthias Schuff (SG-VTM)
+ *  Tel.:
+ */
+#ifndef GT_PROCESSEXECUTIONINFO_H
+#define GT_PROCESSEXECUTIONINFO_H
+
+#include "gt_object.h"
+#include "gt_core_exports.h"
+#include "gt_processcomponent.h"
+
+class GT_CORE_EXPORT GtProcessExecutionInfo : public GtObject
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE GtProcessExecutionInfo();
+    ~GtProcessExecutionInfo();
+
+    const double queuedTime();
+    void setQueuedTime(double queuedTime);
+    void setQueuedTimeNow();
+
+    const double startTime();
+    void setStartTime(double startTime);
+    void setStartTimeNow();
+
+    const double endTime();    
+    void setEndTime(double endTime);
+    void setEndTimeNow();
+
+    const GtProcessComponent::STATE processState();
+    void setProcessState(GtProcessComponent::STATE state);
+
+    const GtObjectMementoDiff dataDiffToMerge();
+    void setDataDiffToMerge(const GtObjectMementoDiff& dataDiffToMerge);
+
+    void listEnumOptions();
+private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+
+};
+
+#endif // GT_PROCESSEXECUTIONINFO_H

--- a/src/core/process_management/gt_processexecutioninfo.h
+++ b/src/core/process_management/gt_processexecutioninfo.h
@@ -30,7 +30,7 @@ public:
     void setStartTime(double startTime);
     void setStartTimeNow();
 
-    const double endTime();    
+    const double endTime();
     void setEndTime(double endTime);
     void setEndTimeNow();
 

--- a/src/core/process_management/gt_processexecutioninfo.h
+++ b/src/core/process_management/gt_processexecutioninfo.h
@@ -1,7 +1,7 @@
 /* GTlab - Gas Turbine laboratory
  *
  * SPDX-License-Identifier: MPL-2.0+
- * SPDX-FileCopyrightText: 2023 German Aerospace Center (DLR)
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
  * Source File: gt_processexecutioninfo.h
  *
  *  Created on: 10.04.2026

--- a/src/core/process_management/gt_processexecutioninfo.h
+++ b/src/core/process_management/gt_processexecutioninfo.h
@@ -22,22 +22,22 @@ public:
     Q_INVOKABLE GtProcessExecutionInfo();
     ~GtProcessExecutionInfo();
 
-    const double queuedTime();
+    double queuedTime() const;
     void setQueuedTime(double queuedTime);
     void setQueuedTimeNow();
 
-    const double startTime();
+    double startTime() const;
     void setStartTime(double startTime);
     void setStartTimeNow();
 
-    const double endTime();
+    double endTime() const;
     void setEndTime(double endTime);
     void setEndTimeNow();
 
-    const GtProcessComponent::STATE processState();
+    const GtProcessComponent::STATE processState() const;
     void setProcessState(GtProcessComponent::STATE state);
 
-    const GtObjectMementoDiff dataDiffToMerge();
+    GtObjectMementoDiff dataDiffToMerge() const;
     void setDataDiffToMerge(const GtObjectMementoDiff& dataDiffToMerge);
 
     void listEnumOptions();

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -55,7 +55,9 @@ set (SOURCES
     slotadaptor.cpp
 )
 
-add_executable(GTlabUnitTest ${SOURCES})
+add_executable(GTlabUnitTest ${SOURCES}
+    core/test_gt_processexecutioninfo.cpp
+    core/test_gt_processexecutioninfo.h)
 set_target_properties(GTlabUnitTest PROPERTIES AUTOMOC ON AUTORCC ON)
 
 target_compile_definitions(GTlabUnitTest PRIVATE GT_MODULE_ID="Unittests" "GT_LOG_USE_QT_BINDINGS")

--- a/tests/unittests/core/test_gt_processexecutioninfo.cpp
+++ b/tests/unittests/core/test_gt_processexecutioninfo.cpp
@@ -1,0 +1,98 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ * Source File: test_gt_processexecutioninfo.cpp
+ */
+
+#include "gtest/gtest.h"
+#include <QTemporaryDir>
+#include <memory>
+#include "gt_coreprocessexecutor.h"
+#include "gt_objectgroup.h"
+#include "gt_objectmementodiff.h"
+#include "gt_objectfactory.h"
+#include "gt_project.h"
+
+#include "test_gt_processexecutioninfo.h"
+
+
+
+class TestGtProcessExecutionInfo : public ::testing::Test
+{
+public:
+    TestGtProcessExecutionInfo()
+    {
+        gtObjectFactory->registerClass(TestPackage::staticMetaObject);
+        gtObjectFactory->registerClass(GtPackage::staticMetaObject);
+        gtObjectFactory->registerClass(TestObjectDouble::staticMetaObject);
+        gtObjectFactory->registerClass(TestTask1::staticMetaObject);
+        gtObjectFactory->registerClass(TestCalculatorAPlusB::staticMetaObject);
+        gtObjectFactory->registerClass(TestCalculatorWriteToObject::staticMetaObject);
+    }
+
+protected:
+    void SetUp() override
+    {
+
+    }
+
+    static std::unique_ptr<GtObjectGroup> makeObjectGroup()
+    {
+        QTemporaryDir tempDir;
+        auto proj = std::make_unique<GtObjectGroup>();
+        //auto pkg = new TestPackage;
+        //pkg->setObjectName("TestPackage");
+        //proj->appendChild(pkg);
+        return proj;
+    }
+
+protected:
+    GtCoreProcessExecutor executor;
+    GtObject source;
+
+};
+
+
+
+TEST_F(TestGtProcessExecutionInfo, storeAplusBToObject)
+{
+
+    auto obj = new TestObjectDouble;
+    obj->setObjectName("FOO");
+    obj->setX(1.1);
+
+    auto objgrp = makeObjectGroup();
+    //TestPackage* pkg = objgrp->findDirectChild<TestPackage*>("TestPackage");
+
+    objgrp->appendChild(obj);
+
+/*
+    qDebug() << "Source children:";
+    for(auto c : source.findDirectChildren())
+    {
+        qDebug() <<  "|->" << c << "uuid:" << c->uuid();
+    }*/
+
+    auto task = std::make_unique<TestTask1>();
+    task->setFactory(gtObjectFactory);
+    task->setInput(1.2, 2.3, obj);
+
+
+
+    auto execinfo = new GtProcessExecutionInfo;
+    executor.setSource(objgrp.get());
+    executor.runTask(task.get(), execinfo);
+
+    qDebug() << "info:";
+    qDebug() << "|-> queuedTime:" << execinfo->queuedTime();
+    qDebug() << "|-> startTime:" << execinfo->startTime();
+    qDebug() << "|-> endTime:" << execinfo->endTime();
+    qDebug() << "|-> processState:" << execinfo->processState();
+    qDebug() << "|-> dataDiffToMerge:" << execinfo->dataDiffToMerge().toByteArray();
+
+}
+
+
+
+

--- a/tests/unittests/core/test_gt_processexecutioninfo.cpp
+++ b/tests/unittests/core/test_gt_processexecutioninfo.cpp
@@ -23,33 +23,33 @@ class TestGtProcessExecutionInfo : public ::testing::Test
 public:
     TestGtProcessExecutionInfo()
     {
-        gtObjectFactory->registerClass(TestPackage::staticMetaObject);
-        gtObjectFactory->registerClass(GtPackage::staticMetaObject);
         gtObjectFactory->registerClass(TestObjectDouble::staticMetaObject);
         gtObjectFactory->registerClass(TestTask1::staticMetaObject);
+        gtObjectFactory->registerClass(TestWarningTask1::staticMetaObject);
+        gtObjectFactory->registerClass(TestFailingTask1::staticMetaObject);
+        gtObjectFactory->registerClass(TestFailingTask2::staticMetaObject);
         gtObjectFactory->registerClass(TestCalculatorAPlusB::staticMetaObject);
         gtObjectFactory->registerClass(TestCalculatorWriteToObject::staticMetaObject);
+        gtObjectFactory->registerClass(TestCalculatorFailing::staticMetaObject);
+        gtObjectFactory->registerClass(TestCalculatorWarning::staticMetaObject);
     }
 
 protected:
     void SetUp() override
     {
-
+        source = new GtObject;
+        source->setObjectName("ROOT");
     }
 
-    static std::unique_ptr<GtObjectGroup> makeObjectGroup()
+    void TearDown() override
     {
-        QTemporaryDir tempDir;
-        auto proj = std::make_unique<GtObjectGroup>();
-        //auto pkg = new TestPackage;
-        //pkg->setObjectName("TestPackage");
-        //proj->appendChild(pkg);
-        return proj;
+        delete source;
     }
+
 
 protected:
     GtCoreProcessExecutor executor;
-    GtObject source;
+    GtObject* source;
 
 };
 
@@ -57,42 +57,121 @@ protected:
 
 TEST_F(TestGtProcessExecutionInfo, storeAplusBToObject)
 {
+    double val_x_ini = 1.1;
+    double val_a = 1.2;
+    double val_b = 2.3;
+    double val_x_new = val_a+val_b;
 
-    auto obj = new TestObjectDouble;
-    obj->setObjectName("FOO");
-    obj->setX(1.1);
-
-    auto objgrp = makeObjectGroup();
-    //TestPackage* pkg = objgrp->findDirectChild<TestPackage*>("TestPackage");
-
-    objgrp->appendChild(obj);
-
-/*
-    qDebug() << "Source children:";
-    for(auto c : source.findDirectChildren())
-    {
-        qDebug() <<  "|->" << c << "uuid:" << c->uuid();
-    }*/
+    TestObjectDouble obj;
+    obj.setObjectName("FOO");
+    obj.setX(val_x_ini);
+    source->appendChild(&obj);
 
     auto task = std::make_unique<TestTask1>();
     task->setFactory(gtObjectFactory);
-    task->setInput(1.2, 2.3, obj);
-
-
+    task->setInput(val_a, val_b, &obj);
 
     auto execinfo = new GtProcessExecutionInfo;
-    executor.setSource(objgrp.get());
+    executor.setSource(source);
     executor.runTask(task.get(), execinfo);
 
-    qDebug() << "info:";
-    qDebug() << "|-> queuedTime:" << execinfo->queuedTime();
-    qDebug() << "|-> startTime:" << execinfo->startTime();
-    qDebug() << "|-> endTime:" << execinfo->endTime();
-    qDebug() << "|-> processState:" << execinfo->processState();
-    qDebug() << "|-> dataDiffToMerge:" << execinfo->dataDiffToMerge().toByteArray();
+    // qDebug() << "info:";
+    // qDebug() << "|-> queuedTime:" << execinfo->queuedTime();
+    // qDebug() << "|-> startTime:" << execinfo->startTime();
+    // qDebug() << "|-> endTime:" << execinfo->endTime();
+    // qDebug() << "|-> processState:" << execinfo->processState();
+    // qDebug() << "|-> dataDiffToMerge:" << execinfo->dataDiffToMerge().toByteArray();
+
+
+    auto diff = execinfo->dataDiffToMerge();
+    QDomElement root = diff.documentElement();
+
+
+    // Check state of task
+    ASSERT_EQ(execinfo->processState(), GtProcessComponent::FINISHED);
+    ASSERT_EQ(diff.numberOfDiffSteps(), 1);
+
+    ASSERT_STREQ(root.tagName().toStdString().c_str(), "object");
+    ASSERT_FALSE(root.attribute("uuid").isEmpty());
+    ASSERT_STREQ(root.attribute("uuid").toStdString().c_str(),
+                 obj.uuid().toStdString().c_str());
+    ASSERT_STREQ(root.attribute("name").toStdString().c_str(),
+                 obj.objectName().toStdString().c_str());
+    ASSERT_STREQ(root.attribute("class").toStdString().c_str(),
+                 obj.metaObject()->className());
+
+
+    // property diff check
+    QDomElement propChange = root.firstChildElement("diff-property-change");
+    ASSERT_FALSE(propChange.isNull());
+
+    QString propName = propChange.attribute("name");
+    QString propType = propChange.attribute("type");
+
+    ASSERT_STREQ(propName.toStdString().c_str(), "x");
+    ASSERT_STREQ(propType.toStdString().c_str(), "double");
+
+    QDomElement oldValue = propChange.firstChildElement("oldVal");
+    QDomElement newValue = propChange.firstChildElement("newVal");
+
+    ASSERT_FALSE(oldValue.isNull());
+    ASSERT_FALSE(newValue.isNull());
+
+    ASSERT_STREQ(newValue.text().toStdString().c_str(),  QString::number(val_x_new).toStdString().c_str());
+    ASSERT_STREQ(oldValue.text().toStdString().c_str(),  QString::number(val_x_ini).toStdString().c_str());
 
 }
 
 
+TEST_F(TestGtProcessExecutionInfo, warningTask1)
+{
+    auto task = std::make_unique<TestWarningTask1>();
+    task->setFactory(gtObjectFactory);
 
+    auto execinfo = new GtProcessExecutionInfo;
+    executor.setSource(source);
+    executor.runTask(task.get(), execinfo);
+
+    auto diff = execinfo->dataDiffToMerge();
+    ASSERT_EQ(execinfo->processState(), GtProcessComponent::WARN_FINISHED);
+    ASSERT_TRUE(diff.isNull());
+    ASSERT_EQ(diff.numberOfDiffSteps(), 0);
+}
+
+
+TEST_F(TestGtProcessExecutionInfo, failingTask1)
+{
+    auto task = std::make_unique<TestFailingTask1>();
+    task->setFactory(gtObjectFactory);
+
+    auto execinfo = new GtProcessExecutionInfo;
+    executor.setSource(source);
+    executor.runTask(task.get(), execinfo);
+
+    auto diff = execinfo->dataDiffToMerge();
+    ASSERT_EQ(execinfo->processState(), GtProcessComponent::FAILED);
+    ASSERT_TRUE(diff.isNull());
+    ASSERT_EQ(diff.numberOfDiffSteps(), 0);
+}
+
+TEST_F(TestGtProcessExecutionInfo, failingTask2)
+{
+    TestObjectDouble obj;
+    obj.setObjectName("FOO");
+    obj.setX(1.1);
+    source->appendChild(&obj);
+
+    auto task = std::make_unique<TestFailingTask2>();
+    task->setFactory(gtObjectFactory);
+    task->setInput(2.2, &obj);
+
+    auto execinfo = new GtProcessExecutionInfo;
+    executor.setSource(source);
+    executor.runTask(task.get(), execinfo);
+
+    auto diff = execinfo->dataDiffToMerge();
+    ASSERT_EQ(execinfo->processState(), GtProcessComponent::FAILED);
+    ASSERT_TRUE(diff.isNull());
+    ASSERT_EQ(diff.numberOfDiffSteps(), 0);
+}
 

--- a/tests/unittests/core/test_gt_processexecutioninfo.h
+++ b/tests/unittests/core/test_gt_processexecutioninfo.h
@@ -1,0 +1,233 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ * Source File: test_gt_processexecutioninfo.h
+ */
+
+#ifndef TEST_GT_PROCESSEXECUTIONINFO_H
+#define TEST_GT_PROCESSEXECUTIONINFO_H
+
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include "gt_package.h"
+#include "gt_project.h"
+#include "gt_coreapplication.h"
+#include "gt_coreprocessexecutor.h"
+#include "gt_objectlinkproperty.h"
+#include "gt_task.h"
+#include "gt_calculator.h"
+#include "gt_doubleproperty.h"
+#include "gt_stringproperty.h"
+#include "gt_objectfactory.h"
+#include "gt_propertyconnection.h"
+
+
+class TestPackage : public GtPackage
+{
+public:
+    TestPackage() = default;
+};
+
+class TestObjectDouble : public GtObject
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestObjectDouble():
+        m_x("x", "x")
+    {
+        registerProperty(m_x);
+    };
+
+    void setX(double val)
+    {
+        m_x.setVal(val);
+    }
+
+    double getX()
+    {
+        return m_x.getVal();
+    }
+
+private:
+    GtDoubleProperty m_x;
+};
+
+
+class TestCalculatorAPlusB : public GtCalculator
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestCalculatorAPlusB()
+    {
+        setObjectName("TestCalculatorAPlusB");
+        m_a = new GtDoubleProperty("a", "a");
+        m_b = new GtDoubleProperty("b", "b");
+        m_c = new GtDoubleProperty("c", "c");
+
+        registerProperty(*m_a);
+        registerProperty(*m_b);
+
+        registerMonitoringProperty(*m_c);
+    }
+
+
+    ~TestCalculatorAPlusB() override
+    {
+        delete m_a;
+        delete m_b;
+        delete m_c;
+    }
+
+    void setA(double val)
+    {
+        m_a->setVal(val);
+    }
+
+    void setB(double val)
+    {
+        m_b->setVal(val);
+    }
+
+    bool run() override
+    {
+        auto a = m_a->getVal();
+        auto b = m_b->getVal();
+        double c = a+b;
+        qDebug() << "a+b=" << a << "+" << b << "=" << c;
+        m_c->setVal(c);
+        qDebug() << "m_c->getVal()=="<< m_c->getVal();
+        return true;
+    }
+
+private:
+    GtDoubleProperty* m_a;
+    GtDoubleProperty* m_b;
+    GtDoubleProperty* m_c;
+};
+
+
+class TestCalculatorWriteToObject : public GtCalculator
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestCalculatorWriteToObject()
+    {
+        setObjectName("TestCalculatorWriteToObject");
+        m_a = new GtDoubleProperty("a", "a");
+        m_obj = new GtObjectLinkProperty("obj", "obj", "", this, QStringList() << GT_CLASSNAME(TestObjectDouble), true);
+        registerProperty(*m_a);
+        registerProperty(*m_obj);
+    }
+
+    ~TestCalculatorWriteToObject() override
+    {
+        delete m_a;
+    }
+
+    void setLinkedObj(TestObjectDouble* obj)
+    {
+        m_obj->setVal(obj->uuid());
+        qDebug() << "setLinkedObj" << this;
+        qDebug() << "|-> obj:" << obj->uuid();
+        qDebug() << "|-> m_obj:" << m_obj->getVal();
+    }
+
+    bool run() override
+    {
+        qDebug() << "run TestCalculatorWriteToObject" << this;
+        qDebug() << "m_obj:" << m_obj << m_obj->getVal();
+
+        qDebug() << "proccomp::data";
+        qDebug() << "linkedObjects:" << linkedObjects();
+
+        auto obj = data<TestObjectDouble*>(*m_obj);
+
+        if (!obj)
+        {
+            qDebug() << "TestCalculatorWriteToObject - Linked obj not found!";
+            qDebug() << "uuid:" <<  m_obj->getVal();
+            return false;
+        }
+        qDebug() << "obj:" << obj;
+        qDebug() << "m_a->getVal():" << m_a->getVal();
+        obj->setX(m_a->getVal());
+        qDebug() << "obj getX:" << obj->getX();
+        return true;
+    }
+
+private:
+    GtDoubleProperty* m_a;
+    GtObjectLinkProperty* m_obj;
+};
+
+
+class TestCalculatorFailing : public GtCalculator
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestCalculatorFailing()
+    {
+    }
+
+    ~TestCalculatorFailing() override
+    {
+    }
+
+    bool run() override
+    {
+        return false;
+    }
+};
+
+class TestTask1 : public GtTask
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestTask1()
+    {
+        m_calc1 = new TestCalculatorAPlusB;
+        m_calc2 = new TestCalculatorWriteToObject;
+        appendChild(m_calc1);
+        appendChild(m_calc2);
+
+        m_conn1 = new GtPropertyConnection;
+        m_conn1->setObjectName("Connection1");
+
+        m_conn1->setSourceUuid(m_calc1->uuid());
+        m_conn1->setSourceProp("c");
+        m_conn1->setTargetUuid(m_calc2->uuid());
+        m_conn1->setTargetProp("a");
+
+        appendChild(m_conn1);
+
+        m_conn1->makeConnection();
+
+    }
+
+    ~TestTask1() override
+    {
+        delete m_calc1;
+        delete m_calc2;
+        delete m_conn1;
+    }
+
+    void setInput(double a, double b, TestObjectDouble* targetobj)
+    {
+        m_calc1->setA(a);
+        m_calc1->setB(b);
+        m_calc2->setLinkedObj(targetobj);
+    }
+
+
+private:
+    TestCalculatorAPlusB* m_calc1;
+    TestCalculatorWriteToObject* m_calc2;
+    GtPropertyConnection* m_conn1;
+
+};
+
+
+#endif // TEST_GT_PROCESSEXECUTIONINFO_H

--- a/tests/unittests/core/test_gt_processexecutioninfo.h
+++ b/tests/unittests/core/test_gt_processexecutioninfo.h
@@ -25,12 +25,6 @@
 #include "gt_propertyconnection.h"
 
 
-class TestPackage : public GtPackage
-{
-public:
-    TestPackage() = default;
-};
-
 class TestObjectDouble : public GtObject
 {
     Q_OBJECT
@@ -127,34 +121,24 @@ public:
         delete m_a;
     }
 
+    void setA(double val)
+    {
+        m_a->setVal(val);
+    }
+
     void setLinkedObj(TestObjectDouble* obj)
     {
         m_obj->setVal(obj->uuid());
-        qDebug() << "setLinkedObj" << this;
-        qDebug() << "|-> obj:" << obj->uuid();
-        qDebug() << "|-> m_obj:" << m_obj->getVal();
     }
 
     bool run() override
     {
-        qDebug() << "run TestCalculatorWriteToObject" << this;
-        qDebug() << "m_obj:" << m_obj << m_obj->getVal();
-
-        qDebug() << "proccomp::data";
-        qDebug() << "linkedObjects:" << linkedObjects();
-
         auto obj = data<TestObjectDouble*>(*m_obj);
-
         if (!obj)
         {
-            qDebug() << "TestCalculatorWriteToObject - Linked obj not found!";
-            qDebug() << "uuid:" <<  m_obj->getVal();
             return false;
         }
-        qDebug() << "obj:" << obj;
-        qDebug() << "m_a->getVal():" << m_a->getVal();
         obj->setX(m_a->getVal());
-        qDebug() << "obj getX:" << obj->getX();
         return true;
     }
 
@@ -172,13 +156,24 @@ public:
     {
     }
 
-    ~TestCalculatorFailing() override
+    bool run() override
+    {
+        return false;
+    }
+};
+
+class TestCalculatorWarning : public GtCalculator
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestCalculatorWarning()
     {
     }
 
     bool run() override
     {
-        return false;
+        setWarningFlag(true);
+        return true;
     }
 };
 
@@ -207,13 +202,6 @@ public:
 
     }
 
-    ~TestTask1() override
-    {
-        delete m_calc1;
-        delete m_calc2;
-        delete m_conn1;
-    }
-
     void setInput(double a, double b, TestObjectDouble* targetobj)
     {
         m_calc1->setA(a);
@@ -229,5 +217,51 @@ private:
 
 };
 
+class TestWarningTask1 : public GtTask
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestWarningTask1()
+    {
+        m_calc1 = new TestCalculatorWarning;
+        appendChild(m_calc1);
+    }
+private:
+    TestCalculatorWarning* m_calc1;
+};
+
+class TestFailingTask1 : public GtTask
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestFailingTask1()
+    {
+        m_calc1 = new TestCalculatorFailing;
+        appendChild(m_calc1);
+    }
+private:
+    TestCalculatorFailing* m_calc1;
+};
+
+class TestFailingTask2 : public GtTask
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE TestFailingTask2()
+    {
+        m_calc1 = new TestCalculatorWriteToObject;
+        appendChild(m_calc1);
+        m_calc2 = new TestCalculatorFailing;
+        appendChild(m_calc2);
+    }
+    void setInput(double a, TestObjectDouble* targetobj)
+    {
+        m_calc1->setA(a);
+        m_calc1->setLinkedObj(targetobj);
+    }
+private:
+    TestCalculatorWriteToObject* m_calc1;
+    TestCalculatorFailing* m_calc2;
+};
 
 #endif // TEST_GT_PROCESSEXECUTIONINFO_H


### PR DESCRIPTION
Adds class GtProcessExecutionInfo to store execution info of a task (queued/started/finished time), the GtProcessComponent::STATE and the GtObjectMementoDiff to apply to the data model.

## Description
Overloaded runTask() and queueTask() to optionally hand over a GtProcessExecutionInfo.
The process executor stores this object and writes information to it.

In a dedicated module for (HPC) jobs, the job starts in batch mode and creates a GtProcessExecutionInfo. The object pointer is handed over via runTask().
Ownership of GtProcessExecutionInfo object is within module.

Closes #1499

## How Has This Been Tested?


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Expose task execution results and timing through an optional GtProcessExecutionInfo object.

New Features:
- Add GtProcessExecutionInfo to capture task queue, start, and completion times, process state, and resulting model changes.
- Allow callers to provide execution metadata when running or queueing tasks.

Enhancements:
- Track and clean up execution metadata associated with queued and running tasks.
- Register execution information with the core object factory for broader model integration.

Tests:
- Add unit coverage for successful, warning, and failed task execution metadata and model diffs.