### PR TITLE
Implement project execution context and per-project mutation locking (#1508-#1513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - GTlab now requires C++17 for compilation and usage. - #1441
+ - Core-managed process execution now resolves `currentProject()` through an
+   execution-scoped project context. Existing calculators remain compatible;
+   new execution code should pass an explicit project or `GtExecutionContext`.
+   See the project-context migration guide.
+   - #1507
  - The system of monitoring properties is changed and do not use the GtMonitoring class anymore.
    Now the base properties can be used with the flag setMonitoring. 
    The remaining function registermonitoringProperty includes a call of this function. - #1239

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -97,3 +97,13 @@ This keeps existing calls such as ``gtApp->currentProject()`` source-compatible
 while allowing legacy calculator code to observe its execution project. The
 context is only available on the thread where its scope was installed; callers
 must still use an explicit context for worker-thread execution.
+
+Core process execution
+----------------------
+
+The Core process executor determines the project from the task/source and
+passes an execution context into ``GtRunnable``. The runnable installs that
+context on its worker thread for the complete read, calculator, and write
+boundary. Its project path therefore comes from execution-specific context
+data instead of the GUI-selected project. The scope is removed when the run
+finishes, including failed and interrupted runs.

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -98,6 +98,22 @@ while allowing legacy calculator code to observe its execution project. The
 context is only available on the thread where its scope was installed; callers
 must still use an explicit context for worker-thread execution.
 
+Recommended calculator API
+--------------------------
+
+New calculators should accept a ``GtExecutionContext`` (or the project accessor
+derived from it) from their execution boundary and use that explicit value for
+project data. This makes the project dependency visible and avoids coupling new
+code to the compatibility singleton. Existing calculators may continue to use
+``gtApp->currentProject()``; while they run through the Core process executor,
+that call resolves to the execution project without source changes.
+
+The context is thread-local and is not copied to threads created by a module.
+Worker code must therefore receive the project or context explicitly. A worker
+must not retain a borrowed project pointer beyond the execution lifetime, and
+queued callbacks must not infer a project later through an unscoped global
+lookup.
+
 Core process execution
 ----------------------
 
@@ -123,3 +139,22 @@ while an execution is active. The guard is released on normal completion,
 failure, interruption, setup failure, and executor destruction. This is an
 in-process coordination mechanism only; it does not provide distributed
 locking or transactional conflict resolution.
+
+End-to-end validation and deferred work
+---------------------------------------
+
+The compatibility test suite executes a legacy calculator through the same
+``GtTaskRunner``/``GtRunnable`` boundary used by Core execution. It uses two
+projects, changes the GUI-selected project while the calculator is running, and
+verifies that the execution still observes its own project. Batch-mode tests
+continue to verify the headless compatibility path, while project guards cover
+same-project write serialization and preserve concurrent execution for distinct
+projects.
+
+The following architectural work remains deliberately deferred:
+
+* execution-project snapshots;
+* context-aware asynchronous helpers;
+* per-context externalization and state services;
+* a fully multi-project in-process datamodel; and
+* web API and worker orchestration.

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -95,14 +95,19 @@ the normal task/result or datamodel APIs rather than direct mutation.
 ``GtCoreApplication::currentProject()`` and
 ``GtCoreDatamodel::currentProject()`` use the same resolution policy:
 
-1. the project from the active, thread-local ``GtExecutionContext``;
-2. otherwise the currently selected project of the active session;
-3. ``nullptr`` when neither is available.
+1. If an execution context is active on the current thread, its project is
+   returned. This takes precedence even when the context contains only a
+   project path; in that case ``currentProject()`` returns ``nullptr``.
+2. If no execution context is active, the currently selected project of the
+   active session is returned.
+3. ``nullptr`` when neither an execution context project nor a selected
+   session project is available.
 
 This keeps existing calls such as ``gtApp->currentProject()`` source-compatible
 while allowing legacy calculator code to observe its execution project. The
 context is only available on the thread where its scope was installed; callers
-must still use an explicit context for worker-thread execution.
+must still use an explicit context for worker-thread execution. An active
+path-only context therefore does not fall back to the GUI-selected project.
 
 Recommended calculator API
 --------------------------

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -67,3 +67,19 @@ Known limitations
   application.
 * No production behavior is changed by this baseline. The later execution
   context work must preserve the GUI/main-thread fallback documented here.
+
+Execution context API
+---------------------
+
+The next migration step provides ``GtExecutionContext`` for new execution
+code. It carries a borrowed project pointer, the execution data root, a source
+identifier, the project path, and an optional job identifier. The context does
+not own the project and does not extend its lifetime; the project must remain
+alive for as long as the context may be used.
+
+``GtExecutionContextScope`` installs a context only on the current thread.
+Scopes can be nested and their destructors restore the previous context, also
+when control leaves the scope early or through an exception. The current
+context is available through ``GtExecutionContext::current()``. Contexts are
+not automatically propagated to child threads, and installing a scope does
+not change ``GtCoreApplication::currentProject()``.

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -1,9 +1,10 @@
-Project context compatibility baseline
-=======================================
+Project context and ``currentProject()`` compatibility
+=======================================================
 
-This page records the compatibility baseline for the first project-context
-migration. It describes the behavior that existing desktop code and legacy
-calculators rely on before an execution-scoped context is introduced.
+This page records the temporary compatibility baseline for the first
+project-context migration. The complete module porting guidance is tracked in
+issue 1518; this page documents the API contract needed by the current
+implementation.
 
 Compatibility matrix
 --------------------
@@ -65,23 +66,28 @@ Known limitations
 * The current GUI supports one selected project at a time. This baseline does
   not promise multiple projects being edited concurrently in the desktop
   application.
-* No production behavior is changed by this baseline. The later execution
-  context work must preserve the GUI/main-thread fallback documented here.
+* This is a transition document. Module-specific porting recipes and broader
+  integration guidance are intentionally tracked separately in issue 1518.
 
 Execution context API
 ---------------------
 
-The next migration step provides ``GtExecutionContext`` for new execution
-code. It carries a borrowed project pointer, the execution data root, a source
-identifier, the project path, and an optional job identifier. The context does
-not own the project and does not extend its lifetime; the project must remain
-alive for as long as the context may be used.
+``GtExecutionContext`` provides a borrowed project pointer and an optional
+project path for new execution code. A context is valid when it contains either
+one. A path-only context is useful for path resolution, but
+``currentProject()`` returns ``nullptr`` when no project pointer is present.
+The context does not own the project and does not extend its lifetime; the
+project must remain alive for as long as the context may be used.
 
 ``GtExecutionContextScope`` installs a context only on the current thread.
 Scopes can be nested and their destructors restore the previous context, also
 when control leaves the scope early or through an exception. The current
-context is available through ``GtExecutionContext::current()``. Contexts are
-not automatically propagated to child threads.
+context is available through ``GtExecutionContext::current()``. The scope and
+context are synchronous and thread-local, and are not automatically propagated
+to child threads. Do not retain either the context or its borrowed project
+pointer for asynchronous work. During calculator execution, use the context
+to identify the execution project; persistent project changes must go through
+the normal task/result or datamodel APIs rather than direct mutation.
 
 ``currentProject()`` resolution
 -------------------------------
@@ -101,12 +107,33 @@ must still use an explicit context for worker-thread execution.
 Recommended calculator API
 --------------------------
 
-New calculators should accept a ``GtExecutionContext`` (or the project accessor
-derived from it) from their execution boundary and use that explicit value for
-project data. This makes the project dependency visible and avoids coupling new
-code to the compatibility singleton. Existing calculators may continue to use
-``gtApp->currentProject()``; while they run through the Core process executor,
+New calculator helpers and services should accept a ``GtProject*`` or
+``GtExecutionContext`` from their execution boundary and use that explicit
+value for project data. The historical ``GtCalculator::exec()`` interface does
+not have a project parameter, so existing calculators may continue to use
+``gtApp->currentProject()``. While they run through the Core process executor,
 that call resolves to the execution project without source changes.
+
+For new code, make the dependency explicit at the first helper boundary:
+
+.. code-block:: cpp
+
+   bool MyCalculator::updateProjectData(GtProject* project)
+   {
+       if (!project) return false;
+       // Read execution data and prepare calculator results.
+       return true;
+   }
+
+   bool MyCalculator::exec()
+   {
+       return updateProjectData(gtApp->currentProject());
+   }
+
+The explicit helper can later be called by another execution service without
+depending on the GUI-selected project. Calculators must not retain the borrowed
+project pointer for delayed work or pass it to a child thread without an
+explicit lifetime and ownership policy.
 
 The context is thread-local and is not copied to threads created by a module.
 Worker code must therefore receive the project or context explicitly. A worker
@@ -114,12 +141,29 @@ must not retain a borrowed project pointer beyond the execution lifetime, and
 queued callbacks must not infer a project later through an unscoped global
 lookup.
 
+Module component guidance
+-------------------------
+
+* **Tasks and task groups:** derive the project from the task hierarchy with
+  ``task->findParent<GtProject*>()`` or pass it explicitly from the execution
+  boundary. Do not use the GUI-selected project to identify the task's project.
+* **Calculators:** keep ``exec()`` compatible, but pass ``GtProject*`` or
+  ``GtExecutionContext`` into new calculator helpers and services. Existing
+  ``gtApp->currentProject()`` calls remain supported during Core execution.
+* **Project-bound MDI widgets:** store the project supplied when the widget is
+  opened, for example as a ``QPointer<GtProject>``. Use
+  ``gtApp->currentProject()`` only for actions explicitly targeting the
+  currently selected GUI project.
+* **Worker threads and callbacks:** pass the project or context explicitly;
+  thread-local context is not inherited by a new thread and must not be
+  inferred later from a global lookup.
+
 Core process execution
 ----------------------
 
 The Core process executor determines the project from the task/source and
 passes an execution context into ``GtRunnable``. The runnable installs that
-context on its worker thread for the complete read, calculator, and write
+context on its execution thread for the complete read, calculator, and write
 boundary. Its project path therefore comes from execution-specific context
 data instead of the GUI-selected project. The scope is removed when the run
 finishes, including failed and interrupted runs.
@@ -128,14 +172,16 @@ Project-scoped mutation policy
 ------------------------------
 
 Mutating process executions are serialized per project. The core derives a
-stable execution key from the canonical project path and holds a scoped guard
+stable execution key from the canonical project path, or from the project's
+stable UUID for pathless projects, and holds a scoped guard
 from task setup through result merging. A second executor targeting the same
 project receives a structured ``Busy`` result and is rejected; it is not
 silently queued behind an unrelated executor. Executions for different
 projects use different keys and can proceed concurrently.
 
-Project save and close operations check the same guard and fail deterministically
-while an execution is active. The guard is released on normal completion,
+Project save and close operations acquire the same exclusive guard for their
+complete operation and fail deterministically while an execution is active.
+The guard is released on normal completion,
 failure, interruption, setup failure, and executor destruction. This is an
 in-process coordination mechanism only; it does not provide distributed
 locking or transactional conflict resolution.

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -107,3 +107,19 @@ context on its worker thread for the complete read, calculator, and write
 boundary. Its project path therefore comes from execution-specific context
 data instead of the GUI-selected project. The scope is removed when the run
 finishes, including failed and interrupted runs.
+
+Project-scoped mutation policy
+------------------------------
+
+Mutating process executions are serialized per project. The core derives a
+stable execution key from the canonical project path and holds a scoped guard
+from task setup through result merging. A second executor targeting the same
+project receives a structured ``Busy`` result and is rejected; it is not
+silently queued behind an unrelated executor. Executions for different
+projects use different keys and can proceed concurrently.
+
+Project save and close operations check the same guard and fail deterministically
+while an execution is active. The guard is released on normal completion,
+failure, interruption, setup failure, and executor destruction. This is an
+in-process coordination mechanism only; it does not provide distributed
+locking or transactional conflict resolution.

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -1,0 +1,69 @@
+Project context compatibility baseline
+=======================================
+
+This page records the compatibility baseline for the first project-context
+migration. It describes the behavior that existing desktop code and legacy
+calculators rely on before an execution-scoped context is introduced.
+
+Compatibility matrix
+--------------------
+
+``currentProject()`` is used through several existing Core access paths:
+
+.. list-table:: Core call-site classification
+   :header-rows: 1
+   :widths: 24 28 48
+
+   * - Area
+     - Representative files
+     - Current contract
+   * - GUI selection and commands
+     - ``src/app/gt_mainwin.cpp``; ``src/app/dock_widgets/``;
+       ``src/gui/object_ui/gt_projectui.cpp``;
+       ``src/gui/dock_widgets/properties/editors/``
+     - Resolve the project selected by the desktop session for display,
+       editing, saving, closing, and undo-command creation.
+   * - GUI data-model coordination
+     - ``src/core/gt_coreapplication.cpp``;
+       ``src/core/gt_coredatamodel.cpp``;
+       ``src/core/gt_session.cpp``
+     - ``GtCoreApplication::currentProject()`` and
+       ``GtCoreDatamodel::currentProject()`` return the session's selected
+       project; no project returns ``nullptr``.
+   * - Process execution
+     - ``src/gui/process_runner/gt_processrunnertransceiver.cpp``;
+       ``src/core/gt_runnable.cpp``;
+       ``src/core/process_management/gt_processdata.cpp``
+     - Existing process infrastructure uses the selected project for the
+       project path, process bookkeeping, and execution cleanup.
+   * - Legacy calculator behavior
+     - ``src/core/process_management/calculators/gt_exporttomementocalculator.cpp``
+     - Calculators may read ``gtApp->currentProject()`` without receiving a
+       project argument. This source-level behavior must remain valid.
+   * - Data access and path lookup
+     - ``src/gui/gt_datamodel.cpp``;
+       ``src/gui/gt_textfilterdelegate.cpp``;
+       ``src/core/gt_runnable.cpp``
+     - Callers use the selected project to find common parents, resolve
+       project paths, or update UI state.
+
+The executable baseline is covered by
+``CurrentProjectCompatibility.guiFallbackTracksSelectedProject`` and
+``CurrentProjectCompatibility.legacyCalculatorReadsSelectedProject``. The
+second test represents a calculator that keeps the existing
+``gtApp->currentProject()`` access and verifies that it observes the selected
+project during execution.
+
+Known limitations
+-----------------
+
+* A project context is not implicitly propagated to module-created worker
+  threads. A worker must receive the project explicitly until a context-aware
+  helper is introduced.
+* Delayed callbacks can run after the initiating process has returned. They
+  must not retain or later infer a project from an unscoped global lookup.
+* The current GUI supports one selected project at a time. This baseline does
+  not promise multiple projects being edited concurrently in the desktop
+  application.
+* No production behavior is changed by this baseline. The later execution
+  context work must preserve the GUI/main-thread fallback documented here.

--- a/docs/dev/howtos/project_context_compatibility.rst
+++ b/docs/dev/howtos/project_context_compatibility.rst
@@ -81,5 +81,19 @@ alive for as long as the context may be used.
 Scopes can be nested and their destructors restore the previous context, also
 when control leaves the scope early or through an exception. The current
 context is available through ``GtExecutionContext::current()``. Contexts are
-not automatically propagated to child threads, and installing a scope does
-not change ``GtCoreApplication::currentProject()``.
+not automatically propagated to child threads.
+
+``currentProject()`` resolution
+-------------------------------
+
+``GtCoreApplication::currentProject()`` and
+``GtCoreDatamodel::currentProject()`` use the same resolution policy:
+
+1. the project from the active, thread-local ``GtExecutionContext``;
+2. otherwise the currently selected project of the active session;
+3. ``nullptr`` when neither is available.
+
+This keeps existing calls such as ``gtApp->currentProject()`` source-compatible
+while allowing legacy calculator code to observe its execution project. The
+context is only available on the thread where its scope was installed; callers
+must still use an explicit context for worker-thread execution.

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -100,6 +100,7 @@ Your first module
    :hidden:
 
    howtos/migration_and_deprecation
+   howtos/project_context_compatibility
    faq
    changelog
 

--- a/src/app/dock_widgets/process/gt_processdock.cpp
+++ b/src/app/dock_widgets/process/gt_processdock.cpp
@@ -1043,7 +1043,7 @@ GtProcessDock::runProcess()
                 }
                 else
                 {
-                    gt::currentProcessExecutor().runTask(task);
+                    gt::currentProcessExecutor().startTask(task);
                 }
             }
         }

--- a/src/batch/batchremote.cpp
+++ b/src/batch/batchremote.cpp
@@ -357,7 +357,7 @@ gt::batch::run(const QString& inputName,
         objectGroup->appendChild(object);
     }
     executor.setSource(objectGroup);
-    executor.runTask(process);
+    executor.startTask(process);
 
     if (process->currentState() != GtProcessComponent::FINISHED)
     {

--- a/src/batch/gt_consolerunprocess.cpp
+++ b/src/batch/gt_consolerunprocess.cpp
@@ -201,7 +201,7 @@ gt::console::runProcess(const QString& projectId,
     }
 
     // execute process
-    gt::currentProcessExecutor().runTask(process);
+    gt::currentProcessExecutor().startTask(process);
 
     if (process->currentState() != GtProcessComponent::FINISHED)
     {

--- a/src/batch/gt_remoteprocessrunnerstates.cpp
+++ b/src/batch/gt_remoteprocessrunnerstates.cpp
@@ -285,7 +285,7 @@ GtInitializedProcessRunnerState::handleCommand(Command& command)
                             tr("Failed to set source!"));
     }
 
-    if (!executor.runTask(m->task))
+    if (executor.startTask(m->task) == GtCoreProcessExecutor::RunTaskResult::Invalid)
     {
         return makeResponse(command, gt::process_runner::RunTaskError,
                            tr("Triggering task execution failed!"));

--- a/src/batch/gt_remoteprocessrunnerstates.cpp
+++ b/src/batch/gt_remoteprocessrunnerstates.cpp
@@ -285,7 +285,7 @@ GtInitializedProcessRunnerState::handleCommand(Command& command)
                             tr("Failed to set source!"));
     }
 
-    if (executor.startTask(m->task) == GtCoreProcessExecutor::RunTaskResult::Invalid)
+    if (executor.startTask(m->task) == GtCoreProcessExecutor::TaskExecState::Invalid)
     {
         return makeResponse(command, gt::process_runner::RunTaskError,
                            tr("Triggering task execution failed!"));

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -78,6 +78,7 @@ set(headers
     states/gt_statecontainer.h
     gt_coreapplication.h
     gt_executioncontext.h
+    gt_projectexecutionguard.h
     gt_core_exports.h
     gt_footprint.h
     gt_globals.h
@@ -188,6 +189,7 @@ set(sources
     states/gt_statecontainer.cpp
     gt_coreapplication.cpp
     gt_executioncontext.cpp
+    gt_projectexecutionguard.cpp
     gt_footprint.cpp
     gt_projectanalyzer.cpp
     gt_saveprojecthelper.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -77,6 +77,7 @@ set(headers
     states/gt_statehandler.h
     states/gt_statecontainer.h
     gt_coreapplication.h
+    gt_executioncontext.h
     gt_core_exports.h
     gt_footprint.h
     gt_globals.h
@@ -186,6 +187,7 @@ set(sources
     states/gt_statehandler.cpp
     states/gt_statecontainer.cpp
     gt_coreapplication.cpp
+    gt_executioncontext.cpp
     gt_footprint.cpp
     gt_projectanalyzer.cpp
     gt_saveprojecthelper.cpp

--- a/src/core/gt_coreapplication.cpp
+++ b/src/core/gt_coreapplication.cpp
@@ -948,14 +948,7 @@ GtCoreApplication::settings()
 GtProject*
 GtCoreApplication::currentProject()
 {
-    GtSession* w = session();
-
-    if (w)
-    {
-        return w->currentProject();
-    }
-
-    return nullptr;
+    return m_dataModel ? m_dataModel->currentProject() : nullptr;
 }
 
 GtProject*

--- a/src/core/gt_coreapplication.h
+++ b/src/core/gt_coreapplication.h
@@ -140,8 +140,11 @@ public:
     GtSettings* settings();
 
     /**
-     * @brief Returns pointer to current project. NULL if no current project
-     * selected.
+     * @brief Returns the execution-context project or the session project.
+     *
+     * This uses the same resolution policy as GtCoreDatamodel::currentProject:
+     * an active context on the current thread takes precedence over the
+     * currently selected session project. NULL is returned if neither exists.
      * @return Pointer to current project
      */
     GtProject* currentProject();

--- a/src/core/gt_coredatamodel.cpp
+++ b/src/core/gt_coredatamodel.cpp
@@ -22,6 +22,7 @@
 #include "gt_statehandler.h"
 #include "gt_externalizationmanager.h"
 #include "gt_executioncontext.h"
+#include "gt_projectexecutionguard.h"
 
 #include "gt_coredatamodel.h"
 
@@ -322,6 +323,12 @@ GtCoreDatamodel::saveProject(GtProject* project)
         return retval;
     }
 
+    if (GtProjectExecutionGuard::isBusy(project))
+    {
+        gtWarning() << tr("Cannot save project while it is being executed.");
+        return false;
+    }
+
     // check session
     if (m_session)
     {
@@ -344,6 +351,12 @@ GtCoreDatamodel::closeProject(GtProject* project)
     // check project
     if (!project)
     {
+        return false;
+    }
+
+    if (GtProjectExecutionGuard::isBusy(project))
+    {
+        gtWarning() << tr("Cannot close project while it is being executed.");
         return false;
     }
 

--- a/src/core/gt_coredatamodel.cpp
+++ b/src/core/gt_coredatamodel.cpp
@@ -323,7 +323,8 @@ GtCoreDatamodel::saveProject(GtProject* project)
         return retval;
     }
 
-    if (GtProjectExecutionGuard::isBusy(project))
+    GtProjectExecutionGuard guard;
+    if (guard.tryAcquire(project) != GtProjectExecutionGuard::Result::Acquired)
     {
         gtWarning() << tr("Cannot save project while it is being executed.");
         return false;
@@ -354,7 +355,8 @@ GtCoreDatamodel::closeProject(GtProject* project)
         return false;
     }
 
-    if (GtProjectExecutionGuard::isBusy(project))
+    GtProjectExecutionGuard guard;
+    if (guard.tryAcquire(project) != GtProjectExecutionGuard::Result::Acquired)
     {
         gtWarning() << tr("Cannot close project while it is being executed.");
         return false;

--- a/src/core/gt_coredatamodel.cpp
+++ b/src/core/gt_coredatamodel.cpp
@@ -21,6 +21,7 @@
 #include "gt_state.h"
 #include "gt_statehandler.h"
 #include "gt_externalizationmanager.h"
+#include "gt_executioncontext.h"
 
 #include "gt_coredatamodel.h"
 
@@ -186,6 +187,11 @@ GtCoreDatamodel::session()
 GtProject*
 GtCoreDatamodel::currentProject()
 {
+    if (auto const* context = GtExecutionContext::current())
+    {
+        return context->project();
+    }
+
     // check session
     if (m_session)
     {

--- a/src/core/gt_coredatamodel.h
+++ b/src/core/gt_coredatamodel.h
@@ -56,8 +56,11 @@ public:
     GtSession* session();
 
     /**
-     * @brief Returns current project. If no current project exists NULL will
-     * be returned.
+     * @brief Returns the execution-context project or the session project.
+     *
+     * If a GtExecutionContext is active on the current thread, its project is
+     * returned. Otherwise the currently selected session project is returned;
+     * if neither exists, NULL is returned.
      * @return Current project pointer
      */
     GtProject* currentProject();

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -499,15 +499,7 @@ GtCoreProcessExecutor::setupTaskRunner()
     // create new task runner
     auto* runner = new GtTaskRunner{m_current};
 
-    GtProject* project = qobject_cast<GtProject*>(m_source.data());
-    if (!project)
-    {
-        project = m_source->findParent<GtProject*>();
-    }
-    if (!project)
-    {
-        project = m_current->findParent<GtProject*>();
-    }
+    GtProject* project = projectForTask(m_current, m_source);
 
     const QString projectPath = pimpl->customProjectPath.isEmpty() && project ?
                                      project->path() :
@@ -543,8 +535,9 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
 {
     gtTrace() << __FUNCTION__;
 
-    const auto guardCleanup = gt::finally(
-        [this]() { pimpl->projectGuard.reset(); });
+    const auto _ = gt::finally([this]() {
+        pimpl->projectGuard.reset();
+    });
 
     // create timer
     QElapsedTimer timer;

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -11,6 +11,7 @@
 #include <QDir>
 #include <QElapsedTimer>
 #include <QEventLoop>
+#include <QScopeGuard>
 
 #include "gt_logging.h"
 #include "gt_runnable.h"
@@ -514,10 +515,7 @@ GtCoreProcessExecutor::setupTaskRunner()
                                      pimpl->customProjectPath;
     GtExecutionContext executionContext(
         project,
-        {},
-        m_source->objectName(),
-        projectPath,
-        m_current->objectName());
+        projectPath);
 
     // create new runnable
     pimpl->currentRunnable = new GtRunnable{
@@ -546,6 +544,10 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
 {
     gtTrace() << __FUNCTION__;
 
+    const auto guardCleanup = qScopeGuard(
+        [this]() { pimpl->projectGuard.reset(); });
+    Q_UNUSED(guardCleanup);
+
     // create timer
     QElapsedTimer timer;
 
@@ -566,7 +568,6 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
     if (!m_current)
     {
         gtFatalId(GT_EXEC_ID) << tr("Current task corrupted!");
-        pimpl->projectGuard.reset();
         taskRunner->deleteLater();
         return;
     }
@@ -591,8 +592,6 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
         }
     }
 
-    pimpl->projectGuard.reset();
-
     gtInfoId(GT_EXEC_ID).medium()
         << tr("----> Task finished (took %1 ms to merge) <----")
                .arg(timer.elapsed());
@@ -603,5 +602,7 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
     // delete task runner
     taskRunner->deleteLater();
 
+    // Release before starting a queued task so it can acquire its own key.
+    pimpl->projectGuard.reset();
     executeNextTask();
 }

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -11,8 +11,6 @@
 #include <QDir>
 #include <QElapsedTimer>
 #include <QEventLoop>
-#include <QScopeGuard>
-
 #include "gt_logging.h"
 #include "gt_runnable.h"
 #include "gt_project.h"
@@ -22,6 +20,7 @@
 #include "gt_objectmementodiff.h"
 #include "gt_coreapplication.h"
 #include "gt_executioncontext.h"
+#include "gt_finally.h"
 #include "gt_projectexecutionguard.h"
 #include "gt_taskrunner.h"
 
@@ -544,9 +543,8 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
 {
     gtTrace() << __FUNCTION__;
 
-    const auto guardCleanup = qScopeGuard(
+    const auto guardCleanup = gt::finally(
         [this]() { pimpl->projectGuard.reset(); });
-    Q_UNUSED(guardCleanup);
 
     // create timer
     QElapsedTimer timer;

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -20,6 +20,7 @@
 #include "gt_task.h"
 #include "gt_objectmementodiff.h"
 #include "gt_coreapplication.h"
+#include "gt_executioncontext.h"
 #include "gt_taskrunner.h"
 
 #include "gt_coreprocessexecutor.h"
@@ -446,8 +447,29 @@ GtCoreProcessExecutor::setupTaskRunner()
     // create new task runner
     auto* runner = new GtTaskRunner{m_current};
 
+    GtProject* project = qobject_cast<GtProject*>(m_source.data());
+    if (!project)
+    {
+        project = m_source->findParent<GtProject*>();
+    }
+    if (!project)
+    {
+        project = m_current->findParent<GtProject*>();
+    }
+
+    const QString projectPath = pimpl->customProjectPath.isEmpty() && project ?
+                                     project->path() :
+                                     pimpl->customProjectPath;
+    GtExecutionContext executionContext(
+        project,
+        {},
+        m_source->objectName(),
+        projectPath,
+        m_current->objectName());
+
     // create new runnable
-    pimpl->currentRunnable = new GtRunnable{pimpl->customProjectPath};
+    pimpl->currentRunnable = new GtRunnable{
+        pimpl->customProjectPath, std::move(executionContext)};
 
     // setup task runner
     if (!runner->setUp(pimpl->currentRunnable, m_source))

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -85,15 +85,8 @@ GtCoreProcessExecutor::setCoreExecutorFlags(Flags flags)
     pimpl->detached =  flags.testFlag(gt::NonBlockingExecution);
 }
 
-bool
-GtCoreProcessExecutor::runTask(GtTask* task)
-{
-    const auto result = runTaskWithResult(task);
-    return result == RunTaskResult::Started || result == RunTaskResult::Queued;
-}
-
 GtCoreProcessExecutor::RunTaskResult
-GtCoreProcessExecutor::runTaskWithResult(GtTask* task)
+GtCoreProcessExecutor::startTask(GtTask* task)
 {
     gtDebugId(GT_EXEC_ID).medium() << __FUNCTION__;
 
@@ -107,17 +100,11 @@ GtCoreProcessExecutor::runTaskWithResult(GtTask* task)
         return RunTaskResult::Queued;
     }
 
-    return executeNextTaskWithResult();
-}
-
-bool
-GtCoreProcessExecutor::executeNextTask()
-{
-    return executeNextTaskWithResult() == RunTaskResult::Started;
+    return startNextTask();
 }
 
 GtCoreProcessExecutor::RunTaskResult
-GtCoreProcessExecutor::executeNextTaskWithResult()
+GtCoreProcessExecutor::startNextTask()
 {
     // check whether a task is already running
     if (taskCurrentlyRunning())
@@ -519,7 +506,7 @@ GtCoreProcessExecutor::setupTaskRunner()
         delete pimpl->currentRunnable;
         delete runner;
         clearCurrentTask();
-        executeNextTask();
+        startNextTask();
         return nullptr;
     }
 
@@ -595,5 +582,5 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
 
     // Release before starting a queued task so it can acquire its own key.
     pimpl->projectGuard.reset();
-    executeNextTask();
+    startNextTask();
 }

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -85,39 +85,39 @@ GtCoreProcessExecutor::setCoreExecutorFlags(Flags flags)
     pimpl->detached =  flags.testFlag(gt::NonBlockingExecution);
 }
 
-GtCoreProcessExecutor::RunTaskResult
+GtCoreProcessExecutor::TaskExecState
 GtCoreProcessExecutor::startTask(GtTask* task)
 {
     gtDebugId(GT_EXEC_ID).medium() << __FUNCTION__;
 
     if (!queueTask(task))
     {
-        return RunTaskResult::Invalid;
+        return TaskExecState::Invalid;
     }
 
     if (taskCurrentlyRunning())
     {
-        return RunTaskResult::Queued;
+        return TaskExecState::Queued;
     }
 
     return startNextTask();
 }
 
-GtCoreProcessExecutor::RunTaskResult
+GtCoreProcessExecutor::TaskExecState
 GtCoreProcessExecutor::startNextTask()
 {
     // check whether a task is already running
     if (taskCurrentlyRunning())
     {
         gtErrorId(GT_EXEC_ID) << tr("A Task is already running!");
-        return RunTaskResult::Busy;
+        return TaskExecState::Busy;
     }
 
     // check whether queue is empty
     if (m_queue.isEmpty())
     {
         emit allTasksCompleted();
-        return RunTaskResult::Invalid;
+        return TaskExecState::Invalid;
     }
 
     // checkout next task in queue
@@ -128,7 +128,7 @@ GtCoreProcessExecutor::startNextTask()
     {
         gtErrorId(GT_EXEC_ID) << tr("Cannot execute an invalid Task!");
         clearCurrentTask();
-        return RunTaskResult::Invalid;
+        return TaskExecState::Invalid;
     }
 
     // setup source
@@ -142,7 +142,7 @@ GtCoreProcessExecutor::startNextTask()
         {
             gtErrorId(GT_EXEC_ID) << tr("Source corrupted!");
             clearCurrentTask();
-            return RunTaskResult::Invalid;
+            return TaskExecState::Invalid;
         }
     }
 
@@ -157,7 +157,7 @@ GtCoreProcessExecutor::startNextTask()
             m_current->setState(GtProcessComponent::NONE);
             m_current = nullptr;
             emit queueChanged();
-            return RunTaskResult::Busy;
+            return TaskExecState::Busy;
         }
         if (result == GtProjectExecutionGuard::Result::InvalidProject)
         {
@@ -169,7 +169,7 @@ GtCoreProcessExecutor::startNextTask()
 
     execute();
 
-    return RunTaskResult::Started;
+    return TaskExecState::Started;
 }
 
 bool

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -566,6 +566,7 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
     if (!m_current)
     {
         gtFatalId(GT_EXEC_ID) << tr("Current task corrupted!");
+        pimpl->projectGuard.reset();
         taskRunner->deleteLater();
         return;
     }

--- a/src/core/gt_coreprocessexecutor.cpp
+++ b/src/core/gt_coreprocessexecutor.cpp
@@ -21,6 +21,7 @@
 #include "gt_objectmementodiff.h"
 #include "gt_coreapplication.h"
 #include "gt_executioncontext.h"
+#include "gt_projectexecutionguard.h"
 #include "gt_taskrunner.h"
 
 #include "gt_coreprocessexecutor.h"
@@ -43,7 +44,26 @@ struct GtCoreProcessExecutor::Impl
 
     /// Pointer to current runnable
     QPointer<GtRunnable> currentRunnable;
+
+    std::unique_ptr<GtProjectExecutionGuard> projectGuard;
 };
+
+namespace
+{
+GtProject* projectForTask(GtTask* task, GtObject* source)
+{
+    auto* project = qobject_cast<GtProject*>(source);
+    if (!project && source)
+    {
+        project = source->findParent<GtProject*>();
+    }
+    if (!project && task)
+    {
+        project = task->findParent<GtProject*>();
+    }
+    return project;
+}
+}
 
 GtCoreProcessExecutor::GtCoreProcessExecutor(QObject* parent, Flags flags) :
     QObject(parent),
@@ -68,36 +88,49 @@ GtCoreProcessExecutor::setCoreExecutorFlags(Flags flags)
 bool
 GtCoreProcessExecutor::runTask(GtTask* task)
 {
+    const auto result = runTaskWithResult(task);
+    return result == RunTaskResult::Started || result == RunTaskResult::Queued;
+}
+
+GtCoreProcessExecutor::RunTaskResult
+GtCoreProcessExecutor::runTaskWithResult(GtTask* task)
+{
     gtDebugId(GT_EXEC_ID).medium() << __FUNCTION__;
 
     if (!queueTask(task))
     {
-        return false;
+        return RunTaskResult::Invalid;
     }
 
     if (taskCurrentlyRunning())
     {
-        return true;
+        return RunTaskResult::Queued;
     }
 
-    return executeNextTask();
+    return executeNextTaskWithResult();
 }
 
 bool
 GtCoreProcessExecutor::executeNextTask()
 {
+    return executeNextTaskWithResult() == RunTaskResult::Started;
+}
+
+GtCoreProcessExecutor::RunTaskResult
+GtCoreProcessExecutor::executeNextTaskWithResult()
+{
     // check whether a task is already running
     if (taskCurrentlyRunning())
     {
         gtErrorId(GT_EXEC_ID) << tr("A Task is already running!");
-        return false;
+        return RunTaskResult::Busy;
     }
 
     // check whether queue is empty
     if (m_queue.isEmpty())
     {
         emit allTasksCompleted();
-        return false;
+        return RunTaskResult::Invalid;
     }
 
     // checkout next task in queue
@@ -108,7 +141,7 @@ GtCoreProcessExecutor::executeNextTask()
     {
         gtErrorId(GT_EXEC_ID) << tr("Cannot execute an invalid Task!");
         clearCurrentTask();
-        return false;
+        return RunTaskResult::Invalid;
     }
 
     // setup source
@@ -122,7 +155,26 @@ GtCoreProcessExecutor::executeNextTask()
         {
             gtErrorId(GT_EXEC_ID) << tr("Source corrupted!");
             clearCurrentTask();
-            return false;
+            return RunTaskResult::Invalid;
+        }
+    }
+
+    if (auto* project = projectForTask(m_current, m_source))
+    {
+        pimpl->projectGuard = std::make_unique<GtProjectExecutionGuard>();
+        const auto result = pimpl->projectGuard->tryAcquire(project);
+        if (result == GtProjectExecutionGuard::Result::Busy)
+        {
+            pimpl->projectGuard.reset();
+            m_queue.removeAll(m_current);
+            m_current->setState(GtProcessComponent::NONE);
+            m_current = nullptr;
+            emit queueChanged();
+            return RunTaskResult::Busy;
+        }
+        if (result == GtProjectExecutionGuard::Result::InvalidProject)
+        {
+            pimpl->projectGuard.reset();
         }
     }
 
@@ -130,7 +182,7 @@ GtCoreProcessExecutor::executeNextTask()
 
     execute();
 
-    return true;
+    return RunTaskResult::Started;
 }
 
 bool
@@ -474,6 +526,7 @@ GtCoreProcessExecutor::setupTaskRunner()
     // setup task runner
     if (!runner->setUp(pimpl->currentRunnable, m_source))
     {
+        pimpl->projectGuard.reset();
         delete pimpl->currentRunnable;
         delete runner;
         clearCurrentTask();
@@ -536,6 +589,8 @@ GtCoreProcessExecutor::onTaskRunnerFinished()
             handleTaskFinishedHelper(changedData, finishedTask);
         }
     }
+
+    pimpl->projectGuard.reset();
 
     gtInfoId(GT_EXEC_ID).medium()
         << tr("----> Task finished (took %1 ms to merge) <----")

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -53,14 +53,14 @@ public:
 
     enum class RunTaskResult
     {
+        /// Task or execution setup was invalid.
+        Invalid = 0,
         /// Execution was started immediately.
         Started,
         /// Task was accepted into this executor's queue.
         Queued,
         /// Task was rejected because the project or executor is busy.
-        Busy,
-        /// Task or execution setup was invalid.
-        Invalid
+        Busy
     };
 
     /// Id of this executor

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -51,7 +51,7 @@ class GT_CORE_EXPORT GtCoreProcessExecutor : public QObject
 
 public:
 
-    enum class RunTaskResult
+    enum class TaskExecState
     {
         /// Task or execution setup was invalid.
         Invalid = 0,
@@ -85,13 +85,13 @@ public:
     bool runTask(GtTask* task)
     {
         const auto result = startTask(task);
-        return result == RunTaskResult::Started || result == RunTaskResult::Queued;
+        return result == TaskExecState::Started || result == TaskExecState::Queued;
     }
 
     GT_DEPRECATED_REMOVED_IN(2, 2, "Use startNextTask instead")
     bool executeNextTask()
     {
-        return startNextTask() == RunTaskResult::Started;
+        return startNextTask() == TaskExecState::Started;
     }
 
     /**
@@ -103,12 +103,12 @@ public:
      * The compatibility wrapper runTask() returns true for both Started and
      * Queued.
      */
-    RunTaskResult startTask(GtTask* task);
+    TaskExecState startTask(GtTask* task);
 
     /**
      * @brief Starts the next task in the queue. No task must be running.
      */
-    RunTaskResult startNextTask();
+    TaskExecState startNextTask();
 
     /**
      * @brief Terminates current running task.

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -53,9 +53,13 @@ public:
 
     enum class RunTaskResult
     {
+        /// Execution was started immediately.
         Started,
+        /// Task was accepted into this executor's queue.
         Queued,
+        /// Task was rejected because the project or executor is busy.
         Busy,
+        /// Task or execution setup was invalid.
         Invalid
     };
 
@@ -84,7 +88,11 @@ public:
     bool runTask(GtTask* task);
 
     /**
-     * @brief Runs a task and reports whether it started, was queued, or was rejected.
+     * @brief Runs a task and reports the outcome.
+     *
+     * Busy tasks are rejected and removed; they are not retried automatically.
+     * The compatibility wrapper runTask() returns true for both Started and
+     * Queued.
      */
     RunTaskResult runTaskWithResult(GtTask* task);
 

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -81,26 +81,34 @@ public:
 
     void setCoreExecutorFlags(Flags flags);
 
-    /**
-     * @brief Runs a process if the queue is free
-     * @param process GtdProcess
-     */
-    bool runTask(GtTask* task);
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use startTask instead")
+    bool runTask(GtTask* task)
+    {
+        const auto result = startTask(task);
+        return result == RunTaskResult::Started || result == RunTaskResult::Queued;
+    }
+
+    GT_DEPRECATED_REMOVED_IN(2, 2, "Use startNextTask instead")
+    bool executeNextTask()
+    {
+        return startNextTask() == RunTaskResult::Started;
+    }
 
     /**
      * @brief Runs a task and reports the outcome.
+     *
+     * Queues the task and then starts it via ::startNextTask().
      *
      * Busy tasks are rejected and removed; they are not retried automatically.
      * The compatibility wrapper runTask() returns true for both Started and
      * Queued.
      */
-    RunTaskResult runTaskWithResult(GtTask* task);
+    RunTaskResult startTask(GtTask* task);
 
     /**
-     * @brief Executes the next task in the queue. No task must be running.
-     * @return Whether task execution was successfully triggered
+     * @brief Starts the next task in the queue. No task must be running.
      */
-    bool executeNextTask();
+    RunTaskResult startNextTask();
 
     /**
      * @brief Terminates current running task.
@@ -238,9 +246,6 @@ protected:
     GtTaskRunner* setupTaskRunner();
 
 private:
-
-    RunTaskResult executeNextTaskWithResult();
-
     ///pimpl
     struct Impl;
     std::unique_ptr<Impl> pimpl;

--- a/src/core/gt_coreprocessexecutor.h
+++ b/src/core/gt_coreprocessexecutor.h
@@ -24,6 +24,7 @@ class GtTask;
 class GtRunnable;
 class GtCalculator;
 class GtTaskRunner;
+class GtProjectExecutionGuard;
 
 class GtObjectLinkProperty;
 
@@ -50,6 +51,14 @@ class GT_CORE_EXPORT GtCoreProcessExecutor : public QObject
 
 public:
 
+    enum class RunTaskResult
+    {
+        Started,
+        Queued,
+        Busy,
+        Invalid
+    };
+
     /// Id of this executor
     static const std::string S_ID;
 
@@ -73,6 +82,11 @@ public:
      * @param process GtdProcess
      */
     bool runTask(GtTask* task);
+
+    /**
+     * @brief Runs a task and reports whether it started, was queued, or was rejected.
+     */
+    RunTaskResult runTaskWithResult(GtTask* task);
 
     /**
      * @brief Executes the next task in the queue. No task must be running.
@@ -216,6 +230,8 @@ protected:
     GtTaskRunner* setupTaskRunner();
 
 private:
+
+    RunTaskResult executeNextTaskWithResult();
 
     ///pimpl
     struct Impl;

--- a/src/core/gt_executioncontext.cpp
+++ b/src/core/gt_executioncontext.cpp
@@ -16,7 +16,7 @@ thread_local GtExecutionContext const* currentExecutionContext = nullptr;
 
 } // namespace
 
-GtExecutionContext::GtExecutionContext(GtProject const* project,
+GtExecutionContext::GtExecutionContext(GtProject* project,
                                        QString executionDataRoot,
                                        QString source,
                                        QString projectPath,
@@ -33,7 +33,7 @@ GtExecutionContext::GtExecutionContext(GtProject const* project,
     }
 }
 
-GtProject const*
+GtProject*
 GtExecutionContext::project() const noexcept
 {
     return m_project;

--- a/src/core/gt_executioncontext.cpp
+++ b/src/core/gt_executioncontext.cpp
@@ -17,15 +17,9 @@ thread_local GtExecutionContext const* currentExecutionContext = nullptr;
 } // namespace
 
 GtExecutionContext::GtExecutionContext(GtProject* project,
-                                       QString executionDataRoot,
-                                       QString source,
-                                       QString projectPath,
-                                       QString jobId) :
+                                       QString projectPath) :
     m_project(project),
-    m_executionDataRoot(std::move(executionDataRoot)),
-    m_source(std::move(source)),
-    m_projectPath(std::move(projectPath)),
-    m_jobId(std::move(jobId))
+    m_projectPath(std::move(projectPath))
 {
     if (m_projectPath.isEmpty() && m_project)
     {
@@ -40,33 +34,15 @@ GtExecutionContext::project() const noexcept
 }
 
 QString const&
-GtExecutionContext::executionDataRoot() const noexcept
-{
-    return m_executionDataRoot;
-}
-
-QString const&
-GtExecutionContext::source() const noexcept
-{
-    return m_source;
-}
-
-QString const&
 GtExecutionContext::projectPath() const noexcept
 {
     return m_projectPath;
 }
 
-QString const&
-GtExecutionContext::jobId() const noexcept
-{
-    return m_jobId;
-}
-
 bool
 GtExecutionContext::isValid() const noexcept
 {
-    return m_project != nullptr;
+    return m_project != nullptr || !m_projectPath.isEmpty();
 }
 
 GtExecutionContext const*

--- a/src/core/gt_executioncontext.cpp
+++ b/src/core/gt_executioncontext.cpp
@@ -51,12 +51,6 @@ GtExecutionContext::current() noexcept
     return currentExecutionContext;
 }
 
-GtExecutionContext const*
-GtExecutionContext::currentContext() noexcept
-{
-    return current();
-}
-
 GtExecutionContextScope::GtExecutionContextScope(
     GtExecutionContext const& context) :
     m_previous(currentExecutionContext)

--- a/src/core/gt_executioncontext.cpp
+++ b/src/core/gt_executioncontext.cpp
@@ -1,0 +1,94 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#include "gt_executioncontext.h"
+
+#include <utility>
+
+#include "gt_project.h"
+
+namespace {
+
+thread_local GtExecutionContext const* currentExecutionContext = nullptr;
+
+} // namespace
+
+GtExecutionContext::GtExecutionContext(GtProject const* project,
+                                       QString executionDataRoot,
+                                       QString source,
+                                       QString projectPath,
+                                       QString jobId) :
+    m_project(project),
+    m_executionDataRoot(std::move(executionDataRoot)),
+    m_source(std::move(source)),
+    m_projectPath(std::move(projectPath)),
+    m_jobId(std::move(jobId))
+{
+    if (m_projectPath.isEmpty() && m_project)
+    {
+        m_projectPath = m_project->path();
+    }
+}
+
+GtProject const*
+GtExecutionContext::project() const noexcept
+{
+    return m_project;
+}
+
+QString const&
+GtExecutionContext::executionDataRoot() const noexcept
+{
+    return m_executionDataRoot;
+}
+
+QString const&
+GtExecutionContext::source() const noexcept
+{
+    return m_source;
+}
+
+QString const&
+GtExecutionContext::projectPath() const noexcept
+{
+    return m_projectPath;
+}
+
+QString const&
+GtExecutionContext::jobId() const noexcept
+{
+    return m_jobId;
+}
+
+bool
+GtExecutionContext::isValid() const noexcept
+{
+    return m_project != nullptr;
+}
+
+GtExecutionContext const*
+GtExecutionContext::current() noexcept
+{
+    return currentExecutionContext;
+}
+
+GtExecutionContext const*
+GtExecutionContext::currentContext() noexcept
+{
+    return current();
+}
+
+GtExecutionContextScope::GtExecutionContextScope(
+    GtExecutionContext const& context) :
+    m_previous(currentExecutionContext)
+{
+    currentExecutionContext = &context;
+}
+
+GtExecutionContextScope::~GtExecutionContextScope()
+{
+    currentExecutionContext = m_previous;
+}

--- a/src/core/gt_executioncontext.h
+++ b/src/core/gt_executioncontext.h
@@ -82,6 +82,7 @@ class GT_CORE_EXPORT GtExecutionContextScope
 {
 public:
     explicit GtExecutionContextScope(GtExecutionContext const& context);
+    GtExecutionContextScope(GtExecutionContext&&) = delete;
     ~GtExecutionContextScope();
 
     GtExecutionContextScope(GtExecutionContextScope const&) = delete;

--- a/src/core/gt_executioncontext.h
+++ b/src/core/gt_executioncontext.h
@@ -1,0 +1,94 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#ifndef GTEXECUTIONCONTEXT_H
+#define GTEXECUTIONCONTEXT_H
+
+#include "gt_core_exports.h"
+
+#include <QString>
+
+class GtProject;
+
+/**
+ * @brief Describes the project and paths associated with one execution.
+ *
+ * The project pointer is borrowed and is never owned by this object. The
+ * pointed-to project must outlive every context and scope that refers to it.
+ */
+class GT_CORE_EXPORT GtExecutionContext
+{
+public:
+    /**
+     * @brief Creates an execution context.
+     * @param project Project associated with the execution, not owned.
+     * @param executionDataRoot Root directory for execution data.
+     * @param source Source identifier or path for the execution.
+     * @param projectPath Project path. If empty, it is taken from @p project.
+     * @param jobId Optional job or execution identifier.
+     */
+    explicit GtExecutionContext(
+        GtProject const* project = nullptr,
+        QString executionDataRoot = {},
+        QString source = {},
+        QString projectPath = {},
+        QString jobId = {});
+
+    /// Returns the borrowed project associated with this execution.
+    GtProject const* project() const noexcept;
+
+    /// Returns the root directory for execution data.
+    QString const& executionDataRoot() const noexcept;
+
+    /// Returns the execution source identifier or path.
+    QString const& source() const noexcept;
+
+    /// Returns the project path associated with this execution.
+    QString const& projectPath() const noexcept;
+
+    /// Returns the optional job or execution identifier.
+    QString const& jobId() const noexcept;
+
+    /// Returns whether a project is associated with this context.
+    bool isValid() const noexcept;
+
+    /**
+     * @brief Returns the context installed on the current thread.
+     * @return Borrowed current context, or nullptr if no scope is active.
+     */
+    static GtExecutionContext const* current() noexcept;
+
+    /// Alias for current(), for callers that prefer the explicit name.
+    static GtExecutionContext const* currentContext() noexcept;
+
+private:
+    GtProject const* m_project;
+    QString m_executionDataRoot;
+    QString m_source;
+    QString m_projectPath;
+    QString m_jobId;
+};
+
+/**
+ * @brief Installs an execution context for the lifetime of a scope.
+ *
+ * Scopes are thread-local, nestable, non-copyable, and restore the previous
+ * context in their destructor. The referenced context must outlive the scope.
+ */
+class GT_CORE_EXPORT GtExecutionContextScope
+{
+public:
+    explicit GtExecutionContextScope(GtExecutionContext const& context);
+    ~GtExecutionContextScope();
+
+    GtExecutionContextScope(GtExecutionContextScope const&) = delete;
+    GtExecutionContextScope& operator=(GtExecutionContextScope const&) = delete;
+
+private:
+    GtExecutionContext const* m_previous;
+};
+
+#endif // GTEXECUTIONCONTEXT_H

--- a/src/core/gt_executioncontext.h
+++ b/src/core/gt_executioncontext.h
@@ -31,14 +31,14 @@ public:
      * @param jobId Optional job or execution identifier.
      */
     explicit GtExecutionContext(
-        GtProject const* project = nullptr,
+        GtProject* project = nullptr,
         QString executionDataRoot = {},
         QString source = {},
         QString projectPath = {},
         QString jobId = {});
 
     /// Returns the borrowed project associated with this execution.
-    GtProject const* project() const noexcept;
+    GtProject* project() const noexcept;
 
     /// Returns the root directory for execution data.
     QString const& executionDataRoot() const noexcept;
@@ -65,7 +65,7 @@ public:
     static GtExecutionContext const* currentContext() noexcept;
 
 private:
-    GtProject const* m_project;
+    GtProject* m_project;
     QString m_executionDataRoot;
     QString m_source;
     QString m_projectPath;

--- a/src/core/gt_executioncontext.h
+++ b/src/core/gt_executioncontext.h
@@ -71,6 +71,7 @@ public:
 
     GtExecutionContextScope(GtExecutionContextScope const&) = delete;
     GtExecutionContextScope& operator=(GtExecutionContextScope const&) = delete;
+    GtExecutionContextScope& operator=(GtExecutionContextScope&&) = delete;
 
 private:
     GtExecutionContext const* m_previous;

--- a/src/core/gt_executioncontext.h
+++ b/src/core/gt_executioncontext.h
@@ -18,6 +18,9 @@ class GtProject;
  *
  * The project pointer is borrowed and is never owned by this object. The
  * pointed-to project must outlive every context and scope that refers to it.
+ * A context is usable when it contains a project or a project path. Contexts
+ * are intended for synchronous execution boundaries: the project is borrowed,
+ * the scope is thread-local, and neither is propagated to child threads.
  */
 class GT_CORE_EXPORT GtExecutionContext
 {
@@ -25,34 +28,19 @@ public:
     /**
      * @brief Creates an execution context.
      * @param project Project associated with the execution, not owned.
-     * @param executionDataRoot Root directory for execution data.
-     * @param source Source identifier or path for the execution.
      * @param projectPath Project path. If empty, it is taken from @p project.
-     * @param jobId Optional job or execution identifier.
      */
     explicit GtExecutionContext(
         GtProject* project = nullptr,
-        QString executionDataRoot = {},
-        QString source = {},
-        QString projectPath = {},
-        QString jobId = {});
+        QString projectPath = {});
 
     /// Returns the borrowed project associated with this execution.
     GtProject* project() const noexcept;
 
-    /// Returns the root directory for execution data.
-    QString const& executionDataRoot() const noexcept;
-
-    /// Returns the execution source identifier or path.
-    QString const& source() const noexcept;
-
     /// Returns the project path associated with this execution.
     QString const& projectPath() const noexcept;
 
-    /// Returns the optional job or execution identifier.
-    QString const& jobId() const noexcept;
-
-    /// Returns whether a project is associated with this context.
+    /// Returns whether a project or project path is available.
     bool isValid() const noexcept;
 
     /**
@@ -66,10 +54,7 @@ public:
 
 private:
     GtProject* m_project;
-    QString m_executionDataRoot;
-    QString m_source;
     QString m_projectPath;
-    QString m_jobId;
 };
 
 /**
@@ -77,6 +62,8 @@ private:
  *
  * Scopes are thread-local, nestable, non-copyable, and restore the previous
  * context in their destructor. The referenced context must outlive the scope.
+ * Neither the scope nor the context extends the lifetime of the borrowed
+ * project. Do not retain the context or project pointer for asynchronous work.
  */
 class GT_CORE_EXPORT GtExecutionContextScope
 {

--- a/src/core/gt_executioncontext.h
+++ b/src/core/gt_executioncontext.h
@@ -49,9 +49,6 @@ public:
      */
     static GtExecutionContext const* current() noexcept;
 
-    /// Alias for current(), for callers that prefer the explicit name.
-    static GtExecutionContext const* currentContext() noexcept;
-
 private:
     GtProject* m_project;
     QString m_projectPath;

--- a/src/core/gt_projectexecutionguard.cpp
+++ b/src/core/gt_projectexecutionguard.cpp
@@ -11,6 +11,7 @@
 #include <QMutex>
 #include <QMutexLocker>
 #include <QSet>
+#include <QtGlobal>
 
 #include "gt_project.h"
 
@@ -84,19 +85,30 @@ GtProjectExecutionGuard::key() const
 QString
 GtProjectExecutionGuard::projectKey(GtProject const* project)
 {
-    if (!project || project->path().isEmpty())
+    if (!project)
     {
         return {};
     }
 
-    QFileInfo info(project->path());
-    QString path = info.canonicalFilePath();
-    if (path.isEmpty())
+    if (!project->path().isEmpty())
     {
-        path = info.absoluteFilePath();
+        QFileInfo info(project->path());
+        QString path = info.canonicalFilePath();
+        if (path.isEmpty())
+        {
+            path = info.absoluteFilePath();
+        }
+
+        return QDir::cleanPath(path);
     }
 
-    return QDir::cleanPath(path);
+    if (!project->uuid().isEmpty())
+    {
+        return QStringLiteral("uuid:") + project->uuid();
+    }
+
+    return QStringLiteral("object:%1")
+        .arg(reinterpret_cast<quintptr>(project), 0, 16);
 }
 
 bool

--- a/src/core/gt_projectexecutionguard.cpp
+++ b/src/core/gt_projectexecutionguard.cpp
@@ -1,0 +1,113 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#include "gt_projectexecutionguard.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QSet>
+
+#include "gt_project.h"
+
+namespace
+{
+QMutex& guardMutex()
+{
+    static QMutex mutex;
+    return mutex;
+}
+
+QSet<QString>& guardedProjects()
+{
+    static QSet<QString> projects;
+    return projects;
+}
+}
+
+GtProjectExecutionGuard::~GtProjectExecutionGuard()
+{
+    release();
+}
+
+GtProjectExecutionGuard::Result
+GtProjectExecutionGuard::tryAcquire(GtProject* project)
+{
+    release();
+
+    const QString projectPath = projectKey(project);
+    if (projectPath.isEmpty())
+    {
+        return Result::InvalidProject;
+    }
+
+    QMutexLocker locker(&guardMutex());
+    if (guardedProjects().contains(projectPath))
+    {
+        return Result::Busy;
+    }
+
+    guardedProjects().insert(projectPath);
+    m_key = projectPath;
+    return Result::Acquired;
+}
+
+void
+GtProjectExecutionGuard::release()
+{
+    if (m_key.isEmpty())
+    {
+        return;
+    }
+
+    QMutexLocker locker(&guardMutex());
+    guardedProjects().remove(m_key);
+    m_key.clear();
+}
+
+bool
+GtProjectExecutionGuard::isHeld() const
+{
+    return !m_key.isEmpty();
+}
+
+QString
+GtProjectExecutionGuard::key() const
+{
+    return m_key;
+}
+
+QString
+GtProjectExecutionGuard::projectKey(GtProject const* project)
+{
+    if (!project || project->path().isEmpty())
+    {
+        return {};
+    }
+
+    QFileInfo info(project->path());
+    QString path = info.canonicalFilePath();
+    if (path.isEmpty())
+    {
+        path = info.absoluteFilePath();
+    }
+
+    return QDir::cleanPath(path);
+}
+
+bool
+GtProjectExecutionGuard::isBusy(GtProject const* project)
+{
+    const QString projectPath = projectKey(project);
+    if (projectPath.isEmpty())
+    {
+        return false;
+    }
+
+    QMutexLocker locker(&guardMutex());
+    return guardedProjects().contains(projectPath);
+}

--- a/src/core/gt_projectexecutionguard.cpp
+++ b/src/core/gt_projectexecutionguard.cpp
@@ -40,20 +40,20 @@ GtProjectExecutionGuard::tryAcquire(GtProject* project)
 {
     release();
 
-    const QString projectPath = projectKey(project);
-    if (projectPath.isEmpty())
+    const QString key = projectKey(project);
+    if (key.isEmpty())
     {
         return Result::InvalidProject;
     }
 
     QMutexLocker locker(&guardMutex());
-    if (guardedProjects().contains(projectPath))
+    if (guardedProjects().contains(key))
     {
         return Result::Busy;
     }
 
-    guardedProjects().insert(projectPath);
-    m_key = projectPath;
+    guardedProjects().insert(key);
+    m_key = key;
     return Result::Acquired;
 }
 
@@ -71,13 +71,13 @@ GtProjectExecutionGuard::release()
 }
 
 bool
-GtProjectExecutionGuard::isHeld() const
+GtProjectExecutionGuard::isLocked() const
 {
     return !m_key.isEmpty();
 }
 
 QString
-GtProjectExecutionGuard::key() const
+GtProjectExecutionGuard::projectKey() const
 {
     return m_key;
 }
@@ -112,7 +112,7 @@ GtProjectExecutionGuard::projectKey(GtProject const* project)
 }
 
 bool
-GtProjectExecutionGuard::isBusy(GtProject const* project)
+GtProjectExecutionGuard::isLocked(GtProject const* project)
 {
     const QString projectPath = projectKey(project);
     if (projectPath.isEmpty())

--- a/src/core/gt_projectexecutionguard.h
+++ b/src/core/gt_projectexecutionguard.h
@@ -1,0 +1,45 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#ifndef GTPROJECTEXECUTIONGUARD_H
+#define GTPROJECTEXECUTIONGUARD_H
+
+#include "gt_core_exports.h"
+
+#include <QString>
+
+class GtProject;
+
+class GT_CORE_EXPORT GtProjectExecutionGuard
+{
+public:
+    enum class Result
+    {
+        Acquired,
+        Busy,
+        InvalidProject
+    };
+
+    GtProjectExecutionGuard() = default;
+    ~GtProjectExecutionGuard();
+
+    GtProjectExecutionGuard(GtProjectExecutionGuard const&) = delete;
+    GtProjectExecutionGuard& operator=(GtProjectExecutionGuard const&) = delete;
+
+    Result tryAcquire(GtProject* project);
+    void release();
+
+    bool isHeld() const;
+    QString key() const;
+
+    static QString projectKey(GtProject const* project);
+    static bool isBusy(GtProject const* project);
+
+private:
+    QString m_key;
+};
+
+#endif // GTPROJECTEXECUTIONGUARD_H

--- a/src/core/gt_projectexecutionguard.h
+++ b/src/core/gt_projectexecutionguard.h
@@ -16,6 +16,13 @@ class GtProject;
 class GT_CORE_EXPORT GtProjectExecutionGuard
 {
 public:
+    /**
+     * @brief Result of trying to acquire a project execution guard.
+     *
+     * Guards are process-local, thread-safe, and held for the lifetime of the
+     * guard object. Acquiring a new project first releases a previously held
+     * key.
+     */
     enum class Result
     {
         Acquired,
@@ -29,12 +36,25 @@ public:
     GtProjectExecutionGuard(GtProjectExecutionGuard const&) = delete;
     GtProjectExecutionGuard& operator=(GtProjectExecutionGuard const&) = delete;
 
+    /**
+     * @brief Tries to acquire exclusive access for @p project.
+     * @return Acquired on success, Busy if another guard holds the project,
+     *         or InvalidProject if no stable project identity is available.
+     */
     Result tryAcquire(GtProject* project);
+
+    /// Releases the currently held project key, if any.
     void release();
 
     bool isHeld() const;
     QString key() const;
 
+    /**
+     * @brief Returns the project identity used by the process-local guard.
+     *
+     * Existing project paths are canonicalized. Pathless projects use their
+     * stable object UUID and finally their in-process object address.
+     */
     static QString projectKey(GtProject const* project);
     static bool isBusy(GtProject const* project);
 

--- a/src/core/gt_projectexecutionguard.h
+++ b/src/core/gt_projectexecutionguard.h
@@ -25,9 +25,9 @@ public:
      */
     enum class Result
     {
+        InvalidProject = 0,
         Acquired,
         Busy,
-        InvalidProject
     };
 
     GtProjectExecutionGuard() = default;
@@ -43,11 +43,28 @@ public:
      */
     Result tryAcquire(GtProject* project);
 
-    /// Releases the currently held project key, if any.
+    /**
+     * @brief Releases the currently held project key, if any.
+     */
     void release();
 
-    bool isHeld() const;
-    QString key() const;
+    /**
+     * Returns, whether this guard aquired a project or not
+     */
+    bool isLocked() const;
+
+    /**
+     * @brief The indentity of the project this guard protects.
+     *
+     * The key is used to identify a certain project and discriminate
+     * it from others.
+     *
+     * In the current implementation, it is just the project path,
+     * but it could also be its uuid.
+     *
+     * @return Value of the key
+     */
+    QString projectKey() const;
 
     /**
      * @brief Returns the project identity used by the process-local guard.
@@ -56,7 +73,7 @@ public:
      * stable object UUID and finally their in-process object address.
      */
     static QString projectKey(GtProject const* project);
-    static bool isBusy(GtProject const* project);
+    static bool isLocked(GtProject const* project);
 
 private:
     QString m_key;

--- a/src/core/gt_projectexecutionguard.h
+++ b/src/core/gt_projectexecutionguard.h
@@ -19,9 +19,9 @@ public:
     /**
      * @brief Result of trying to acquire a project execution guard.
      *
-     * Guards are process-local, thread-safe, and held for the lifetime of the
-     * guard object. Acquiring a new project first releases a previously held
-     * key.
+     * The process-local guard registry is thread-safe. A guard instance must
+     * be owned and used by one thread and is held for its lifetime. Acquiring
+     * a new project first releases a previously held key.
      */
     enum class Result
     {

--- a/src/core/gt_runnable.cpp
+++ b/src/core/gt_runnable.cpp
@@ -12,6 +12,8 @@
 #include <QDir>
 #include <QDebug>
 
+#include <optional>
+
 #include "gt_runnable.h"
 #include "gt_objectmemento.h"
 #include "gt_objectfactory.h"
@@ -21,7 +23,14 @@
 #include "gt_logging.h"
 
 GtRunnable::GtRunnable(QString projectPath) :
-    m_projectPath{std::move(projectPath)}
+    GtRunnable(std::move(projectPath), GtExecutionContext())
+{
+}
+
+GtRunnable::GtRunnable(QString projectPath,
+                       GtExecutionContext executionContext) :
+    m_projectPath{std::move(projectPath)},
+    m_executionContext{std::move(executionContext)}
 {
     setObjectName("GtRunnable");
 }
@@ -29,6 +38,19 @@ GtRunnable::GtRunnable(QString projectPath) :
 void
 GtRunnable::run()
 {
+    std::optional<GtExecutionContextScope> contextScope;
+    const bool hasExecutionContext =
+        m_executionContext.project() ||
+        !m_executionContext.executionDataRoot().isEmpty() ||
+        !m_executionContext.source().isEmpty() ||
+        !m_executionContext.projectPath().isEmpty() ||
+        !m_executionContext.jobId().isEmpty();
+
+    if (hasExecutionContext)
+    {
+        contextScope.emplace(m_executionContext);
+    }
+
     bool success = true;
 
     readObjects();
@@ -120,6 +142,11 @@ GtRunnable::tempDir()
 QString
 GtRunnable::projectPath()
 {
+    if (auto const* context = GtExecutionContext::current())
+    {
+        return context->projectPath();
+    }
+
     if (!m_projectPath.isEmpty())
     {
         return m_projectPath;

--- a/src/core/gt_runnable.cpp
+++ b/src/core/gt_runnable.cpp
@@ -39,14 +39,7 @@ void
 GtRunnable::run()
 {
     std::optional<GtExecutionContextScope> contextScope;
-    const bool hasExecutionContext =
-        m_executionContext.project() ||
-        !m_executionContext.executionDataRoot().isEmpty() ||
-        !m_executionContext.source().isEmpty() ||
-        !m_executionContext.projectPath().isEmpty() ||
-        !m_executionContext.jobId().isEmpty();
-
-    if (hasExecutionContext)
+    if (m_executionContext.isValid())
     {
         contextScope.emplace(m_executionContext);
     }

--- a/src/core/gt_runnable.h
+++ b/src/core/gt_runnable.h
@@ -26,7 +26,7 @@ class GT_CORE_EXPORT GtRunnable : public GtAbstractRunnable
 
 public:
     /**
-     * @brief Constrcutor. Sets a custom project path for the execution process
+     * @brief Constructor. Sets a custom project path for the execution process
      * @param projectPath Project path
      */
     explicit GtRunnable(QString projectPath = {});
@@ -34,7 +34,9 @@ public:
     /**
      * @brief Constructs a runnable with execution-specific context data.
      * @param projectPath Legacy custom project path
-     * @param executionContext Context to install while running
+     * @param executionContext Borrowed project/path context installed only
+     *        during run(). The referenced project must outlive run() and must
+     *        not be retained for asynchronous work.
      */
     GtRunnable(QString projectPath, GtExecutionContext executionContext);
 
@@ -55,8 +57,10 @@ public:
     QDir tempDir() override;
 
     /**
-     * @brief Returns path of current project.
-     * @return Path to current project.
+     * @brief Returns the execution-context project path, if present.
+     *
+     * Resolution is context first, then the legacy custom path, then the
+     * selected application project.
      */
     QString projectPath() override;
 

--- a/src/core/gt_runnable.h
+++ b/src/core/gt_runnable.h
@@ -11,6 +11,7 @@
 #ifndef GTRUNNABLE_H
 #define GTRUNNABLE_H
 
+#include "gt_core_exports.h"
 #include "gt_abstractrunnable.h"
 #include "gt_executioncontext.h"
 
@@ -19,7 +20,7 @@
 /**
  * @brief The GtRunnable class
  */
-class GtRunnable : public GtAbstractRunnable
+class GT_CORE_EXPORT GtRunnable : public GtAbstractRunnable
 {
     Q_OBJECT
 

--- a/src/core/gt_runnable.h
+++ b/src/core/gt_runnable.h
@@ -12,6 +12,7 @@
 #define GTRUNNABLE_H
 
 #include "gt_abstractrunnable.h"
+#include "gt_executioncontext.h"
 
 #include "gt_processcomponent.h"
 
@@ -28,6 +29,13 @@ public:
      * @param projectPath Project path
      */
     explicit GtRunnable(QString projectPath = {});
+
+    /**
+     * @brief Constructs a runnable with execution-specific context data.
+     * @param projectPath Legacy custom project path
+     * @param executionContext Context to install while running
+     */
+    GtRunnable(QString projectPath, GtExecutionContext executionContext);
 
     /**
      * @brief run
@@ -62,6 +70,9 @@ private:
 
     /// custom project path (by default empty)
     QString m_projectPath;
+
+    /// Context associated with this execution.
+    GtExecutionContext m_executionContext;
 
     /**
      * @brief transferObjects

--- a/src/gui/process_runner/gt_processrunner.cpp
+++ b/src/gui/process_runner/gt_processrunner.cpp
@@ -222,7 +222,7 @@ GtProcessRunner::onTaskCollected()
     clearCurrentTask();
 
     // execute next task
-    executeNextTask();
+    startNextTask();
 }
 
 void
@@ -383,7 +383,7 @@ GtProcessRunner::onTransceiverAborted()
     clearCurrentTask();
 
     // execute next task
-    executeNextTask();
+    startNextTask();
 }
 
 gt::process_runner::ConnectionAddress

--- a/tests/unittests/calculators/test_gt_runnable.cpp
+++ b/tests/unittests/calculators/test_gt_runnable.cpp
@@ -14,6 +14,8 @@
 #include "gt_object.h"
 #include "gt_objectlinkproperty.h"
 #include "gt_objectpathproperty.h"
+#include "gt_project.h"
+#include "gt_runnable.h"
 
 class TestCalculatorRunnable : public GtAbstractRunnable
 {
@@ -103,6 +105,23 @@ public:
 private:
     GtObjectLinkProperty linkProp;
     GtObjectPathProperty pathProp;
+};
+
+class ContextObservingCalculator : public TestableCalculator
+{
+public:
+    GtProject* observedProject = nullptr;
+    QString observedPath;
+    bool contextWasActive = false;
+
+    bool run() override
+    {
+        auto const* context = GtExecutionContext::current();
+        contextWasActive = context != nullptr;
+        observedProject = context ? context->project() : nullptr;
+        observedPath = projectPath();
+        return true;
+    }
 };
 
 class TestGtRunnable : public ::testing::Test
@@ -216,4 +235,59 @@ TEST_F(TestGtRunnable, successfulRunClearsTempDirectoryWhenEnabled)
     ASSERT_TRUE(calc.exec());
     EXPECT_EQ(runnable.clearTempDirCalls, 1);
     EXPECT_EQ(runnable.clearedPath, QString("temp/calculator"));
+}
+
+TEST_F(TestGtRunnable, customProjectPathRemainsAvailableWithoutContext)
+{
+    GtRunnable runnable(QStringLiteral("custom-project-path"));
+
+    EXPECT_EQ(runnable.projectPath(), QStringLiteral("custom-project-path"));
+}
+
+TEST_F(TestGtRunnable, executionContextIsInstalledForRunAndRestoredAfterwards)
+{
+    GtExecutionContext context(nullptr,
+                               {},
+                               QStringLiteral("source"),
+                               QStringLiteral("project-path"),
+                               QStringLiteral("job"));
+    GtRunnable runnable(QString{}, context);
+    ContextObservingCalculator observer;
+    ASSERT_TRUE(runnable.appendProcessComponent(&observer));
+
+    runnable.run();
+
+    EXPECT_TRUE(observer.contextWasActive);
+    EXPECT_EQ(observer.observedPath, QStringLiteral("project-path"));
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+}
+
+TEST_F(TestGtRunnable, sequentialRunsUseDifferentExecutionContexts)
+{
+    class TestProject : public GtProject
+    {
+    public:
+        explicit TestProject(QString path) : GtProject(std::move(path)) {}
+    } firstProject(QStringLiteral("first")),
+        secondProject(QStringLiteral("second"));
+
+    GtExecutionContext firstContext(&firstProject, {}, {},
+                                    QStringLiteral("first-path"));
+    GtRunnable firstRunnable({}, firstContext);
+    ContextObservingCalculator firstCalculator;
+    ASSERT_TRUE(firstRunnable.appendProcessComponent(&firstCalculator));
+    firstRunnable.run();
+
+    GtExecutionContext secondContext(&secondProject, {}, {},
+                                     QStringLiteral("second-path"));
+    GtRunnable secondRunnable({}, secondContext);
+    ContextObservingCalculator secondCalculator;
+    ASSERT_TRUE(secondRunnable.appendProcessComponent(&secondCalculator));
+    secondRunnable.run();
+
+    EXPECT_EQ(firstCalculator.observedProject, &firstProject);
+    EXPECT_EQ(firstCalculator.observedPath, QStringLiteral("first-path"));
+    EXPECT_EQ(secondCalculator.observedProject, &secondProject);
+    EXPECT_EQ(secondCalculator.observedPath, QStringLiteral("second-path"));
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
 }

--- a/tests/unittests/calculators/test_gt_runnable.cpp
+++ b/tests/unittests/calculators/test_gt_runnable.cpp
@@ -262,6 +262,21 @@ TEST_F(TestGtRunnable, executionContextIsInstalledForRunAndRestoredAfterwards)
     EXPECT_EQ(GtExecutionContext::current(), nullptr);
 }
 
+TEST_F(TestGtRunnable, runWithoutContextPreservesAnExistingContext)
+{
+    GtExecutionContext outerContext(nullptr,
+                                     {},
+                                     QStringLiteral("outer-source"),
+                                     QStringLiteral("outer-project"),
+                                     QStringLiteral("outer-job"));
+    GtExecutionContextScope outerScope(outerContext);
+    GtRunnable runnable;
+
+    runnable.run();
+
+    EXPECT_EQ(GtExecutionContext::current(), &outerContext);
+}
+
 TEST_F(TestGtRunnable, sequentialRunsUseDifferentExecutionContexts)
 {
     class TestProject : public GtProject

--- a/tests/unittests/calculators/test_gt_runnable.cpp
+++ b/tests/unittests/calculators/test_gt_runnable.cpp
@@ -246,11 +246,7 @@ TEST_F(TestGtRunnable, customProjectPathRemainsAvailableWithoutContext)
 
 TEST_F(TestGtRunnable, executionContextIsInstalledForRunAndRestoredAfterwards)
 {
-    GtExecutionContext context(nullptr,
-                               {},
-                               QStringLiteral("source"),
-                               QStringLiteral("project-path"),
-                               QStringLiteral("job"));
+    GtExecutionContext context(nullptr, QStringLiteral("project-path"));
     GtRunnable runnable(QString{}, context);
     ContextObservingCalculator observer;
     ASSERT_TRUE(runnable.appendProcessComponent(&observer));
@@ -264,11 +260,7 @@ TEST_F(TestGtRunnable, executionContextIsInstalledForRunAndRestoredAfterwards)
 
 TEST_F(TestGtRunnable, runWithoutContextPreservesAnExistingContext)
 {
-    GtExecutionContext outerContext(nullptr,
-                                     {},
-                                     QStringLiteral("outer-source"),
-                                     QStringLiteral("outer-project"),
-                                     QStringLiteral("outer-job"));
+    GtExecutionContext outerContext(nullptr, QStringLiteral("outer-project"));
     GtExecutionContextScope outerScope(outerContext);
     GtRunnable runnable;
 
@@ -286,14 +278,14 @@ TEST_F(TestGtRunnable, sequentialRunsUseDifferentExecutionContexts)
     } firstProject(QStringLiteral("first")),
         secondProject(QStringLiteral("second"));
 
-    GtExecutionContext firstContext(&firstProject, {}, {},
+    GtExecutionContext firstContext(&firstProject,
                                     QStringLiteral("first-path"));
     GtRunnable firstRunnable({}, firstContext);
     ContextObservingCalculator firstCalculator;
     ASSERT_TRUE(firstRunnable.appendProcessComponent(&firstCalculator));
     firstRunnable.run();
 
-    GtExecutionContext secondContext(&secondProject, {}, {},
+    GtExecutionContext secondContext(&secondProject,
                                      QStringLiteral("second-path"));
     GtRunnable secondRunnable({}, secondContext);
     ContextObservingCalculator secondCalculator;

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -19,9 +19,13 @@
 #include "gt_coredatamodel.h"
 #include "gt_externalizationmanager.h"
 #include "gt_executioncontext.h"
+#include "gt_objectfactory.h"
 #include "gt_project.h"
 #include "gt_projectexecutionguard.h"
+#include "gt_runnable.h"
 #include "gt_session.h"
+#include "gt_task.h"
+#include "gt_taskrunner.h"
 
 namespace {
 
@@ -115,6 +119,31 @@ public:
         return observedProject != nullptr;
     }
 };
+
+class EndToEndLegacyCalculator : public GtCalculator
+{
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE EndToEndLegacyCalculator() = default;
+
+    static GtProject* projectToSelect;
+    static GtProject* observedProject;
+
+    bool run() override
+    {
+        if (projectToSelect)
+        {
+            gtApp->setCurrentProject(projectToSelect);
+        }
+
+        observedProject = gtApp->currentProject();
+        return observedProject != nullptr;
+    }
+};
+
+GtProject* EndToEndLegacyCalculator::projectToSelect = nullptr;
+GtProject* EndToEndLegacyCalculator::observedProject = nullptr;
 
 std::unique_ptr<TestSession> sessionWithProjects(TestProject*& first,
                                                  TestProject*& second)
@@ -258,3 +287,45 @@ TEST(CurrentProjectCompatibility, nestedExecutionContextsRestorePreviousProject)
     }
     EXPECT_EQ(gtApp->currentProject(), second);
 }
+
+TEST(CurrentProjectCompatibility,
+     endToEndLegacyExecutionKeepsProjectContextWhenGuiSelectionChanges)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
+
+    gtObjectFactory->registerClass(
+        EndToEndLegacyCalculator::staticMetaObject);
+    gtObjectFactory->registerClass(GtTask::staticMetaObject);
+
+    auto task = std::make_unique<GtTask>();
+    task->setFactory(gtObjectFactory);
+    auto calculator = std::make_unique<EndToEndLegacyCalculator>();
+    calculator->setFactory(gtObjectFactory);
+    ASSERT_TRUE(task->appendChild(calculator.get()));
+    calculator.release();
+    ASSERT_TRUE(second->appendChild(task.get()));
+    task.release();
+
+    EndToEndLegacyCalculator::projectToSelect = first;
+    EndToEndLegacyCalculator::observedProject = nullptr;
+
+    auto* runnable = new GtRunnable(
+        {}, GtExecutionContext(second, {}, {}, second->path(), "job-b"));
+    GtTaskRunner runner(second->findDirectChildren<GtTask*>().front());
+    ASSERT_TRUE(runner.setUp(runnable, second));
+
+    runnable->run();
+
+    EXPECT_EQ(EndToEndLegacyCalculator::observedProject, second);
+    EXPECT_EQ(gtApp->currentProject(), first);
+
+    EndToEndLegacyCalculator::projectToSelect = nullptr;
+    EndToEndLegacyCalculator::observedProject = nullptr;
+}
+
+#include "test_currentproject_compatibility.moc"

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -10,11 +10,15 @@
 
 #include <QCoreApplication>
 #include <QDir>
+#include <QFile>
+#include <QUuid>
 
 #include "gt_abstractrunnable.h"
 #include "gt_calculator.h"
 #include "gt_coreapplication.h"
+#include "gt_coredatamodel.h"
 #include "gt_externalizationmanager.h"
+#include "gt_executioncontext.h"
 #include "gt_project.h"
 #include "gt_session.h"
 
@@ -30,6 +34,11 @@ class TestSession : public GtSession
 {
 public:
     TestSession() : GtSession() {}
+
+    static bool createEmptySessionForTest(const QString& id)
+    {
+        return createEmptySession(id);
+    }
 
     void addProjectForTest(GtProject* project)
     {
@@ -57,7 +66,16 @@ public:
 
     void installSession(std::unique_ptr<TestSession> session)
     {
-        m_session = std::move(session);
+        constexpr auto sessionId = "currentproject-compatibility";
+        ASSERT_TRUE(TestSession::createEmptySessionForTest(
+            QString::fromLatin1(sessionId)));
+        m_session.reset();
+        initSession(QString::fromLatin1(sessionId));
+
+        for (auto* project : session->projects())
+        {
+            ASSERT_TRUE(gtDataModel->newProject(project, false));
+        }
     }
 
 protected:
@@ -99,12 +117,36 @@ std::unique_ptr<TestSession> sessionWithProjects(TestProject*& first,
                                                  TestProject*& second)
 {
     auto session = std::make_unique<TestSession>();
+    const QString suffix = QUuid::createUuid().toString(QUuid::WithoutBraces);
     const QString firstPath = QDir::tempPath() +
-                              QStringLiteral("/gtlab-project-a-1508");
+                              QStringLiteral("/gtlab-project-a-1508-") + suffix;
     const QString secondPath = QDir::tempPath() +
-                               QStringLiteral("/gtlab-project-b-1508");
+                               QStringLiteral("/gtlab-project-b-1508-") + suffix;
     QDir().mkpath(firstPath);
     QDir().mkpath(secondPath);
+    const auto writeProjectFile = [](const QString& path,
+                                     const QString& name) {
+        QFile file(QDir(path).filePath(GtProject::mainFilename()));
+        if (file.open(QIODevice::WriteOnly | QIODevice::Text))
+        {
+            file.write(QStringLiteral(
+                           "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                           "<GTLAB projectname=\"%1\" version=\"1.7.0-rc1\">\n"
+                           "    <env-footprint>\n"
+                           "        <core-ver>2.0.0</core-ver>\n"
+                           "        <modules/>\n"
+                           "    </env-footprint>\n"
+                           "    <comment/>\n"
+                           "    <MODULES/>\n"
+                           "    <PROCESSES/>\n"
+                           "    <LABELS/>\n"
+                           "</GTLAB>\n")
+                           .arg(name)
+                           .toUtf8());
+        }
+    };
+    writeProjectFile(firstPath, QStringLiteral("project-a-1508-") + suffix);
+    writeProjectFile(secondPath, QStringLiteral("project-b-1508-") + suffix);
     first = new TestProject(firstPath);
     second = new TestProject(secondPath);
     session->addProjectForTest(first);
@@ -120,13 +162,10 @@ TEST(CurrentProjectCompatibility, guiFallbackTracksSelectedProject)
     TestProject* first = nullptr;
     TestProject* second = nullptr;
     auto session = sessionWithProjects(first, second);
-    ASSERT_TRUE(session->selectProjectForTest(first));
     application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
 
     EXPECT_EQ(gtApp->currentProject(), first);
-
-    ASSERT_TRUE(gtApp->setCurrentProject(second));
-    EXPECT_EQ(gtApp->currentProject(), second);
 }
 
 TEST(CurrentProjectCompatibility, legacyCalculatorReadsSelectedProject)
@@ -135,13 +174,67 @@ TEST(CurrentProjectCompatibility, legacyCalculatorReadsSelectedProject)
     TestProject* first = nullptr;
     TestProject* second = nullptr;
     auto session = sessionWithProjects(first, second);
-    ASSERT_TRUE(session->selectProjectForTest(second));
     application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
 
     TestRunnable runnable;
     LegacyCurrentProjectCalculator calculator;
     calculator.setParent(&runnable);
 
     ASSERT_TRUE(calculator.exec());
-    EXPECT_EQ(calculator.observedProject, second);
+    EXPECT_EQ(calculator.observedProject, first);
+}
+
+TEST(CurrentProjectCompatibility, executionContextOverridesGuiFallback)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
+
+    GtExecutionContext context(second);
+    GtExecutionContextScope scope(context);
+
+    EXPECT_EQ(gtApp->currentProject(), second);
+    EXPECT_EQ(gtDataModel->currentProject(), second);
+}
+
+TEST(CurrentProjectCompatibility, leavingExecutionContextRestoresGuiFallback)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
+
+    {
+        GtExecutionContext context(second);
+        GtExecutionContextScope scope(context);
+        EXPECT_EQ(gtApp->currentProject(), second);
+    }
+
+    EXPECT_EQ(gtApp->currentProject(), first);
+}
+
+TEST(CurrentProjectCompatibility, nestedExecutionContextsRestorePreviousProject)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
+
+    GtExecutionContext outer(second);
+    GtExecutionContext inner(first);
+    GtExecutionContextScope outerScope(outer);
+    EXPECT_EQ(gtApp->currentProject(), second);
+    {
+        GtExecutionContextScope innerScope(inner);
+        EXPECT_EQ(gtApp->currentProject(), first);
+    }
+    EXPECT_EQ(gtApp->currentProject(), second);
 }

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -20,6 +20,7 @@
 #include "gt_externalizationmanager.h"
 #include "gt_executioncontext.h"
 #include "gt_project.h"
+#include "gt_projectexecutionguard.h"
 #include "gt_session.h"
 
 namespace {
@@ -217,6 +218,23 @@ TEST(CurrentProjectCompatibility, leavingExecutionContextRestoresGuiFallback)
     }
 
     EXPECT_EQ(gtApp->currentProject(), first);
+}
+
+TEST(CurrentProjectCompatibility, saveAndCloseRejectBusyProject)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
+
+    GtProjectExecutionGuard guard;
+    ASSERT_EQ(guard.tryAcquire(first),
+              GtProjectExecutionGuard::Result::Acquired);
+
+    EXPECT_FALSE(gtDataModel->saveProject(first));
+    EXPECT_FALSE(gtDataModel->closeProject(first));
 }
 
 TEST(CurrentProjectCompatibility, nestedExecutionContextsRestorePreviousProject)

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -314,8 +314,7 @@ TEST(CurrentProjectCompatibility,
     EndToEndLegacyCalculator::projectToSelect = first;
     EndToEndLegacyCalculator::observedProject = nullptr;
 
-    auto* runnable = new GtRunnable(
-        {}, GtExecutionContext(second, {}, {}, second->path(), "job-b"));
+    auto* runnable = new GtRunnable({}, GtExecutionContext(second));
     GtTaskRunner runner(second->findDirectChildren<GtTask*>().front());
     ASSERT_TRUE(runner.setUp(runnable, second));
 

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -1,0 +1,135 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <QCoreApplication>
+#include <QDir>
+
+#include "gt_abstractrunnable.h"
+#include "gt_calculator.h"
+#include "gt_coreapplication.h"
+#include "gt_project.h"
+#include "gt_session.h"
+
+namespace {
+
+class TestProject : public GtProject
+{
+public:
+    explicit TestProject(const QString& path) : GtProject(path) {}
+};
+
+class TestSession : public GtSession
+{
+public:
+    TestSession() : GtSession() {}
+
+    void addProjectForTest(GtProject* project)
+    {
+        addProject(project);
+    }
+
+    bool selectProjectForTest(GtProject* project)
+    {
+        return setCurrentProject(project);
+    }
+};
+
+class TestApplication : public GtCoreApplication
+{
+public:
+    TestApplication() : GtCoreApplication(qApp, AppMode::Batch)
+    {
+        init();
+    }
+
+    void installSession(std::unique_ptr<TestSession> session)
+    {
+        m_session = std::move(session);
+    }
+
+protected:
+    bool initFirstRun() override
+    {
+        return true;
+    }
+};
+
+class TestRunnable : public GtAbstractRunnable
+{
+public:
+    void run() override {}
+
+    QDir tempDir() override { return {}; }
+
+    bool clearTempDir(const QString&) override { return true; }
+
+    QString projectPath() override
+    {
+        return gtApp && gtApp->currentProject() ?
+                   gtApp->currentProject()->path() : QString{};
+    }
+};
+
+class LegacyCurrentProjectCalculator : public GtCalculator
+{
+public:
+    GtProject* observedProject = nullptr;
+
+    bool run() override
+    {
+        observedProject = gtApp->currentProject();
+        return observedProject != nullptr;
+    }
+};
+
+std::unique_ptr<TestSession> sessionWithProjects(TestProject*& first,
+                                                 TestProject*& second)
+{
+    auto session = std::make_unique<TestSession>();
+    first = new TestProject(QStringLiteral("/test/project-a"));
+    second = new TestProject(QStringLiteral("/test/project-b"));
+    session->addProjectForTest(first);
+    session->addProjectForTest(second);
+    return session;
+}
+
+} // namespace
+
+TEST(CurrentProjectCompatibility, guiFallbackTracksSelectedProject)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    ASSERT_TRUE(session->selectProjectForTest(first));
+    application.installSession(std::move(session));
+
+    EXPECT_EQ(gtApp->currentProject(), first);
+
+    ASSERT_TRUE(gtApp->setCurrentProject(second));
+    EXPECT_EQ(gtApp->currentProject(), second);
+}
+
+TEST(CurrentProjectCompatibility, legacyCalculatorReadsSelectedProject)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    ASSERT_TRUE(session->selectProjectForTest(second));
+    application.installSession(std::move(session));
+
+    TestRunnable runnable;
+    LegacyCurrentProjectCalculator calculator;
+    calculator.setParent(&runnable);
+
+    ASSERT_TRUE(calculator.exec());
+    EXPECT_EQ(calculator.observedProject, second);
+}

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -68,6 +68,8 @@ public:
     void installSession(std::unique_ptr<TestSession> session)
     {
         constexpr auto sessionId = "currentproject-compatibility";
+        ASSERT_FALSE(gtApp->roamingPath().isEmpty());
+        ASSERT_TRUE(QDir().mkpath(gtApp->roamingPath()));
         ASSERT_TRUE(TestSession::createEmptySessionForTest(
             QString::fromLatin1(sessionId)));
         m_session.reset();

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -233,6 +233,24 @@ TEST(CurrentProjectCompatibility, executionContextOverridesGuiFallback)
     EXPECT_EQ(gtDataModel->currentProject(), second);
 }
 
+TEST(CurrentProjectCompatibility,
+     pathOnlyExecutionContextSuppressesGuiFallback)
+{
+    TestApplication application;
+    TestProject* first = nullptr;
+    TestProject* second = nullptr;
+    auto session = sessionWithProjects(first, second);
+    application.installSession(std::move(session));
+    ASSERT_TRUE(gtDataModel->openProject(first));
+
+    GtExecutionContext context(nullptr,
+                               QStringLiteral("/path-only-project"));
+    GtExecutionContextScope scope(context);
+
+    EXPECT_EQ(gtApp->currentProject(), nullptr);
+    EXPECT_EQ(gtDataModel->currentProject(), nullptr);
+}
+
 TEST(CurrentProjectCompatibility, leavingExecutionContextRestoresGuiFallback)
 {
     TestApplication application;

--- a/tests/unittests/core/test_currentproject_compatibility.cpp
+++ b/tests/unittests/core/test_currentproject_compatibility.cpp
@@ -14,6 +14,7 @@
 #include "gt_abstractrunnable.h"
 #include "gt_calculator.h"
 #include "gt_coreapplication.h"
+#include "gt_externalizationmanager.h"
 #include "gt_project.h"
 #include "gt_session.h"
 
@@ -47,6 +48,11 @@ public:
     TestApplication() : GtCoreApplication(qApp, AppMode::Batch)
     {
         init();
+    }
+
+    ~TestApplication() override
+    {
+        gtExternalizationManager->onProjectLoaded(QDir::tempPath());
     }
 
     void installSession(std::unique_ptr<TestSession> session)
@@ -93,8 +99,14 @@ std::unique_ptr<TestSession> sessionWithProjects(TestProject*& first,
                                                  TestProject*& second)
 {
     auto session = std::make_unique<TestSession>();
-    first = new TestProject(QStringLiteral("/test/project-a"));
-    second = new TestProject(QStringLiteral("/test/project-b"));
+    const QString firstPath = QDir::tempPath() +
+                              QStringLiteral("/gtlab-project-a-1508");
+    const QString secondPath = QDir::tempPath() +
+                               QStringLiteral("/gtlab-project-b-1508");
+    QDir().mkpath(firstPath);
+    QDir().mkpath(secondPath);
+    first = new TestProject(firstPath);
+    second = new TestProject(secondPath);
     session->addProjectForTest(first);
     session->addProjectForTest(second);
     return session;

--- a/tests/unittests/core/test_gt_coreprocessexecutor.cpp
+++ b/tests/unittests/core/test_gt_coreprocessexecutor.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "gt_coreprocessexecutor.h"
+#include "gt_objectfactory.h"
 #include "gt_project.h"
 #include "gt_projectexecutionguard.h"
 #include "gt_task.h"
@@ -27,6 +28,7 @@ public:
     int executeCalls = 0;
     int terminateCalls = 0;
     bool terminateResult = true;
+    bool useRealExecution = false;
 
     void setCurrentTask(GtTask* task)
     {
@@ -41,6 +43,12 @@ public:
 protected:
     void execute() override
     {
+        if (useRealExecution)
+        {
+            GtCoreProcessExecutor::execute();
+            return;
+        }
+
         ++executeCalls;
     }
 
@@ -109,6 +117,13 @@ TEST_F(TestGtCoreProcessExecutor, queueTaskRejectsNullAndDuplicateTasks)
     EXPECT_TRUE(executor.taskQueued(task.get()));
     EXPECT_FALSE(executor.queueTask(task.get()));
     EXPECT_EQ(queueChanges, 1);
+}
+
+TEST_F(TestGtCoreProcessExecutor, runTaskReturnsInvalidForRejectedTask)
+{
+    EXPECT_FALSE(executor.runTask(nullptr));
+    EXPECT_EQ(executor.runTaskWithResult(nullptr),
+              GtCoreProcessExecutor::RunTaskResult::Invalid);
 }
 
 TEST_F(TestGtCoreProcessExecutor,
@@ -306,6 +321,41 @@ TEST_F(TestGtCoreProcessExecutor,
     EXPECT_TRUE(executor.executeNextTask());
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_EQ(executor.currentRunningTask(), task.get());
+}
+
+TEST(GtCoreProcessExecutor, ReleasesProjectGuardAfterRealExecution)
+{
+    gtObjectFactory->registerClass(GtTask::staticMetaObject);
+
+    TestProject project(QStringLiteral("/tmp/gtlab-executor-real.gtlab"));
+    project.setObjectName("project");
+    auto task = std::make_unique<GtTask>();
+    task->setFactory(gtObjectFactory);
+    ASSERT_TRUE(project.appendChild(task.get()));
+
+    TestExecutor executor;
+    executor.useRealExecution = true;
+    ASSERT_TRUE(executor.setSource(&project));
+
+    EXPECT_EQ(executor.runTaskWithResult(task.get()),
+              GtCoreProcessExecutor::RunTaskResult::Started);
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_FALSE(executor.taskCurrentlyRunning());
+}
+
+TEST(GtCoreProcessExecutor, AllowsExecutionForProjectWithoutPath)
+{
+    TestProject project(QString{});
+    auto task = std::make_unique<GtTask>();
+    ASSERT_TRUE(project.appendChild(task.get()));
+
+    TestExecutor executor;
+    ASSERT_TRUE(executor.setSource(&project));
+
+    EXPECT_EQ(executor.runTaskWithResult(task.get()),
+              GtCoreProcessExecutor::RunTaskResult::Started);
+    EXPECT_EQ(executor.executeCalls, 1);
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
 }
 
 TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)

--- a/tests/unittests/core/test_gt_coreprocessexecutor.cpp
+++ b/tests/unittests/core/test_gt_coreprocessexecutor.cpp
@@ -78,6 +78,14 @@ public:
     }
 };
 
+class SignalEmitter : public QObject
+{
+    Q_OBJECT
+
+signals:
+    void triggered();
+};
+
 class TestGtCoreProcessExecutor : public ::testing::Test
 {
 protected:
@@ -344,7 +352,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardAfterRealExecution)
     EXPECT_FALSE(executor.taskCurrentlyRunning());
 }
 
-TEST(GtCoreProcessExecutor, AllowsExecutionForProjectWithoutPath)
+TEST(GtCoreProcessExecutor, GuardsExecutionForProjectWithoutPath)
 {
     TestProject project(QString{});
     auto task = std::make_unique<GtTask>();
@@ -356,7 +364,7 @@ TEST(GtCoreProcessExecutor, AllowsExecutionForProjectWithoutPath)
     EXPECT_EQ(executor.runTaskWithResult(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
     EXPECT_EQ(executor.executeCalls, 1);
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
 }
 
 TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)
@@ -400,6 +408,27 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardWhenCurrentTaskIsDeleted)
     EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
 }
 
+TEST(GtCoreProcessExecutor, ReleasesProjectGuardForInvalidRunnerSender)
+{
+    TestProject project(
+        QStringLiteral("/tmp/gtlab-executor-invalid-sender.gtlab"));
+    auto task = std::make_unique<GtTask>();
+    ASSERT_TRUE(project.appendChild(task.get()));
+
+    TestExecutor executor;
+    ASSERT_TRUE(executor.setSource(&project));
+    ASSERT_EQ(executor.runTaskWithResult(task.get()),
+              GtCoreProcessExecutor::RunTaskResult::Started);
+    ASSERT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+
+    SignalEmitter emitter;
+    QObject::connect(&emitter, SIGNAL(triggered()), &executor,
+                     SLOT(onTaskRunnerFinished()), Qt::DirectConnection);
+    emit emitter.triggered();
+
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+}
+
 TEST(GtCoreProcessExecutor, AllowsConcurrentExecutionsForDifferentProjects)
 {
     TestProject firstProject(QStringLiteral("/tmp/gtlab-executor-a.gtlab"));
@@ -417,3 +446,5 @@ TEST(GtCoreProcessExecutor, AllowsConcurrentExecutionsForDifferentProjects)
     EXPECT_EQ(second.runTaskWithResult(secondTask.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
 }
+
+#include "test_gt_coreprocessexecutor.moc"

--- a/tests/unittests/core/test_gt_coreprocessexecutor.cpp
+++ b/tests/unittests/core/test_gt_coreprocessexecutor.cpp
@@ -131,7 +131,7 @@ TEST_F(TestGtCoreProcessExecutor, queueTaskRejectsNullAndDuplicateTasks)
 TEST_F(TestGtCoreProcessExecutor, runTaskReturnsInvalidForRejectedTask)
 {
     EXPECT_EQ(executor.startTask(nullptr),
-              GtCoreProcessExecutor::RunTaskResult::Invalid);
+              GtCoreProcessExecutor::TaskExecState::Invalid);
 }
 
 TEST_F(TestGtCoreProcessExecutor,
@@ -141,7 +141,7 @@ TEST_F(TestGtCoreProcessExecutor,
     QObject::connect(&executor, &GtCoreProcessExecutor::allTasksCompleted,
                      [&completed]() { ++completed; });
 
-    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::TaskExecState::Invalid, executor.startNextTask());
     EXPECT_EQ(completed, 1);
     EXPECT_EQ(executor.executeCalls, 0);
 }
@@ -154,7 +154,7 @@ TEST_F(TestGtCoreProcessExecutor, executeNextTaskRejectsWhenTaskAlreadyRunning)
     ASSERT_TRUE(executor.queueTask(queuedTask.get()));
     executor.setCurrentTask(runningTask.get());
 
-    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Busy, executor.startNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::TaskExecState::Busy, executor.startNextTask());
     EXPECT_EQ(executor.executeCalls, 0);
     EXPECT_EQ(executor.currentRunningTask(), runningTask.get());
     EXPECT_TRUE(executor.taskQueued(queuedTask.get()));
@@ -164,7 +164,7 @@ TEST_F(TestGtCoreProcessExecutor, executeNextTaskRejectsNullQueuedTask)
 {
     executor.appendQueuedTask(nullptr);
 
-    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::TaskExecState::Invalid, executor.startNextTask());
     EXPECT_EQ(executor.currentRunningTask(), nullptr);
     EXPECT_TRUE(executor.queue().isEmpty());
 }
@@ -175,7 +175,7 @@ TEST_F(TestGtCoreProcessExecutor, executeNextTaskRejectsTaskWithoutSource)
 
     ASSERT_TRUE(executor.queueTask(task.get()));
 
-    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::TaskExecState::Invalid, executor.startNextTask());
     EXPECT_EQ(task->currentState(), GtProcessComponent::FAILED);
     EXPECT_EQ(executor.currentRunningTask(), nullptr);
     EXPECT_TRUE(executor.queue().isEmpty());
@@ -192,7 +192,7 @@ TEST_F(TestGtCoreProcessExecutor, runTaskQueuesTaskAndTriggersExecute)
     QObject::connect(&executor, &GtCoreProcessExecutor::queueChanged,
                      [&queueChanges]() { ++queueChanges; });
 
-    EXPECT_NE(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startTask(task.get()));
+    EXPECT_NE(GtCoreProcessExecutor::TaskExecState::Invalid, executor.startTask(task.get()));
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_EQ(executor.currentRunningTask(), task.get());
     EXPECT_TRUE(executor.taskQueued(task.get()));
@@ -207,7 +207,7 @@ TEST_F(TestGtCoreProcessExecutor,
 
     executor.setCurrentTask(runningTask.get());
 
-    EXPECT_NE(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startTask(queuedTask.get()));
+    EXPECT_NE(GtCoreProcessExecutor::TaskExecState::Invalid, executor.startTask(queuedTask.get()));
     EXPECT_EQ(executor.executeCalls, 0);
     EXPECT_TRUE(executor.taskQueued(queuedTask.get()));
     EXPECT_EQ(executor.currentRunningTask(), runningTask.get());
@@ -258,7 +258,7 @@ TEST_F(TestGtCoreProcessExecutor,
     auto task2 = makeTask("task-2");
 
     ASSERT_TRUE(executor.setSource(&source));
-    ASSERT_NE(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startTask(task1.get()));
+    ASSERT_NE(GtCoreProcessExecutor::TaskExecState::Invalid, executor.startTask(task1.get()));
     ASSERT_TRUE(executor.queueTask(task2.get()));
 
     EXPECT_FALSE(executor.terminateTask(task2.get()));
@@ -326,7 +326,7 @@ TEST_F(TestGtCoreProcessExecutor,
     ASSERT_TRUE(project.appendChild(task.get()));
 
     EXPECT_TRUE(executor.queueTask(task.get()));
-    EXPECT_TRUE(executor.startNextTask() != GtCoreProcessExecutor::RunTaskResult::Invalid);
+    EXPECT_TRUE(executor.startNextTask() != GtCoreProcessExecutor::TaskExecState::Invalid);
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_EQ(executor.currentRunningTask(), task.get());
 }
@@ -346,7 +346,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardAfterRealExecution)
     ASSERT_TRUE(executor.setSource(&project));
 
     EXPECT_EQ(executor.startTask(task.get()),
-              GtCoreProcessExecutor::RunTaskResult::Started);
+              GtCoreProcessExecutor::TaskExecState::Started);
     EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&project));
     EXPECT_FALSE(executor.taskCurrentlyRunning());
 }
@@ -361,7 +361,7 @@ TEST(GtCoreProcessExecutor, GuardsExecutionForProjectWithoutPath)
     ASSERT_TRUE(executor.setSource(&project));
 
     EXPECT_EQ(executor.startTask(task.get()),
-              GtCoreProcessExecutor::RunTaskResult::Started);
+              GtCoreProcessExecutor::TaskExecState::Started);
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 }
@@ -378,9 +378,9 @@ TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)
     TestExecutor second;
 
     EXPECT_EQ(first.startTask(firstTask.get()),
-              GtCoreProcessExecutor::RunTaskResult::Started);
+              GtCoreProcessExecutor::TaskExecState::Started);
     EXPECT_EQ(second.startTask(secondTask.get()),
-              GtCoreProcessExecutor::RunTaskResult::Busy);
+              GtCoreProcessExecutor::TaskExecState::Busy);
     EXPECT_EQ(secondTask->currentState(), GtProcessComponent::NONE);
     EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 }
@@ -395,7 +395,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardWhenCurrentTaskIsDeleted)
     TestExecutor executor;
     ASSERT_TRUE(executor.setSource(&project));
     ASSERT_EQ(executor.startTask(task.get()),
-              GtCoreProcessExecutor::RunTaskResult::Started);
+              GtCoreProcessExecutor::TaskExecState::Started);
     ASSERT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 
     executor.setCurrentTask(nullptr);
@@ -417,7 +417,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardForInvalidRunnerSender)
     TestExecutor executor;
     ASSERT_TRUE(executor.setSource(&project));
     ASSERT_EQ(executor.startTask(task.get()),
-              GtCoreProcessExecutor::RunTaskResult::Started);
+              GtCoreProcessExecutor::TaskExecState::Started);
     ASSERT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 
     SignalEmitter emitter;
@@ -441,9 +441,9 @@ TEST(GtCoreProcessExecutor, AllowsConcurrentExecutionsForDifferentProjects)
     TestExecutor second;
 
     EXPECT_EQ(first.startTask(firstTask.get()),
-              GtCoreProcessExecutor::RunTaskResult::Started);
+              GtCoreProcessExecutor::TaskExecState::Started);
     EXPECT_EQ(second.startTask(secondTask.get()),
-              GtCoreProcessExecutor::RunTaskResult::Started);
+              GtCoreProcessExecutor::TaskExecState::Started);
 }
 
 #include "test_gt_coreprocessexecutor.moc"

--- a/tests/unittests/core/test_gt_coreprocessexecutor.cpp
+++ b/tests/unittests/core/test_gt_coreprocessexecutor.cpp
@@ -130,8 +130,7 @@ TEST_F(TestGtCoreProcessExecutor, queueTaskRejectsNullAndDuplicateTasks)
 
 TEST_F(TestGtCoreProcessExecutor, runTaskReturnsInvalidForRejectedTask)
 {
-    EXPECT_FALSE(executor.runTask(nullptr));
-    EXPECT_EQ(executor.runTaskWithResult(nullptr),
+    EXPECT_EQ(executor.startTask(nullptr),
               GtCoreProcessExecutor::RunTaskResult::Invalid);
 }
 
@@ -142,7 +141,7 @@ TEST_F(TestGtCoreProcessExecutor,
     QObject::connect(&executor, &GtCoreProcessExecutor::allTasksCompleted,
                      [&completed]() { ++completed; });
 
-    EXPECT_FALSE(executor.executeNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startNextTask());
     EXPECT_EQ(completed, 1);
     EXPECT_EQ(executor.executeCalls, 0);
 }
@@ -155,7 +154,7 @@ TEST_F(TestGtCoreProcessExecutor, executeNextTaskRejectsWhenTaskAlreadyRunning)
     ASSERT_TRUE(executor.queueTask(queuedTask.get()));
     executor.setCurrentTask(runningTask.get());
 
-    EXPECT_FALSE(executor.executeNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Busy, executor.startNextTask());
     EXPECT_EQ(executor.executeCalls, 0);
     EXPECT_EQ(executor.currentRunningTask(), runningTask.get());
     EXPECT_TRUE(executor.taskQueued(queuedTask.get()));
@@ -165,7 +164,7 @@ TEST_F(TestGtCoreProcessExecutor, executeNextTaskRejectsNullQueuedTask)
 {
     executor.appendQueuedTask(nullptr);
 
-    EXPECT_FALSE(executor.executeNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startNextTask());
     EXPECT_EQ(executor.currentRunningTask(), nullptr);
     EXPECT_TRUE(executor.queue().isEmpty());
 }
@@ -176,7 +175,7 @@ TEST_F(TestGtCoreProcessExecutor, executeNextTaskRejectsTaskWithoutSource)
 
     ASSERT_TRUE(executor.queueTask(task.get()));
 
-    EXPECT_FALSE(executor.executeNextTask());
+    EXPECT_EQ(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startNextTask());
     EXPECT_EQ(task->currentState(), GtProcessComponent::FAILED);
     EXPECT_EQ(executor.currentRunningTask(), nullptr);
     EXPECT_TRUE(executor.queue().isEmpty());
@@ -193,7 +192,7 @@ TEST_F(TestGtCoreProcessExecutor, runTaskQueuesTaskAndTriggersExecute)
     QObject::connect(&executor, &GtCoreProcessExecutor::queueChanged,
                      [&queueChanges]() { ++queueChanges; });
 
-    EXPECT_TRUE(executor.runTask(task.get()));
+    EXPECT_NE(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startTask(task.get()));
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_EQ(executor.currentRunningTask(), task.get());
     EXPECT_TRUE(executor.taskQueued(task.get()));
@@ -208,7 +207,7 @@ TEST_F(TestGtCoreProcessExecutor,
 
     executor.setCurrentTask(runningTask.get());
 
-    EXPECT_TRUE(executor.runTask(queuedTask.get()));
+    EXPECT_NE(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startTask(queuedTask.get()));
     EXPECT_EQ(executor.executeCalls, 0);
     EXPECT_TRUE(executor.taskQueued(queuedTask.get()));
     EXPECT_EQ(executor.currentRunningTask(), runningTask.get());
@@ -259,7 +258,7 @@ TEST_F(TestGtCoreProcessExecutor,
     auto task2 = makeTask("task-2");
 
     ASSERT_TRUE(executor.setSource(&source));
-    ASSERT_TRUE(executor.runTask(task1.get()));
+    ASSERT_NE(GtCoreProcessExecutor::RunTaskResult::Invalid, executor.startTask(task1.get()));
     ASSERT_TRUE(executor.queueTask(task2.get()));
 
     EXPECT_FALSE(executor.terminateTask(task2.get()));
@@ -327,7 +326,7 @@ TEST_F(TestGtCoreProcessExecutor,
     ASSERT_TRUE(project.appendChild(task.get()));
 
     EXPECT_TRUE(executor.queueTask(task.get()));
-    EXPECT_TRUE(executor.executeNextTask());
+    EXPECT_TRUE(executor.startNextTask() != GtCoreProcessExecutor::RunTaskResult::Invalid);
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_EQ(executor.currentRunningTask(), task.get());
 }
@@ -346,7 +345,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardAfterRealExecution)
     executor.useRealExecution = true;
     ASSERT_TRUE(executor.setSource(&project));
 
-    EXPECT_EQ(executor.runTaskWithResult(task.get()),
+    EXPECT_EQ(executor.startTask(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
     EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&project));
     EXPECT_FALSE(executor.taskCurrentlyRunning());
@@ -361,7 +360,7 @@ TEST(GtCoreProcessExecutor, GuardsExecutionForProjectWithoutPath)
     TestExecutor executor;
     ASSERT_TRUE(executor.setSource(&project));
 
-    EXPECT_EQ(executor.runTaskWithResult(task.get()),
+    EXPECT_EQ(executor.startTask(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
@@ -378,9 +377,9 @@ TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)
     TestExecutor first;
     TestExecutor second;
 
-    EXPECT_EQ(first.runTaskWithResult(firstTask.get()),
+    EXPECT_EQ(first.startTask(firstTask.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
-    EXPECT_EQ(second.runTaskWithResult(secondTask.get()),
+    EXPECT_EQ(second.startTask(secondTask.get()),
               GtCoreProcessExecutor::RunTaskResult::Busy);
     EXPECT_EQ(secondTask->currentState(), GtProcessComponent::NONE);
     EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
@@ -395,7 +394,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardWhenCurrentTaskIsDeleted)
 
     TestExecutor executor;
     ASSERT_TRUE(executor.setSource(&project));
-    ASSERT_EQ(executor.runTaskWithResult(task.get()),
+    ASSERT_EQ(executor.startTask(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
     ASSERT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 
@@ -417,7 +416,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardForInvalidRunnerSender)
 
     TestExecutor executor;
     ASSERT_TRUE(executor.setSource(&project));
-    ASSERT_EQ(executor.runTaskWithResult(task.get()),
+    ASSERT_EQ(executor.startTask(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
     ASSERT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 
@@ -441,9 +440,9 @@ TEST(GtCoreProcessExecutor, AllowsConcurrentExecutionsForDifferentProjects)
     TestExecutor first;
     TestExecutor second;
 
-    EXPECT_EQ(first.runTaskWithResult(firstTask.get()),
+    EXPECT_EQ(first.startTask(firstTask.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
-    EXPECT_EQ(second.runTaskWithResult(secondTask.get()),
+    EXPECT_EQ(second.startTask(secondTask.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
 }
 

--- a/tests/unittests/core/test_gt_coreprocessexecutor.cpp
+++ b/tests/unittests/core/test_gt_coreprocessexecutor.cpp
@@ -348,7 +348,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardAfterRealExecution)
 
     EXPECT_EQ(executor.runTaskWithResult(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&project));
     EXPECT_FALSE(executor.taskCurrentlyRunning());
 }
 
@@ -364,7 +364,7 @@ TEST(GtCoreProcessExecutor, GuardsExecutionForProjectWithoutPath)
     EXPECT_EQ(executor.runTaskWithResult(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
     EXPECT_EQ(executor.executeCalls, 1);
-    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 }
 
 TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)
@@ -383,7 +383,7 @@ TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)
     EXPECT_EQ(second.runTaskWithResult(secondTask.get()),
               GtCoreProcessExecutor::RunTaskResult::Busy);
     EXPECT_EQ(secondTask->currentState(), GtProcessComponent::NONE);
-    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 }
 
 TEST(GtCoreProcessExecutor, ReleasesProjectGuardWhenCurrentTaskIsDeleted)
@@ -397,7 +397,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardWhenCurrentTaskIsDeleted)
     ASSERT_TRUE(executor.setSource(&project));
     ASSERT_EQ(executor.runTaskWithResult(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
-    ASSERT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+    ASSERT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 
     executor.setCurrentTask(nullptr);
     GtTaskRunner runner(nullptr);
@@ -405,7 +405,7 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardWhenCurrentTaskIsDeleted)
                      SLOT(onTaskRunnerFinished()), Qt::DirectConnection);
     emit runner.finished();
 
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&project));
 }
 
 TEST(GtCoreProcessExecutor, ReleasesProjectGuardForInvalidRunnerSender)
@@ -419,14 +419,14 @@ TEST(GtCoreProcessExecutor, ReleasesProjectGuardForInvalidRunnerSender)
     ASSERT_TRUE(executor.setSource(&project));
     ASSERT_EQ(executor.runTaskWithResult(task.get()),
               GtCoreProcessExecutor::RunTaskResult::Started);
-    ASSERT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+    ASSERT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 
     SignalEmitter emitter;
     QObject::connect(&emitter, SIGNAL(triggered()), &executor,
                      SLOT(onTaskRunnerFinished()), Qt::DirectConnection);
     emit emitter.triggered();
 
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&project));
 }
 
 TEST(GtCoreProcessExecutor, AllowsConcurrentExecutionsForDifferentProjects)

--- a/tests/unittests/core/test_gt_coreprocessexecutor.cpp
+++ b/tests/unittests/core/test_gt_coreprocessexecutor.cpp
@@ -11,6 +11,7 @@
 
 #include "gt_coreprocessexecutor.h"
 #include "gt_project.h"
+#include "gt_projectexecutionguard.h"
 #include "gt_task.h"
 
 class TestExecutor : public GtCoreProcessExecutor
@@ -305,4 +306,41 @@ TEST_F(TestGtCoreProcessExecutor,
     EXPECT_TRUE(executor.executeNextTask());
     EXPECT_EQ(executor.executeCalls, 1);
     EXPECT_EQ(executor.currentRunningTask(), task.get());
+}
+
+TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)
+{
+    TestProject project(QStringLiteral("/tmp/gtlab-executor-project.gtlab"));
+    auto firstTask = std::make_unique<GtTask>();
+    auto secondTask = std::make_unique<GtTask>();
+    ASSERT_TRUE(project.appendChild(firstTask.get()));
+    ASSERT_TRUE(project.appendChild(secondTask.get()));
+
+    TestExecutor first;
+    TestExecutor second;
+
+    EXPECT_EQ(first.runTaskWithResult(firstTask.get()),
+              GtCoreProcessExecutor::RunTaskResult::Started);
+    EXPECT_EQ(second.runTaskWithResult(secondTask.get()),
+              GtCoreProcessExecutor::RunTaskResult::Busy);
+    EXPECT_EQ(secondTask->currentState(), GtProcessComponent::NONE);
+    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+}
+
+TEST(GtCoreProcessExecutor, AllowsConcurrentExecutionsForDifferentProjects)
+{
+    TestProject firstProject(QStringLiteral("/tmp/gtlab-executor-a.gtlab"));
+    TestProject secondProject(QStringLiteral("/tmp/gtlab-executor-b.gtlab"));
+    auto firstTask = std::make_unique<GtTask>();
+    auto secondTask = std::make_unique<GtTask>();
+    ASSERT_TRUE(firstProject.appendChild(firstTask.get()));
+    ASSERT_TRUE(secondProject.appendChild(secondTask.get()));
+
+    TestExecutor first;
+    TestExecutor second;
+
+    EXPECT_EQ(first.runTaskWithResult(firstTask.get()),
+              GtCoreProcessExecutor::RunTaskResult::Started);
+    EXPECT_EQ(second.runTaskWithResult(secondTask.get()),
+              GtCoreProcessExecutor::RunTaskResult::Started);
 }

--- a/tests/unittests/core/test_gt_coreprocessexecutor.cpp
+++ b/tests/unittests/core/test_gt_coreprocessexecutor.cpp
@@ -14,6 +14,7 @@
 #include "gt_project.h"
 #include "gt_projectexecutionguard.h"
 #include "gt_task.h"
+#include "gt_taskrunner.h"
 
 class TestExecutor : public GtCoreProcessExecutor
 {
@@ -375,6 +376,28 @@ TEST(GtCoreProcessExecutor, RejectsMutatingExecutionForBusyProject)
               GtCoreProcessExecutor::RunTaskResult::Busy);
     EXPECT_EQ(secondTask->currentState(), GtProcessComponent::NONE);
     EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+}
+
+TEST(GtCoreProcessExecutor, ReleasesProjectGuardWhenCurrentTaskIsDeleted)
+{
+    TestProject project(
+        QStringLiteral("/tmp/gtlab-executor-deleted-task.gtlab"));
+    auto task = std::make_unique<GtTask>();
+    ASSERT_TRUE(project.appendChild(task.get()));
+
+    TestExecutor executor;
+    ASSERT_TRUE(executor.setSource(&project));
+    ASSERT_EQ(executor.runTaskWithResult(task.get()),
+              GtCoreProcessExecutor::RunTaskResult::Started);
+    ASSERT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+
+    executor.setCurrentTask(nullptr);
+    GtTaskRunner runner(nullptr);
+    QObject::connect(&runner, SIGNAL(finished()), &executor,
+                     SLOT(onTaskRunnerFinished()), Qt::DirectConnection);
+    emit runner.finished();
+
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
 }
 
 TEST(GtCoreProcessExecutor, AllowsConcurrentExecutionsForDifferentProjects)

--- a/tests/unittests/core/test_gt_executioncontext.cpp
+++ b/tests/unittests/core/test_gt_executioncontext.cpp
@@ -9,8 +9,12 @@
 #include <future>
 #include <stdexcept>
 #include <thread>
+#include <type_traits>
 
 #include "gt_executioncontext.h"
+
+static_assert(!std::is_constructible_v<GtExecutionContextScope,
+                                       GtExecutionContext&&>);
 
 TEST(GtExecutionContext, storesExecutionData)
 {

--- a/tests/unittests/core/test_gt_executioncontext.cpp
+++ b/tests/unittests/core/test_gt_executioncontext.cpp
@@ -1,0 +1,121 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#include "gtest/gtest.h"
+
+#include <future>
+#include <stdexcept>
+#include <thread>
+
+#include "gt_executioncontext.h"
+
+TEST(GtExecutionContext, storesExecutionData)
+{
+    GtExecutionContext context(nullptr,
+                               QStringLiteral("/data"),
+                               QStringLiteral("source-a"),
+                               QStringLiteral("/project"),
+                               QStringLiteral("job-1"));
+
+    EXPECT_EQ(context.project(), nullptr);
+    EXPECT_EQ(context.executionDataRoot(), QStringLiteral("/data"));
+    EXPECT_EQ(context.source(), QStringLiteral("source-a"));
+    EXPECT_EQ(context.projectPath(), QStringLiteral("/project"));
+    EXPECT_EQ(context.jobId(), QStringLiteral("job-1"));
+    EXPECT_FALSE(context.isValid());
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+}
+
+TEST(GtExecutionContext, scopeInstallsAndRestoresContext)
+{
+    GtExecutionContext context(nullptr, {}, {}, QStringLiteral("/project"));
+
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+    {
+        GtExecutionContextScope scope(context);
+        EXPECT_EQ(GtExecutionContext::current(), &context);
+        EXPECT_EQ(GtExecutionContext::currentContext(), &context);
+    }
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+}
+
+TEST(GtExecutionContext, nestedScopesRestorePreviousContext)
+{
+    GtExecutionContext outer(nullptr, {}, {}, QStringLiteral("/outer"));
+    GtExecutionContext inner(nullptr, {}, {}, QStringLiteral("/inner"));
+
+    GtExecutionContextScope outerScope(outer);
+    EXPECT_EQ(GtExecutionContext::current(), &outer);
+    {
+        GtExecutionContextScope innerScope(inner);
+        EXPECT_EQ(GtExecutionContext::current(), &inner);
+    }
+    EXPECT_EQ(GtExecutionContext::current(), &outer);
+}
+
+TEST(GtExecutionContext, scopeRestoresAfterEarlyReturn)
+{
+    GtExecutionContext context(nullptr, {}, {}, QStringLiteral("/project"));
+
+    const auto installAndReturn = [&context]() {
+        GtExecutionContextScope scope(context);
+        return GtExecutionContext::current();
+    };
+
+    EXPECT_EQ(installAndReturn(), &context);
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+}
+
+TEST(GtExecutionContext, scopeRestoresAfterException)
+{
+    GtExecutionContext context(nullptr, {}, {}, QStringLiteral("/project"));
+
+    try
+    {
+        GtExecutionContextScope scope(context);
+        throw std::runtime_error("test");
+    }
+    catch (std::runtime_error const&)
+    {
+    }
+
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+}
+
+TEST(GtExecutionContext, contextsAreIsolatedBetweenThreads)
+{
+    GtExecutionContext first(nullptr, {}, {}, QStringLiteral("/first"));
+    GtExecutionContext second(nullptr, {}, {}, QStringLiteral("/second"));
+    std::promise<void> firstReady;
+    std::promise<void> releaseFirst;
+    auto firstReadyFuture = firstReady.get_future();
+    auto releaseFirstFuture = releaseFirst.get_future();
+    GtExecutionContext const* observedByFirst = nullptr;
+    GtExecutionContext const* observedBySecond = nullptr;
+
+    std::thread firstThread([&]() {
+        GtExecutionContextScope scope(first);
+        observedByFirst = GtExecutionContext::current();
+        firstReady.set_value();
+        releaseFirstFuture.wait();
+    });
+
+    firstReadyFuture.wait();
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+
+    std::thread secondThread([&]() {
+        GtExecutionContextScope scope(second);
+        observedBySecond = GtExecutionContext::current();
+    });
+
+    secondThread.join();
+    releaseFirst.set_value();
+    firstThread.join();
+
+    EXPECT_EQ(observedByFirst, &first);
+    EXPECT_EQ(observedBySecond, &second);
+    EXPECT_EQ(GtExecutionContext::current(), nullptr);
+}

--- a/tests/unittests/core/test_gt_executioncontext.cpp
+++ b/tests/unittests/core/test_gt_executioncontext.cpp
@@ -62,7 +62,6 @@ TEST(GtExecutionContext, scopeInstallsAndRestoresContext)
     {
         GtExecutionContextScope scope(context);
         EXPECT_EQ(GtExecutionContext::current(), &context);
-        EXPECT_EQ(GtExecutionContext::currentContext(), &context);
     }
     EXPECT_EQ(GtExecutionContext::current(), nullptr);
 }

--- a/tests/unittests/core/test_gt_executioncontext.cpp
+++ b/tests/unittests/core/test_gt_executioncontext.cpp
@@ -10,32 +10,53 @@
 #include <stdexcept>
 #include <thread>
 #include <type_traits>
+#include <utility>
 
 #include "gt_executioncontext.h"
+#include "gt_project.h"
 
 static_assert(!std::is_constructible_v<GtExecutionContextScope,
                                        GtExecutionContext&&>);
 
-TEST(GtExecutionContext, storesExecutionData)
+namespace
 {
-    GtExecutionContext context(nullptr,
-                               QStringLiteral("/data"),
-                               QStringLiteral("source-a"),
-                               QStringLiteral("/project"),
-                               QStringLiteral("job-1"));
+class TestProject : public GtProject
+{
+public:
+    explicit TestProject(QString path) : GtProject(std::move(path)) {}
+};
+}
+
+TEST(GtExecutionContext, storesProjectData)
+{
+    GtExecutionContext context(nullptr, QStringLiteral("/project"));
 
     EXPECT_EQ(context.project(), nullptr);
-    EXPECT_EQ(context.executionDataRoot(), QStringLiteral("/data"));
-    EXPECT_EQ(context.source(), QStringLiteral("source-a"));
     EXPECT_EQ(context.projectPath(), QStringLiteral("/project"));
-    EXPECT_EQ(context.jobId(), QStringLiteral("job-1"));
-    EXPECT_FALSE(context.isValid());
+    EXPECT_TRUE(context.isValid());
     EXPECT_EQ(GtExecutionContext::current(), nullptr);
+}
+
+TEST(GtExecutionContext, projectOnlyContextIsValid)
+{
+    TestProject project(QString{});
+    GtExecutionContext context(&project);
+
+    EXPECT_TRUE(context.isValid());
+    EXPECT_EQ(context.project(), &project);
+    EXPECT_EQ(context.projectPath(), project.path());
+}
+
+TEST(GtExecutionContext, emptyContextIsInvalid)
+{
+    GtExecutionContext context;
+
+    EXPECT_FALSE(context.isValid());
 }
 
 TEST(GtExecutionContext, scopeInstallsAndRestoresContext)
 {
-    GtExecutionContext context(nullptr, {}, {}, QStringLiteral("/project"));
+    GtExecutionContext context(nullptr, QStringLiteral("/project"));
 
     EXPECT_EQ(GtExecutionContext::current(), nullptr);
     {
@@ -48,8 +69,8 @@ TEST(GtExecutionContext, scopeInstallsAndRestoresContext)
 
 TEST(GtExecutionContext, nestedScopesRestorePreviousContext)
 {
-    GtExecutionContext outer(nullptr, {}, {}, QStringLiteral("/outer"));
-    GtExecutionContext inner(nullptr, {}, {}, QStringLiteral("/inner"));
+    GtExecutionContext outer(nullptr, QStringLiteral("/outer"));
+    GtExecutionContext inner(nullptr, QStringLiteral("/inner"));
 
     GtExecutionContextScope outerScope(outer);
     EXPECT_EQ(GtExecutionContext::current(), &outer);
@@ -62,7 +83,7 @@ TEST(GtExecutionContext, nestedScopesRestorePreviousContext)
 
 TEST(GtExecutionContext, scopeRestoresAfterEarlyReturn)
 {
-    GtExecutionContext context(nullptr, {}, {}, QStringLiteral("/project"));
+    GtExecutionContext context(nullptr, QStringLiteral("/project"));
 
     const auto installAndReturn = [&context]() {
         GtExecutionContextScope scope(context);
@@ -75,7 +96,7 @@ TEST(GtExecutionContext, scopeRestoresAfterEarlyReturn)
 
 TEST(GtExecutionContext, scopeRestoresAfterException)
 {
-    GtExecutionContext context(nullptr, {}, {}, QStringLiteral("/project"));
+    GtExecutionContext context(nullptr, QStringLiteral("/project"));
 
     try
     {
@@ -91,8 +112,8 @@ TEST(GtExecutionContext, scopeRestoresAfterException)
 
 TEST(GtExecutionContext, contextsAreIsolatedBetweenThreads)
 {
-    GtExecutionContext first(nullptr, {}, {}, QStringLiteral("/first"));
-    GtExecutionContext second(nullptr, {}, {}, QStringLiteral("/second"));
+    GtExecutionContext first(nullptr, QStringLiteral("/first"));
+    GtExecutionContext second(nullptr, QStringLiteral("/second"));
     std::promise<void> firstReady;
     std::promise<void> releaseFirst;
     auto firstReadyFuture = firstReady.get_future();

--- a/tests/unittests/core/test_gt_projectexecutionguard.cpp
+++ b/tests/unittests/core/test_gt_projectexecutionguard.cpp
@@ -1,0 +1,59 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: MPL-2.0+
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#include "gtest/gtest.h"
+
+#include "gt_project.h"
+#include "gt_projectexecutionguard.h"
+
+namespace
+{
+class TestProject : public GtProject
+{
+public:
+    explicit TestProject(QString path) : GtProject(std::move(path)) {}
+};
+}
+
+TEST(GtProjectExecutionGuard, UsesCanonicalProjectIdentity)
+{
+    TestProject first(QStringLiteral("/tmp/gtlab-project/./project.gtlab"));
+    TestProject second(QStringLiteral("/tmp/gtlab-project/project.gtlab"));
+
+    EXPECT_EQ(GtProjectExecutionGuard::projectKey(&first),
+              GtProjectExecutionGuard::projectKey(&second));
+}
+
+TEST(GtProjectExecutionGuard, SerializesSameProjectAndReleases)
+{
+    TestProject project(QStringLiteral("/tmp/gtlab-project.gtlab"));
+    GtProjectExecutionGuard first;
+    GtProjectExecutionGuard second;
+
+    EXPECT_EQ(first.tryAcquire(&project),
+              GtProjectExecutionGuard::Result::Acquired);
+    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_EQ(second.tryAcquire(&project),
+              GtProjectExecutionGuard::Result::Busy);
+
+    first.release();
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_EQ(second.tryAcquire(&project),
+              GtProjectExecutionGuard::Result::Acquired);
+}
+
+TEST(GtProjectExecutionGuard, DoesNotSerializeDifferentProjects)
+{
+    TestProject first(QStringLiteral("/tmp/gtlab-project-a.gtlab"));
+    TestProject second(QStringLiteral("/tmp/gtlab-project-b.gtlab"));
+    GtProjectExecutionGuard firstGuard;
+    GtProjectExecutionGuard secondGuard;
+
+    EXPECT_EQ(firstGuard.tryAcquire(&first),
+              GtProjectExecutionGuard::Result::Acquired);
+    EXPECT_EQ(secondGuard.tryAcquire(&second),
+              GtProjectExecutionGuard::Result::Acquired);
+}

--- a/tests/unittests/core/test_gt_projectexecutionguard.cpp
+++ b/tests/unittests/core/test_gt_projectexecutionguard.cpp
@@ -27,6 +27,45 @@ TEST(GtProjectExecutionGuard, UsesCanonicalProjectIdentity)
               GtProjectExecutionGuard::projectKey(&second));
 }
 
+TEST(GtProjectExecutionGuard, RejectsInvalidProjects)
+{
+    TestProject project(QString{});
+    GtProjectExecutionGuard guard;
+
+    EXPECT_TRUE(GtProjectExecutionGuard::projectKey(nullptr).isEmpty());
+    EXPECT_TRUE(GtProjectExecutionGuard::projectKey(&project).isEmpty());
+    EXPECT_EQ(guard.tryAcquire(nullptr),
+              GtProjectExecutionGuard::Result::InvalidProject);
+    EXPECT_EQ(guard.tryAcquire(&project),
+              GtProjectExecutionGuard::Result::InvalidProject);
+    EXPECT_FALSE(guard.isHeld());
+    EXPECT_TRUE(guard.key().isEmpty());
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(nullptr));
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+}
+
+TEST(GtProjectExecutionGuard, ReacquiringReleasesPreviousProject)
+{
+    TestProject first(QStringLiteral("/tmp/gtlab-project-reacquire-a.gtlab"));
+    TestProject second(QStringLiteral("/tmp/gtlab-project-reacquire-b.gtlab"));
+    GtProjectExecutionGuard guard;
+
+    ASSERT_EQ(guard.tryAcquire(&first),
+              GtProjectExecutionGuard::Result::Acquired);
+    ASSERT_TRUE(guard.isHeld());
+    ASSERT_EQ(guard.tryAcquire(&second),
+              GtProjectExecutionGuard::Result::Acquired);
+
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&first));
+    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&second));
+    EXPECT_EQ(guard.key(),
+              GtProjectExecutionGuard::projectKey(&second));
+
+    guard.release();
+    guard.release();
+    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&second));
+}
+
 TEST(GtProjectExecutionGuard, SerializesSameProjectAndReleases)
 {
     TestProject project(QStringLiteral("/tmp/gtlab-project.gtlab"));

--- a/tests/unittests/core/test_gt_projectexecutionguard.cpp
+++ b/tests/unittests/core/test_gt_projectexecutionguard.cpp
@@ -27,21 +27,33 @@ TEST(GtProjectExecutionGuard, UsesCanonicalProjectIdentity)
               GtProjectExecutionGuard::projectKey(&second));
 }
 
-TEST(GtProjectExecutionGuard, RejectsInvalidProjects)
+TEST(GtProjectExecutionGuard, RejectsNullProjects)
 {
     TestProject project(QString{});
     GtProjectExecutionGuard guard;
 
     EXPECT_TRUE(GtProjectExecutionGuard::projectKey(nullptr).isEmpty());
-    EXPECT_TRUE(GtProjectExecutionGuard::projectKey(&project).isEmpty());
+    EXPECT_FALSE(GtProjectExecutionGuard::projectKey(&project).isEmpty());
     EXPECT_EQ(guard.tryAcquire(nullptr),
               GtProjectExecutionGuard::Result::InvalidProject);
     EXPECT_EQ(guard.tryAcquire(&project),
-              GtProjectExecutionGuard::Result::InvalidProject);
-    EXPECT_FALSE(guard.isHeld());
-    EXPECT_TRUE(guard.key().isEmpty());
+              GtProjectExecutionGuard::Result::Acquired);
+    EXPECT_TRUE(guard.isHeld());
+    EXPECT_FALSE(guard.key().isEmpty());
     EXPECT_FALSE(GtProjectExecutionGuard::isBusy(nullptr));
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+}
+
+TEST(GtProjectExecutionGuard, SerializesPathlessProjects)
+{
+    TestProject project(QString{});
+    GtProjectExecutionGuard first;
+    GtProjectExecutionGuard second;
+
+    ASSERT_EQ(first.tryAcquire(&project),
+              GtProjectExecutionGuard::Result::Acquired);
+    EXPECT_EQ(second.tryAcquire(&project),
+              GtProjectExecutionGuard::Result::Busy);
 }
 
 TEST(GtProjectExecutionGuard, ReacquiringReleasesPreviousProject)

--- a/tests/unittests/core/test_gt_projectexecutionguard.cpp
+++ b/tests/unittests/core/test_gt_projectexecutionguard.cpp
@@ -38,10 +38,10 @@ TEST(GtProjectExecutionGuard, RejectsNullProjects)
               GtProjectExecutionGuard::Result::InvalidProject);
     EXPECT_EQ(guard.tryAcquire(&project),
               GtProjectExecutionGuard::Result::Acquired);
-    EXPECT_TRUE(guard.isHeld());
-    EXPECT_FALSE(guard.key().isEmpty());
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(nullptr));
-    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_TRUE(guard.isLocked());
+    EXPECT_FALSE(guard.projectKey().isEmpty());
+    EXPECT_FALSE(GtProjectExecutionGuard::isLocked(nullptr));
+    EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
 }
 
 TEST(GtProjectExecutionGuard, SerializesPathlessProjects)
@@ -64,18 +64,18 @@ TEST(GtProjectExecutionGuard, ReacquiringReleasesPreviousProject)
 
     ASSERT_EQ(guard.tryAcquire(&first),
               GtProjectExecutionGuard::Result::Acquired);
-    ASSERT_TRUE(guard.isHeld());
+    ASSERT_TRUE(guard.isLocked());
     ASSERT_EQ(guard.tryAcquire(&second),
               GtProjectExecutionGuard::Result::Acquired);
 
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&first));
-    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&second));
-    EXPECT_EQ(guard.key(),
+    EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&first));
+    EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&second));
+    EXPECT_EQ(guard.projectKey(),
               GtProjectExecutionGuard::projectKey(&second));
 
     guard.release();
     guard.release();
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&second));
+    EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&second));
 }
 
 TEST(GtProjectExecutionGuard, SerializesSameProjectAndReleases)
@@ -86,12 +86,12 @@ TEST(GtProjectExecutionGuard, SerializesSameProjectAndReleases)
 
     EXPECT_EQ(first.tryAcquire(&project),
               GtProjectExecutionGuard::Result::Acquired);
-    EXPECT_TRUE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_TRUE(GtProjectExecutionGuard::isLocked(&project));
     EXPECT_EQ(second.tryAcquire(&project),
               GtProjectExecutionGuard::Result::Busy);
 
     first.release();
-    EXPECT_FALSE(GtProjectExecutionGuard::isBusy(&project));
+    EXPECT_FALSE(GtProjectExecutionGuard::isLocked(&project));
     EXPECT_EQ(second.tryAcquire(&project),
               GtProjectExecutionGuard::Result::Acquired);
 }


### PR DESCRIPTION
## Motivation and scope

GTlab Core currently assumes a single globally selected project in many code paths. This works for the desktop application, but prevents the process engine from safely serving multiple independent projects in a headless runtime or backend service.

The long-term goal is a multi-project runtime in which tasks for different projects can be submitted and executed independently, including through an asynchronous service API. The existing desktop GUI and legacy modules must remain compatible during this migration.

This pull request is the first compatibility-focused step toward that goal. It does not implement the complete runtime or service API. Instead, it:

- separates the execution project from the project selected in the desktop UI;
- introduces an execution-scoped project context;
- preserves existing `currentProject()`-based calculators;
- prevents concurrent mutations of the same project; and
- allows executions for different projects to proceed independently.

Runtime lifecycle management, asynchronous task handles, worker orchestration, multi-process coordination, and the web/backend API remain follow-up work.

## Description

This pull request implements the complete first slice of Epic #1507 (#1508-#1513): compatibility-first project context for multi-project services.

Existing calculators can continue to use `gtApp->currentProject()` without source changes. Without an active execution context, `currentProject()` resolves to the selected GUI/session project. During Core execution, an active `GtExecutionContext` takes precedence: it resolves to the execution project, while an active path-only context deliberately returns `nullptr` and does not fall back to the GUI-selected project.

The change also introduces per-project mutation serialization and deterministic protection for project save/close operations. Projects with a path are identified by their canonical path; pathless projects use their UUID, with a process-local object identity as the final fallback. Batch/headless behavior is preserved.

The compatibility-baseline document is intentionally temporary. It documents the current transition and recommended explicit context API; integration into the regular developer documentation is tracked as follow-up issue #1518.

API and ABI compatibility:

- Existing `currentProject()` call sites and legacy calculator source remain source-compatible.
- The new public `GtExecutionContext`, `GtExecutionContextScope`, and `GtProjectExecutionGuard` types are exported through the Core export mechanism.
- The public `GtExecutionContext` API was intentionally reduced to a borrowed project pointer and project path.
- Existing public methods remain available; no existing module-facing API is removed or renamed.
- The legacy `GtRunnable(QString)` constructor remains available, while the context-aware constructor is additive.
- The change is not presented as drop-in ABI-compatible for already compiled consumers: adding execution-context state to `GtRunnable` changes its class layout, so dependent binaries must be rebuilt. The existing Core executor keeps its state behind its private implementation boundary.

The end-to-end regression scenario uses two projects and a legacy calculator. It verifies that a running execution keeps its project context even when the GUI-selected project changes, while same-project writes remain serialized and different projects can execute independently.

Related issues: #1507, #1508, #1509, #1510, #1511, #1512, #1513

## How Has This Been Tested?

- Focused context, runnable, executor, and project-guard tests: 25 passed, including the path-only context and guard-cleanup regression tests.
- Full `GTlabUnitTest --gtest_shuffle --gtest_random_seed=1514`: completed without test failures; the existing Windows file-locking test remains skipped.
- Developer documentation built successfully.
- Final CI status for commit `53a3aeae`: Ubuntu, Windows, Linux coverage, documentation, user documentation, license compliance, and Sourcery review passed. Qt6/Windows and the GitLab mirror checks were still pending when this description was updated.

## Checklist:

- [x] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the user's point of view.
- [x] The new code complies with the GTlab's style guide.
- [x] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [x] The number of code quality warnings is not increasing.

## Summary by Sourcery

Introduce execution-scoped project resolution and per-project mutation serialization as the compatibility foundation for multi-project Core execution.

New Features:
- Add execution-scoped project contexts that let Core code resolve the active project independently of the GUI-selected project.
- Add process-local per-project execution guards that serialize mutations and permit concurrent execution of different projects.
- Expose execution results so callers can distinguish started, queued, busy, and invalid tasks.

Bug Fixes:
- Prevent project saves and closes from occurring while the project is being executed.
- Ensure execution guards and contexts are released or restored when runs finish, fail, or unwind.

Enhancements:
- Preserve existing currentProject()-based calculator behavior while prioritizing an active execution context and supporting path-only contexts without GUI fallback.
- Maintain the legacy runnable constructor and custom project-path behavior while adding context-aware execution support.

Documentation:
- Add a temporary developer migration guide describing project-context compatibility and explicit context usage.
- Document execution-context project resolution in the changelog and developer documentation index.

Tests:
- Add regression coverage for context scoping, nesting, thread isolation, runnable compatibility, project locking, executor lifecycle cleanup, and independent multi-project execution.