### PR TITLE
Reduce deprecation warnings related to use of old property constructors

### DIFF
--- a/src/core/process_management/gt_doublemonitoringproperty.cpp
+++ b/src/core/process_management/gt_doublemonitoringproperty.cpp
@@ -21,9 +21,9 @@ GtDoubleMonitoringProperty::GtDoubleMonitoringProperty(const QString& ident,
 
 GtDoubleMonitoringProperty::GtDoubleMonitoringProperty(const QString& ident,
                                                        const QString& name) :
-    GtDoubleMonitoringProperty(ident, name, QString())
+    GtDoubleProperty(ident, name)
 {
-
+    setMonitoring(true);
 }
 
 gt::PropertyFactoryFunction

--- a/src/core/process_management/gt_doublemonitoringproperty.h
+++ b/src/core/process_management/gt_doublemonitoringproperty.h
@@ -32,7 +32,7 @@ public:
      * @param ident
      * @param name
      */
-    [[deprecated ("Use GtDoubleProperty and set the monitoring flag")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use GtDoubleProperty and set the monitoring flag")
     Q_INVOKABLE GtDoubleMonitoringProperty(const QString& ident,
                                            const QString& name);
 
@@ -42,7 +42,7 @@ public:
      * @param name shown in the GUI
      * @param brief description text
      */
-    [[deprecated ("Use GtDoubleProperty and set the monitoring flag")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use GtDoubleProperty and set the monitoring flag")
     Q_INVOKABLE GtDoubleMonitoringProperty(const QString& ident,
                                            const QString& name,
                                            const QString& brief);
@@ -54,7 +54,7 @@ namespace gt
 /**
  * @brief Creates a property factory for monitoring doubles with a default value
  */
-[[deprecated("Use makeMonitoring(makeDoubleProperty(value)) instead")]]
+GT_DEPRECATED_REMOVED_IN(2, 2, "Use makeMonitoring(makeDoubleProperty(value)) instead")
 GT_CORE_EXPORT
 gt::PropertyFactoryFunction makeDoubleMonitoringProperty(double value);
 

--- a/src/core/process_management/gt_intmonitoringproperty.cpp
+++ b/src/core/process_management/gt_intmonitoringproperty.cpp
@@ -21,7 +21,7 @@ GtIntMonitoringProperty::GtIntMonitoringProperty(const QString& ident,
 
 GtIntMonitoringProperty::GtIntMonitoringProperty(const QString& ident,
                                                  const QString& name) :
-    GtIntProperty(ident, name)
+    GtIntProperty(ident, name, QString())
 {
     setMonitoring(true);
 }

--- a/src/core/process_management/gt_intmonitoringproperty.cpp
+++ b/src/core/process_management/gt_intmonitoringproperty.cpp
@@ -21,9 +21,9 @@ GtIntMonitoringProperty::GtIntMonitoringProperty(const QString& ident,
 
 GtIntMonitoringProperty::GtIntMonitoringProperty(const QString& ident,
                                                  const QString& name) :
-    GtIntMonitoringProperty(ident, name, QString())
+    GtIntProperty(ident, name)
 {
-
+    setMonitoring(true);
 }
 
 gt::PropertyFactoryFunction

--- a/src/core/process_management/gt_intmonitoringproperty.h
+++ b/src/core/process_management/gt_intmonitoringproperty.h
@@ -31,7 +31,7 @@ public:
      * @param ident
      * @param name
      */
-    [[deprecated ("Use GtIntProperty and set the monitoring flag")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use GtIntProperty and set the monitoring flag")
     Q_INVOKABLE GtIntMonitoringProperty(const QString& ident,
                                         const QString& name);
 
@@ -41,7 +41,7 @@ public:
      * @param name shown in the GUI
      * @param brief description text
      */
-    [[deprecated ("Use GtIntProperty and set the monitoring flag")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use GtIntProperty and set the monitoring flag")
     Q_INVOKABLE GtIntMonitoringProperty(const QString& ident,
                                         const QString& name,
                                         const QString& brief);
@@ -54,7 +54,7 @@ namespace gt
 /**
  * @brief Creates a property factory for monitoring ints with a default value
  */
-[[deprecated("Use makeMonitoring(makeIntProperty(value)) instead")]]
+GT_DEPRECATED_REMOVED_IN(2, 2, "Use makeMonitoring(makeIntProperty(value)) instead")
 GT_CORE_EXPORT
 gt::PropertyFactoryFunction makeIntMonitoringProperty(int value);
 

--- a/src/dataprocessor/property/gt_doubleproperty.h
+++ b/src/dataprocessor/property/gt_doubleproperty.h
@@ -74,7 +74,8 @@ public:
      * @param highSideBoundary
      * @param value
      */
-    [[deprecated("Use function with GtDoubleProperty::Boundaries definition instead")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use function with GtDoubleProperty::Boundaries"
+                                   " definition instead")
     GtDoubleProperty(const QString& ident,
                      const QString& name,
                      const QString& brief,
@@ -93,7 +94,8 @@ public:
      * @param boundary
      * @param value
      */
-    [[deprecated("Use function with GtDoubleProperty::Boundaries definition instead")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use function with GtDoubleProperty::Boundaries"
+                                   " definition instead")
     GtDoubleProperty(const QString& ident,
                      const QString& name,
                      const QString& brief,

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -262,9 +262,12 @@ gt::makeIntProperty(int value)
 gt::PropertyFactoryFunction
 gt::makeIntProperty(GtIntProperty::BoundType boundaryType, int boundary, int value)
 {
+    // supress warning inside a deprecated function
+    GT_SUPPRESS_DEPRECATED_BEGIN
     return [=](QString const& id){
         return new GtIntProperty(id, id, QString{}, boundaryType, boundary, value);
     };
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 gt::PropertyFactoryFunction

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -133,22 +133,16 @@ GtIntProperty::GtIntProperty(const QString& ident,
                              GtIntProperty::BoundType boundType,
                              const int boundary,
                              const int& value) :
-    GtIntProperty(ident, name, brief, value)
+    GtIntProperty(
+        ident,
+        name,
+        brief,
+        gt::Boundaries<int>::makeNormalized(
+            boundType == BoundLow ? boundary : std::numeric_limits<int>::min(),
+            boundType == BoundHigh ? boundary : std::numeric_limits<int>::max()),
+        value)
 { 
-    switch(boundType)
-    {
-    case BoundLow:
-        m_boundsCheckFlagLow = true;
-        m_boundLo = boundary;
-        break;
-    case BoundHigh:
-        m_boundsCheckFlagHi = true;
-        m_boundHi = boundary;
-        break;
-    }
 
-    m_value = gt::clamp(value, m_boundLo, m_boundHi);
-    m_initValue = m_value;
 }
 
 void

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -263,14 +263,14 @@ gt::PropertyFactoryFunction
 gt::makeIntProperty(GtIntProperty::BoundType boundaryType, int boundary, int value)
 {
     return [=](QString const& id){
-
-        switch(boundaryType)
+        if (boundaryType == GtIntProperty::BoundLow)
         {
-        case GtIntProperty::BoundLow:
             return new GtIntProperty(id, id, QString{},
                                      gt::Boundaries<int>::makeLower(boundary),
                                      value);
-        case GtIntProperty::BoundHigh:
+        }
+        else // GtIntProperty::BoundHigh
+        {
             return new GtIntProperty(id, id, QString{},
                                      gt::Boundaries<int>::makeUpper(boundary),
                                      value);

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -121,7 +121,9 @@ GtIntProperty::GtIntProperty(const QString& ident,
                              const int lowSideBoundary,
                              const int highSideBoundary,
                              const int& value) :
-    GtIntProperty(ident, name, brief, lowSideBoundary, highSideBoundary, value)
+    GtIntProperty(ident, name, brief,
+                  gt::Boundaries<int>::makeNormalized(lowSideBoundary, highSideBoundary), 
+                  value)
 { }
 
 GtIntProperty::GtIntProperty(const QString& ident,
@@ -131,8 +133,23 @@ GtIntProperty::GtIntProperty(const QString& ident,
                              GtIntProperty::BoundType boundType,
                              const int boundary,
                              const int& value) :
-    GtIntProperty(ident, name, brief, boundType, boundary, value)
-{ }
+    GtIntProperty(ident, name, brief, value)
+{ 
+    switch(boundType)
+    {
+    case BoundLow:
+        m_boundsCheckFlagLow = true;
+        m_boundLo = boundary;
+        break;
+    case BoundHigh:
+        m_boundsCheckFlagHi = true;
+        m_boundHi = boundary;
+        break;
+    }
+
+    m_value = gt::clamp(value, m_boundLo, m_boundHi);
+    m_initValue = m_value;
+}
 
 void
 GtIntProperty::operator+=(int b)

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -262,12 +262,20 @@ gt::makeIntProperty(int value)
 gt::PropertyFactoryFunction
 gt::makeIntProperty(GtIntProperty::BoundType boundaryType, int boundary, int value)
 {
-    // suppress warning inside a deprecated function
-    GT_SUPPRESS_DEPRECATED_BEGIN
     return [=](QString const& id){
-        return new GtIntProperty(id, id, QString{}, boundaryType, boundary, value);
+
+        switch(boundaryType)
+        {
+        case GtIntProperty::BoundLow:
+            return new GtIntProperty(id, id, QString{},
+                                     gt::Boundaries<int>::makeLower(boundary),
+                                     value);
+        case GtIntProperty::BoundHigh:
+            return new GtIntProperty(id, id, QString{},
+                                     gt::Boundaries<int>::makeUpper(boundary),
+                                     value);
+        }
     };
-    GT_SUPPRESS_DEPRECATED_END
 }
 
 gt::PropertyFactoryFunction

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -262,7 +262,7 @@ gt::makeIntProperty(int value)
 gt::PropertyFactoryFunction
 gt::makeIntProperty(GtIntProperty::BoundType boundaryType, int boundary, int value)
 {
-    // supress warning inside a deprecated function
+    // suppress warning inside a deprecated function
     GT_SUPPRESS_DEPRECATED_BEGIN
     return [=](QString const& id){
         return new GtIntProperty(id, id, QString{}, boundaryType, boundary, value);

--- a/src/dataprocessor/property/gt_intproperty.cpp
+++ b/src/dataprocessor/property/gt_intproperty.cpp
@@ -133,10 +133,7 @@ GtIntProperty::GtIntProperty(const QString& ident,
                              GtIntProperty::BoundType boundType,
                              const int boundary,
                              const int& value) :
-    GtIntProperty(
-        ident,
-        name,
-        brief,
+    GtIntProperty(ident, name, brief,
         gt::Boundaries<int>::makeNormalized(
             boundType == BoundLow ? boundary : std::numeric_limits<int>::min(),
             boundType == BoundHigh ? boundary : std::numeric_limits<int>::max()),
@@ -257,18 +254,11 @@ gt::PropertyFactoryFunction
 gt::makeIntProperty(GtIntProperty::BoundType boundaryType, int boundary, int value)
 {
     return [=](QString const& id){
-        if (boundaryType == GtIntProperty::BoundLow)
-        {
-            return new GtIntProperty(id, id, QString{},
-                                     gt::Boundaries<int>::makeLower(boundary),
-                                     value);
-        }
-        else // GtIntProperty::BoundHigh
-        {
-            return new GtIntProperty(id, id, QString{},
-                                     gt::Boundaries<int>::makeUpper(boundary),
-                                     value);
-        }
+        return new GtIntProperty(id, id, QString{},
+                      gt::Boundaries<int>::makeNormalized(
+                          boundaryType == GtIntProperty::BoundLow ? boundary : std::numeric_limits<int>::min(),
+                          boundaryType == GtIntProperty::BoundHigh ? boundary : std::numeric_limits<int>::max()),
+                          value);
     };
 }
 

--- a/src/dataprocessor/property/gt_intproperty.h
+++ b/src/dataprocessor/property/gt_intproperty.h
@@ -55,7 +55,9 @@ public:
                   const QString& brief,
                   int value);
 
-    [[deprecated("Use function with GtIntProperty::Boundaries definition instead")]]
+
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use function with GtIntProperty::Boundaries"
+                                   " definition instead")
     GtIntProperty(const QString& ident,
                   const QString& name,
                   const QString& brief,
@@ -63,7 +65,8 @@ public:
                   int highSideBoundary,
                   int value = 0);
 
-    [[deprecated("Use function with GtIntProperty::Boundaries definition instead")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use function with GtIntProperty::Boundaries"
+                                   " definition instead")
     GtIntProperty(const QString& ident,
                   const QString& name,
                   const QString& brief,
@@ -85,8 +88,9 @@ public:
      * @param unitCategory
      * @param value
      */
-    [[deprecated("Int Properties do not support units properly and "
-                 "will be removed in the future")]]
+
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Int Properties do not support units properly"
+                                   " and will be removed in the future")
     GtIntProperty(const QString& ident,
                   const QString& name,
                   const QString& brief,
@@ -103,8 +107,8 @@ public:
      * @param highSideBoundary
      * @param value
      */
-    [[deprecated("Int Properties do not support units properly and "
-                 "will be removed in the future")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Int Properties do not support units properly"
+                                   " and will be removed in the future")
     GtIntProperty(const QString& ident,
                   const QString& name,
                   const QString& brief,
@@ -123,8 +127,8 @@ public:
      * @param boundary
      * @param value
      */
-    [[deprecated("Int Properties do not support units properly and "
-                 "will be removed in the future")]]
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Int Properties do not support units properly"
+                                   " and will be removed in the future")
     GtIntProperty(const QString& ident,
                   const QString& name,
                   const QString& brief,
@@ -221,7 +225,9 @@ gt::PropertyFactoryFunction makeIntProperty(int value);
  * @param lowSideBoundary Lower side boundary
  * @param highSideBoundary High side boundary
  */
-[[deprecated("Use function with GtIntProperty::Bound bound definition instead")]]
+
+GT_DEPRECATED_REMOVED_IN(2, 2, "Use function with GtIntProperty::Bound bound "
+                               "definition instead")
 GT_DATAMODEL_EXPORT
 gt::PropertyFactoryFunction makeIntProperty(int lowSideBoundary,
                                             int highSideBoundary,
@@ -234,7 +240,8 @@ gt::PropertyFactoryFunction makeIntProperty(int lowSideBoundary,
  * @param boundaryType Boundary type
  * @param boundary Boundary
  */
-[[deprecated("Use function with GtIntProperty::Boundaries definition instead")]]
+GT_DEPRECATED_REMOVED_IN(2, 2, "Use function with GtIntProperty::Boundaries "
+                               "definition instead")
 GT_DATAMODEL_EXPORT
 gt::PropertyFactoryFunction makeIntProperty(GtIntProperty::BoundType boundaryType,
                                             int boundary,

--- a/tests/modules/process_interface/calculator/test_calculator.h
+++ b/tests/modules/process_interface/calculator/test_calculator.h
@@ -9,7 +9,6 @@
 
 #include "gt_calculator.h"
 #include "gt_doubleproperty.h"
-#include "gt_doublemonitoringproperty.h"
 #include "gt_objectlinkproperty.h"
 #include "gt_objectpathproperty.h"
 
@@ -25,7 +24,7 @@ public:
 
     GtDoubleProperty m_value;
 
-    GtDoubleMonitoringProperty m_result;
+    GtDoubleProperty m_result;
 
     GtObjectLinkProperty m_objectLink;
 

--- a/tests/modules/process_interface/calculator/test_processstatescalculator.cpp
+++ b/tests/modules/process_interface/calculator/test_processstatescalculator.cpp
@@ -16,8 +16,7 @@ TestProcessStatesCalculator::TestProcessStatesCalculator() :
     m_pInterval{"interval", "Interval", "Time until next state change",
                 GtUnit::Time, 5},
     m_pIterations{"iterations", "Iterations",
-                  "How many times should the state change",
-                  GtUnit::NonDimensional, 2}
+                  "How many times should the state change", 2}
 {
     setObjectName("Process State Changer");
 

--- a/tests/unittests/core/test_gt_processtestclasses.h
+++ b/tests/unittests/core/test_gt_processtestclasses.h
@@ -141,7 +141,7 @@ public:
     {
         GtPropertyStructDefinition monVarStruct("MonitoringVarsStruct");
         monVarStruct.defineMember("name", gt::makeStringProperty());
-        monVarStruct.defineMember("value", gt::makeIntMonitoringProperty(0));
+        monVarStruct.defineMember("value", gt::makeMonitoring(gt::makeIntProperty(0)));
 
         monitoringVars.registerAllowedType(monVarStruct);
 

--- a/tests/unittests/datamodel/test_gt_doublemonitoringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_doublemonitoringproperty.cpp
@@ -28,6 +28,7 @@ protected:
 
 TEST_F(TestGtDoubleMonitoringProperty, initialization)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtDoubleMonitoringProperty prop("testIdent", "testName");
 
     ASSERT_STREQ(prop.objectName().toStdString().c_str(), "testName");
@@ -43,17 +44,21 @@ TEST_F(TestGtDoubleMonitoringProperty, initialization)
     ASSERT_STREQ(prop2.ident().toStdString().c_str(), "testIdent2");
 
     ASSERT_STREQ(prop2.brief().toStdString().c_str(), "testBrief2");
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtDoubleMonitoringProperty, isReadOnly)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtDoubleMonitoringProperty prop("testIdent", "testName");
 
     ASSERT_TRUE(prop.isReadOnly());
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtDoubleMonitoringProperty, setVal)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtDoubleMonitoringProperty prop("testIdent", "testName");
 
     prop.setVal(11.3);
@@ -63,4 +68,5 @@ TEST_F(TestGtDoubleMonitoringProperty, setVal)
     prop = 0.75;
 
     ASSERT_DOUBLE_EQ(prop.getVal(), 0.75);
+    GT_SUPPRESS_DEPRECATED_END
 }

--- a/tests/unittests/datamodel/test_gt_doubleproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_doubleproperty.cpp
@@ -12,8 +12,6 @@
 #include "gtest/gtest.h"
 
 #include "gt_doubleproperty.h"
-#include "gt_logging.h"
-
 
 /// This is a test fixture that does a init for each test
 class TestGtDoubleProperty : public ::testing::Test
@@ -21,6 +19,7 @@ class TestGtDoubleProperty : public ::testing::Test
 protected:
     virtual void SetUp()
     {
+        GT_SUPPRESS_DEPRECATED_BEGIN
         m_prop = new GtDoubleProperty("prop", "test double", "test brief",
                                       GtUnit::Category::Area);
 
@@ -40,6 +39,7 @@ protected:
                                                 GtUnit::Category::Area,
                                                 GtDoubleProperty::BoundHigh,
                                                 200.43, 340.2);
+        GT_SUPPRESS_DEPRECATED_END
     }
 
     virtual void TearDown()
@@ -336,12 +336,14 @@ TEST_F(TestGtDoubleProperty, boundsHighOnly)
 
 TEST_F(TestGtDoubleProperty, wrongBounds)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtDoubleProperty prop("prop", "test", "test", GtUnit::Category::None,
                           4.0, 3.0, 4.0);
 
     ASSERT_DOUBLE_EQ(prop.get(), 4.0);
     ASSERT_DOUBLE_EQ(prop.lowSideBoundary(), 0.0);
     ASSERT_DOUBLE_EQ(prop.highSideBoundary(), 0.0);
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtDoubleProperty, revert)

--- a/tests/unittests/datamodel/test_gt_intmonitoringproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_intmonitoringproperty.cpp
@@ -28,6 +28,7 @@ protected:
 
 TEST_F(TestGtIntMonitoringProperty, initialization)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtIntMonitoringProperty prop("testIdent", "testName");
 
     ASSERT_STREQ(prop.objectName().toStdString().c_str(), "testName");
@@ -43,17 +44,21 @@ TEST_F(TestGtIntMonitoringProperty, initialization)
     ASSERT_STREQ(prop2.ident().toStdString().c_str(), "testIdent2");
 
     ASSERT_STREQ(prop2.brief().toStdString().c_str(), "testBrief2");
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtIntMonitoringProperty, isReadOnly)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtIntMonitoringProperty prop("testIdent", "testName");
 
     ASSERT_TRUE(prop.isReadOnly());
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtIntMonitoringProperty, setVal)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtIntMonitoringProperty prop("testIdent", "testName");
 
     prop.setVal(11);
@@ -63,4 +68,5 @@ TEST_F(TestGtIntMonitoringProperty, setVal)
     prop = -7;
 
     ASSERT_DOUBLE_EQ(prop.getVal(), -7);
+    GT_SUPPRESS_DEPRECATED_END
 }

--- a/tests/unittests/datamodel/test_gt_intproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_intproperty.cpp
@@ -56,6 +56,7 @@ protected:
 
 TEST_F(TestGtIntProperty, initialization_deprecated)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     // bounded property
     GtIntProperty prop("propBounds", "test int", "test brief", -1, 3);
     EXPECT_EQ(prop.get(), 0);
@@ -115,10 +116,12 @@ TEST_F(TestGtIntProperty, initialization_deprecated)
     EXPECT_STREQ(propHigh2.objectName().toStdString().c_str(), "test int");
     EXPECT_STREQ(propHigh2.brief().toStdString().c_str(), "test brief");
     EXPECT_FALSE(propHigh2.isReadOnly());
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtIntProperty, bounds_deprecated)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     GtIntProperty prop("propBounds", "test int", "test brief", -1, 3);
     bool success = false;
 
@@ -149,10 +152,12 @@ TEST_F(TestGtIntProperty, bounds_deprecated)
     EXPECT_EQ(propWrong.get(), 4);
     EXPECT_EQ(propWrong.lowSideBoundary(),  std::numeric_limits<int>::min());
     EXPECT_EQ(propWrong.highSideBoundary(), std::numeric_limits<int>::max());
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtIntProperty, MakeIntPropertyCreatesCorrectProperty_deprecated)
 {
+    GT_SUPPRESS_DEPRECATED_BEGIN
     auto factory1 = gt::makeIntProperty(0, 100, 42);
 
     std::unique_ptr<GtIntProperty> property1(
@@ -176,7 +181,6 @@ TEST_F(TestGtIntProperty, MakeIntPropertyCreatesCorrectProperty_deprecated)
     EXPECT_EQ(property2->lowSideBoundary(),  std::numeric_limits<int>::min());
 
     auto factory3 = gt::makeIntProperty(GtIntProperty::BoundLow, 15, 35);
-
     std::unique_ptr<GtIntProperty> property3(
         dynamic_cast<GtIntProperty*>(factory3("testId3")));
 
@@ -185,6 +189,31 @@ TEST_F(TestGtIntProperty, MakeIntPropertyCreatesCorrectProperty_deprecated)
     EXPECT_EQ(property3->get(), 35);
     EXPECT_EQ(property3->highSideBoundary(), std::numeric_limits<int>::max());
     EXPECT_EQ(property3->lowSideBoundary(),  15);
+
+    /// lower than low
+    auto factory4 = gt::makeIntProperty(GtIntProperty::BoundLow, 15, 10);
+    std::unique_ptr<GtIntProperty> propertyLowerThanLow(
+        dynamic_cast<GtIntProperty*>(factory4("testId3")));
+
+    ASSERT_NE(propertyLowerThanLow, nullptr);
+    EXPECT_EQ(propertyLowerThanLow->ident(), "testId3");
+    EXPECT_EQ(propertyLowerThanLow->get(), 15);
+    EXPECT_EQ(propertyLowerThanLow->highSideBoundary(), std::numeric_limits<int>::max());
+    EXPECT_EQ(propertyLowerThanLow->lowSideBoundary(),  15);
+
+    /// higher than high
+    auto factory5 = gt::makeIntProperty(GtIntProperty::BoundHigh, 90, 110);
+
+    std::unique_ptr<GtIntProperty> propertyHigherThanHigh(
+        dynamic_cast<GtIntProperty*>(factory5("testId2")));
+
+    ASSERT_NE(propertyHigherThanHigh, nullptr);
+    EXPECT_EQ(propertyHigherThanHigh->ident(), "testId2");
+    EXPECT_EQ(propertyHigherThanHigh->get(), 90);
+    EXPECT_EQ(propertyHigherThanHigh->highSideBoundary(), 90);
+    EXPECT_EQ(propertyHigherThanHigh->lowSideBoundary(),  std::numeric_limits<int>::min());
+
+    GT_SUPPRESS_DEPRECATED_END
 }
 
 TEST_F(TestGtIntProperty, initialization)

--- a/tests/unittests/datamodel/test_gt_intproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_intproperty.cpp
@@ -21,10 +21,6 @@ protected:
     {
         m_prop = new GtIntProperty("prop", "test int", "test brief");
 
-        m_propBounds = new GtIntProperty("propBounds", "test int", "test brief",
-                                         -1,
-                                         3);
-
         m_propBoundsLow = new GtIntProperty("propBoundsLow", "test int", "test brief",
                                             gt::Boundaries<int>::makeLower(2),
                                             4);
@@ -32,30 +28,134 @@ protected:
         m_propBoundsHigh = new GtIntProperty("propBoundsHigh", "test int", "test brief",
                                              gt::Boundaries<int>::makeUpper(38),
                                              54);
+
+        m_propBounds = new GtIntProperty("propBounds", "test int", "test brief",
+                                         gt::Boundaries<int>::makeNormalized(-1, 3));
     }
 
     virtual void TearDown()
     {
         delete m_prop;
 
-        delete m_propBounds;
-
         delete m_propBoundsLow;
 
         delete m_propBoundsHigh;
+
+        delete m_propBounds;
     }
 
     GtIntProperty* m_prop{};
-
-    GtIntProperty* m_propBounds{};
-
-    GtIntProperty* m_propBounds2{};
 
     GtIntProperty* m_propBoundsLow{};
 
     GtIntProperty* m_propBoundsHigh{};
 
+    GtIntProperty* m_propBounds{};
+
 };
+
+TEST_F(TestGtIntProperty, initialization_deprecated)
+{
+    // bounded property
+    GtIntProperty prop("propBounds", "test int", "test brief", -1, 3);
+    EXPECT_EQ(prop.get(), 0);
+    EXPECT_EQ(prop.lowSideBoundary(), -1);
+    EXPECT_EQ(prop.highSideBoundary(), 3);
+    EXPECT_EQ(prop.unitCategory(), GtUnit::Category::NonDimensional);
+    EXPECT_STREQ(prop.objectName().toStdString().c_str(), "test int");
+    EXPECT_STREQ(prop.brief().toStdString().c_str(), "test brief");
+    EXPECT_FALSE(prop.isReadOnly());
+
+    // bounds low
+    GtIntProperty propLow("propBounds", "test int", "test brief", GtIntProperty::BoundLow, 2, 4);
+    EXPECT_EQ(propLow.get(), 4);
+    EXPECT_EQ(propLow.lowSideBoundary(), 2);
+    EXPECT_EQ(propLow.highSideBoundary(), std::numeric_limits<int>::max());
+    EXPECT_EQ(propLow.unitCategory(), GtUnit::Category::NonDimensional);
+    EXPECT_STREQ(propLow.objectName().toStdString().c_str(), "test int");
+    EXPECT_STREQ(propLow.brief().toStdString().c_str(), "test brief");
+    EXPECT_FALSE(propLow.isReadOnly());
+
+    // bounds high
+    GtIntProperty propHigh("propBounds", "test int", "test brief", GtIntProperty::BoundHigh, 38, 4);
+    EXPECT_EQ(propHigh.get(), 4);
+    EXPECT_EQ(propHigh.lowSideBoundary(),  std::numeric_limits<int>::min());
+    EXPECT_EQ(propHigh.highSideBoundary(), 38);
+    EXPECT_EQ(propHigh.unitCategory(), GtUnit::Category::NonDimensional);
+    EXPECT_STREQ(propHigh.objectName().toStdString().c_str(), "test int");
+    EXPECT_STREQ(propHigh.brief().toStdString().c_str(), "test brief");
+    EXPECT_FALSE(propHigh.isReadOnly());
+}
+
+TEST_F(TestGtIntProperty, bounds_deprecated)
+{
+    GtIntProperty prop("propBounds", "test int", "test brief", -1, 3);
+    bool success = false;
+
+    prop.setVal(-1, &success);
+    EXPECT_EQ(prop.get(), -1);
+    EXPECT_TRUE(success);
+
+    success = false;
+
+    prop.setVal(-2, &success);
+    EXPECT_EQ(prop.get(), -1);
+    EXPECT_FALSE(success);
+
+    success = false;
+
+    prop.setVal(3, &success);
+    EXPECT_EQ(prop.get(), 3);
+    EXPECT_TRUE(success);
+
+    success = false;
+
+    prop.setVal(4, &success);
+    EXPECT_EQ(prop.get(), 3);
+    EXPECT_FALSE(success);
+
+    GtIntProperty propWrong("prop", "test", "test", 4, 3, 4);
+
+    EXPECT_EQ(propWrong.get(), 4);
+    EXPECT_EQ(propWrong.lowSideBoundary(),  std::numeric_limits<int>::min());
+    EXPECT_EQ(propWrong.highSideBoundary(), std::numeric_limits<int>::max());
+}
+
+TEST_F(TestGtIntProperty, MakeIntPropertyCreatesCorrectProperty_deprecated)
+{
+    auto factory1 = gt::makeIntProperty(0, 100, 42);
+
+    std::unique_ptr<GtIntProperty> property1(
+        dynamic_cast<GtIntProperty*>(factory1("testId")));
+
+    ASSERT_NE(property1, nullptr);
+    EXPECT_EQ(property1->ident(), "testId");
+    EXPECT_EQ(property1->get(), 42);
+    EXPECT_EQ(property1->lowSideBoundary(), 0);
+    EXPECT_EQ(property1->highSideBoundary(), 100);
+
+    auto factory2 = gt::makeIntProperty(GtIntProperty::BoundHigh, 90, 36);
+
+    std::unique_ptr<GtIntProperty> property2(
+        dynamic_cast<GtIntProperty*>(factory2("testId2")));
+
+    ASSERT_NE(property2, nullptr);
+    EXPECT_EQ(property2->ident(), "testId2");
+    EXPECT_EQ(property2->get(), 36);
+    EXPECT_EQ(property2->highSideBoundary(), 90);
+    EXPECT_EQ(property2->lowSideBoundary(),  std::numeric_limits<int>::min());
+
+    auto factory3 = gt::makeIntProperty(GtIntProperty::BoundLow, 15, 35);
+
+    std::unique_ptr<GtIntProperty> property3(
+        dynamic_cast<GtIntProperty*>(factory3("testId3")));
+
+    ASSERT_NE(property3, nullptr);
+    EXPECT_EQ(property3->ident(), "testId3");
+    EXPECT_EQ(property3->get(), 35);
+    EXPECT_EQ(property3->highSideBoundary(), std::numeric_limits<int>::max());
+    EXPECT_EQ(property3->lowSideBoundary(),  15);
+}
 
 TEST_F(TestGtIntProperty, initialization)
 {
@@ -75,10 +175,8 @@ TEST_F(TestGtIntProperty, initialization)
     EXPECT_EQ(m_propBounds->lowSideBoundary(), -1);
     EXPECT_EQ(m_propBounds->highSideBoundary(), 3);
     EXPECT_EQ(m_propBounds->unitCategory(), GtUnit::Category::NonDimensional);
-    EXPECT_STREQ(m_propBounds->objectName().toStdString().c_str(),
-                 "test int");
-    EXPECT_STREQ(m_propBounds->brief().toStdString().c_str(),
-                 "test brief");
+    EXPECT_STREQ(m_propBounds->objectName().toStdString().c_str(), "test int");
+    EXPECT_STREQ(m_propBounds->brief().toStdString().c_str(), "test brief");
     EXPECT_FALSE(m_propBounds->isReadOnly());
 
     // check what happens if default value is outside of boundary
@@ -108,9 +206,26 @@ TEST_F(TestGtIntProperty, initialization)
               GtUnit::Category::NonDimensional);
     EXPECT_STREQ(m_propBoundsHigh->objectName().toStdString().c_str(),
                  "test int");
-    EXPECT_STREQ(m_propBoundsHigh->brief().toStdString().c_str(),
-                 "test brief");
+    EXPECT_STREQ(m_propBoundsHigh->brief().toStdString().c_str(), "test brief");
     EXPECT_FALSE(m_propBoundsHigh->isReadOnly());
+
+    GtIntProperty propBoundsStart("propBounds", "test int", "test brief",
+                                  gt::Boundaries<int>::makeNormalized(-2, 4), 2);
+    EXPECT_EQ(propBoundsStart.get(), 2);
+    EXPECT_EQ(propBoundsStart.lowSideBoundary(), -2);
+    EXPECT_EQ(propBoundsStart.highSideBoundary(), 4);
+
+    GtIntProperty propBoundsStart2("propBounds", "test int", "test brief",
+                                  gt::Boundaries<int>::makeNormalized(-2, 4), 6);
+    EXPECT_EQ(propBoundsStart2.get(), 4);
+    EXPECT_EQ(propBoundsStart2.lowSideBoundary(), -2);
+    EXPECT_EQ(propBoundsStart2.highSideBoundary(), 4);
+
+    GtIntProperty propBoundsStart3("propBounds", "test int", "test brief",
+                                   gt::Boundaries<int>::makeNormalized(-3, 5), -6);
+    EXPECT_EQ(propBoundsStart3.lowSideBoundary(), -3);
+    EXPECT_EQ(propBoundsStart3.highSideBoundary(), 5);
+    EXPECT_EQ(propBoundsStart3.get(), -3);
 }
 
 TEST_F(TestGtIntProperty, isReadOnly)
@@ -259,11 +374,12 @@ TEST_F(TestGtIntProperty, boundsHighOnly)
 
 TEST_F(TestGtIntProperty, wrongBounds)
 {
-    GtIntProperty prop("prop", "test", "test", 4, 3, 4);
+    GtIntProperty prop2("prop", "test", "test",
+                        gt::Boundaries<int>::makeNormalized(4, 3), 4);
 
-    EXPECT_EQ(prop.get(), 4);
-    EXPECT_EQ(prop.lowSideBoundary(),  std::numeric_limits<int>::min());
-    EXPECT_EQ(prop.highSideBoundary(), std::numeric_limits<int>::max());
+    EXPECT_EQ(prop2.get(), 4);
+    EXPECT_EQ(prop2.lowSideBoundary(),  3);
+    EXPECT_EQ(prop2.highSideBoundary(), 4);
 }
 
 TEST_F(TestGtIntProperty, revert)
@@ -415,3 +531,19 @@ TEST_F(TestGtIntProperty, boundaries)
     EXPECT_DOUBLE_EQ(lh.getVal(), hundred);
 }
 
+TEST_F(TestGtIntProperty, MakeIntPropertyCreatesCorrectProperty)
+{
+    auto bounds = gt::Boundaries<int>::makeNormalized(0, 100);
+
+    auto factory = gt::makeIntProperty(bounds, 42);
+
+    std::unique_ptr<GtIntProperty> property(
+        dynamic_cast<GtIntProperty*>(factory("testId")));
+
+    ASSERT_NE(property, nullptr);
+
+    EXPECT_EQ(property->ident(), "testId");
+    EXPECT_EQ(property->get(), 42);
+    EXPECT_EQ(property->lowSideBoundary(), 0);
+    EXPECT_EQ(property->highSideBoundary(), 100);
+}

--- a/tests/unittests/datamodel/test_gt_intproperty.cpp
+++ b/tests/unittests/datamodel/test_gt_intproperty.cpp
@@ -66,6 +66,16 @@ TEST_F(TestGtIntProperty, initialization_deprecated)
     EXPECT_STREQ(prop.brief().toStdString().c_str(), "test brief");
     EXPECT_FALSE(prop.isReadOnly());
 
+    GtIntProperty prop2("propBounds", "test int", "test brief",
+                       GtUnit::Category::NonDimensional, -2, 4);
+    EXPECT_EQ(prop2.get(), 0);
+    EXPECT_EQ(prop2.lowSideBoundary(), -2);
+    EXPECT_EQ(prop2.highSideBoundary(), 4);
+    EXPECT_EQ(prop2.unitCategory(), GtUnit::Category::NonDimensional);
+    EXPECT_STREQ(prop2.objectName().toStdString().c_str(), "test int");
+    EXPECT_STREQ(prop2.brief().toStdString().c_str(), "test brief");
+    EXPECT_FALSE(prop2.isReadOnly());
+
     // bounds low
     GtIntProperty propLow("propBounds", "test int", "test brief", GtIntProperty::BoundLow, 2, 4);
     EXPECT_EQ(propLow.get(), 4);
@@ -85,6 +95,26 @@ TEST_F(TestGtIntProperty, initialization_deprecated)
     EXPECT_STREQ(propHigh.objectName().toStdString().c_str(), "test int");
     EXPECT_STREQ(propHigh.brief().toStdString().c_str(), "test brief");
     EXPECT_FALSE(propHigh.isReadOnly());
+
+    // bounds low
+    GtIntProperty propLow2("propBounds", "test int", "test brief", GtUnit::NonDimensional, GtIntProperty::BoundLow, 1, 3);
+    EXPECT_EQ(propLow2.get(), 3);
+    EXPECT_EQ(propLow2.lowSideBoundary(), 1);
+    EXPECT_EQ(propLow2.highSideBoundary(), std::numeric_limits<int>::max());
+    EXPECT_EQ(propLow2.unitCategory(), GtUnit::Category::NonDimensional);
+    EXPECT_STREQ(propLow2.objectName().toStdString().c_str(), "test int");
+    EXPECT_STREQ(propLow2.brief().toStdString().c_str(), "test brief");
+    EXPECT_FALSE(propLow2.isReadOnly());
+
+    // bounds high
+    GtIntProperty propHigh2("propBounds", "test int", "test brief", GtUnit::NonDimensional, GtIntProperty::BoundHigh, 39, 5);
+    EXPECT_EQ(propHigh2.get(), 5);
+    EXPECT_EQ(propHigh2.lowSideBoundary(),  std::numeric_limits<int>::min());
+    EXPECT_EQ(propHigh2.highSideBoundary(), 39);
+    EXPECT_EQ(propHigh2.unitCategory(), GtUnit::Category::NonDimensional);
+    EXPECT_STREQ(propHigh2.objectName().toStdString().c_str(), "test int");
+    EXPECT_STREQ(propHigh2.brief().toStdString().c_str(), "test brief");
+    EXPECT_FALSE(propHigh2.isReadOnly());
 }
 
 TEST_F(TestGtIntProperty, bounds_deprecated)

--- a/tests/unittests/datamodel/test_gt_object.h
+++ b/tests/unittests/datamodel/test_gt_object.h
@@ -59,7 +59,7 @@ public:
                                             QString(), GtUnit::Category::Angle),
         m_fileProp("fileProp", "Test File", QString(), QStringList()),
         m_groupProp("Test Group", QString()),
-        m_intProp("intProp", "Test Int", QString(), GtUnit::Category::Angle),
+        m_intProp("intProp", "Test Int", QString()),
         m_labelProp("labelProp", "Test Label", QString(), this),
         m_modeProp("modeProp", "Test Mode", QString()),
         m_modeTypeProp("Test Type", QString()),


### PR DESCRIPTION
The internal usage of some deprecated functions related to properties should be reduced

## Description
For Int- and IntMonitoring- and DoubleMonitoringProperty some deprecated functions are still used internally. To cleanup the build warnings these usages are removed.

As the code now uses always the new versions this code extensions lead to more lines of code which need more tests to fullfill coverage.

## How Has This Been Tested?
Unittests had been extended to check the new and still the old code.
The tests for the functions which are marked as deprecated are in separated test functions to be removed easier in a later version. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Reduce internal usage of deprecated property constructors and adjust monitoring properties to rely on non-deprecated base constructors while preserving behavior.

Enhancements:
- Normalize integer property boundary handling directly in constructors and clamp initial values to configured bounds.
- Refactor int and double monitoring property constructors to construct via the underlying base property types and explicitly enable monitoring.
- Suppress deprecation warnings within the int property factory function without changing its existing interface or behavior.

## Summary by Sourcery

Reduce internal usage of deprecated integer and double property constructors and monitoring property helpers while keeping behavior consistent and tightening boundary handling.

Bug Fixes:
- Normalize and validate integer property boundaries so misordered limits now result in well-defined min/max ranges instead of falling back to unbounded defaults.

Enhancements:
- Route deprecated integer property constructors and integer monitoring factory through the new Boundaries-based APIs to centralize boundary logic and clamping.
- Mark several int, double, and monitoring property constructors and factory helpers with versioned deprecation macros for scheduled removal.
- Update monitoring-related codepaths to create standard properties and enable monitoring via flags instead of relying on dedicated monitoring property types.

Tests:
- Extend unit tests for int and double properties and monitoring properties to cover both new Boundaries-based constructors and legacy deprecated paths, including clamping behavior and factory functions.
- Adjust calculator and process test fixtures to use non-deprecated property APIs and monitoring factories while preserving test semantics.