### PR TITLE
Bool property activation in property connector

### DIFF
--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -109,10 +109,16 @@ GtProcessPropertyPortEntity::connectPort(
         GtProcessPropertyConnectionEntity* connection)
 {
     // check connection
-    if (!connection) return false;
+    if (!connection)
+    {
+        return false;
+    }
 
     // check whether connection already exists
-    if (m_connections.contains(connection)) return false;
+    if (m_connections.contains(connection))
+    {
+        return false;
+    }
 
     // check port type
     if (m_type == GtProcessPropertyPortEntity::INPUT_PORT)
@@ -274,7 +280,10 @@ GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
 QVariant
 GtProcessPropertyPortEntity::propertyValue()
 {
-    if (!m_item) return {};
+    if (!m_item)
+    {
+        return QString();
+    }
 
     return m_item->propertyValue();
 }
@@ -282,7 +291,10 @@ GtProcessPropertyPortEntity::propertyValue()
 QString
 GtProcessPropertyPortEntity::propertyClassName()
 {
-    if (!m_item) return {};
+    if (!m_item)
+    {
+        return QString();
+    }
 
     return m_item->propertyClassName();
 }
@@ -290,7 +302,10 @@ GtProcessPropertyPortEntity::propertyClassName()
 QString
 GtProcessPropertyPortEntity::parentComponentUuid()
 {
-    if (!m_item) return {};
+    if (!m_item)
+    {
+        return QString();
+    }
 
     return m_item->parentComponentUuid();
 }
@@ -298,7 +313,10 @@ GtProcessPropertyPortEntity::parentComponentUuid()
 QString
 GtProcessPropertyPortEntity::propertyId()
 {
-    if (!m_item) return {};
+    if (!m_item)
+    {
+        return QString();
+    }
 
     return m_item->propertyId();
 }

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -109,16 +109,10 @@ GtProcessPropertyPortEntity::connectPort(
         GtProcessPropertyConnectionEntity* connection)
 {
     // check connection
-    if (!connection)
-    {
-        return false;
-    }
+    if (!connection) return false;
 
     // check whether connection already exists
-    if (m_connections.contains(connection))
-    {
-        return false;
-    }
+    if (m_connections.contains(connection)) return false;
 
     // check port type
     if (m_type == GtProcessPropertyPortEntity::INPUT_PORT)
@@ -280,10 +274,7 @@ GtProcessPropertyPortEntity::canConnect(GtProcessPropertyPortEntity* port)
 QVariant
 GtProcessPropertyPortEntity::propertyValue()
 {
-    if (!m_item)
-    {
-        return QVariant();
-    }
+    if (!m_item) return {};
 
     return m_item->propertyValue();
 }
@@ -291,10 +282,7 @@ GtProcessPropertyPortEntity::propertyValue()
 QString
 GtProcessPropertyPortEntity::propertyClassName()
 {
-    if (!m_item)
-    {
-        return QString();
-    }
+    if (!m_item) return {};
 
     return m_item->propertyClassName();
 }
@@ -302,10 +290,7 @@ GtProcessPropertyPortEntity::propertyClassName()
 QString
 GtProcessPropertyPortEntity::parentComponentUuid()
 {
-    if (!m_item)
-    {
-        return QString();
-    }
+    if (!m_item) return {};
 
     return m_item->parentComponentUuid();
 }
@@ -313,10 +298,7 @@ GtProcessPropertyPortEntity::parentComponentUuid()
 QString
 GtProcessPropertyPortEntity::propertyId()
 {
-    if (!m_item)
-    {
-        return QString();
-    }
+    if (!m_item) return {};
 
     return m_item->propertyId();
 }

--- a/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
+++ b/src/app/mdi_items/process_env/entities/gt_processpropertyportentity.cpp
@@ -282,7 +282,7 @@ GtProcessPropertyPortEntity::propertyValue()
 {
     if (!m_item)
     {
-        return QString();
+        return QVariant();
     }
 
     return m_item->propertyValue();

--- a/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
@@ -254,7 +254,7 @@ GtProcessConnectionItem::data(int column, int role)
     }
     }
 
-    return {};;
+    return {};
 }
 
 QString
@@ -265,7 +265,7 @@ GtProcessConnectionItem::componentUuid()
         if (m_component) return m_component->uuid();
     }
 
-    return {};;
+    return {};
 }
 
 QString
@@ -303,7 +303,7 @@ GtProcessConnectionItem::propertyId()
         }
     }
 
-    return QString{};
+    return {};
 }
 
 QVariant

--- a/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
@@ -39,7 +39,8 @@ QStringList GtProcessConnectionItem::m_acceptedPropertyTypes =
                          GT_CLASSNAME(GtIntProperty) <<
                          GT_CLASSNAME(GtObjectLinkProperty) <<
                          GT_CLASSNAME(GtStringProperty) <<
-                         GT_CLASSNAME(GtStringMonitoringProperty);
+                         GT_CLASSNAME(GtStringMonitoringProperty) <<
+                         GT_CLASSNAME(GtBoolProperty);
 
 GtProcessConnectionItem::GtProcessConnectionItem(GtProcessComponent* comp) :
     m_component(comp),
@@ -249,6 +250,12 @@ GtProcessConnectionItem::data(int column, int role)
                     {
                         return gt::gui::icon::letter::s();
                     }
+
+                    if (qobject_cast<GtBoolProperty*>(m_property))
+                    {
+                        return gt::gui::icon::letter::b();
+                    }
+
                 }
 
             }

--- a/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
+++ b/src/app/mdi_items/process_env/gt_processconnectionitem.cpp
@@ -116,30 +116,21 @@ GtProcessConnectionItem::data(int column, int role)
             {
                 if (m_type == GtProcessConnectionItem::PROCESS_COMPONENT)
                 {
-                    if (!m_component)
-                    {
-                        return QVariant();
-                    }
+                    if (!m_component) return {};
 
                     return m_component->objectName();
                 }
 
                 if (m_type == GtProcessConnectionItem::PROPERTY_CONTAINER)
                 {
-                    if (!m_container)
-                    {
-                        return QVariant();
-                    }
+                    if (!m_container) return {};
 
                     return m_container->name();
                 }
 
                 if (m_type == GtProcessConnectionItem::CONTAINER_ENTRY)
                 {
-                    if (!m_containerEntry || !m_container)
-                    {
-                        return QVariant();
-                    }
+                    if (!m_containerEntry || !m_container) return {};
 
                     auto iter = m_container->findEntry(m_containerEntry->ident());
                     // cppcheck-suppress assertWithSideEffect
@@ -147,10 +138,7 @@ GtProcessConnectionItem::data(int column, int role)
                     return m_container->entryDisplayName(iter);
                 }
 
-                if (!m_property)
-                {
-                    return QVariant();
-                }
+                if (!m_property) return {};
 
                 return m_property->objectName();
 
@@ -164,10 +152,7 @@ GtProcessConnectionItem::data(int column, int role)
             {
                 if (m_type == GtProcessConnectionItem::PROCESS_COMPONENT)
                 {
-                    if (!m_component)
-                    {
-                        return QVariant();
-                    }
+                    if (!m_component) return {};
 
                     if (qobject_cast<GtCalculator*>(m_component))
                     {
@@ -176,14 +161,11 @@ GtProcessConnectionItem::data(int column, int role)
                         GtCalculatorData calcData =
                             gtCalculatorFactory->calculatorData(className);
 
-                        GtExtendedCalculatorDataImpl* eData =
+                        auto* eData =
                             dynamic_cast<GtExtendedCalculatorDataImpl*>(
                                 calcData.get());
 
-                        if (eData)
-                        {
-                            return eData->icon;
-                        }
+                        if (eData) return eData->icon;
 
                         return gt::gui::icon::calculator();
 
@@ -197,10 +179,7 @@ GtProcessConnectionItem::data(int column, int role)
                             QVariant value = oui->data(m_component, role,
                                                        column);
 
-                            if (value.isValid())
-                            {
-                                return value;
-                            }
+                            if (value.isValid()) return value;
                         }
                         else
                         {
@@ -208,10 +187,7 @@ GtProcessConnectionItem::data(int column, int role)
                             QVariant value = oui2.data(m_component, role,
                                                        column);
 
-                            if (value.isValid())
-                            {
-                                return value;
-                            }
+                            if (value.isValid()) return value;
                         }
                     }
                 }
@@ -228,7 +204,7 @@ GtProcessConnectionItem::data(int column, int role)
                             return gt::gui::icon::arrowDown();
                         }
 
-                        return QVariant();
+                        return {};
                     }
 
                     if (qobject_cast<GtDoubleProperty*>(m_property))
@@ -255,7 +231,6 @@ GtProcessConnectionItem::data(int column, int role)
                     {
                         return gt::gui::icon::letter::b();
                     }
-
                 }
 
             }
@@ -270,22 +245,16 @@ GtProcessConnectionItem::data(int column, int role)
             if (m_type == GtProcessConnectionItem::MONITORING_PROPERTY ||
                     m_type == GtProcessConnectionItem::DEFAULT_PROPERTY)
             {
-                if (!m_property)
-                {
-                    return false;
-                }
+                if (!m_property) return false;
 
                 return propertyTypeAccepted(m_property);
             }
-            else
-            {
-                return false;
-            }
+            else return false;
         }
     }
     }
 
-    return QVariant();
+    return {};;
 }
 
 QString
@@ -293,32 +262,22 @@ GtProcessConnectionItem::componentUuid()
 {
     if (m_type == GtProcessConnectionItem::PROCESS_COMPONENT)
     {
-        if (m_component)
-        {
-            return m_component->uuid();
-        }
+        if (m_component) return m_component->uuid();
     }
 
-    return QString();
+    return {};;
 }
 
 QString
 GtProcessConnectionItem::parentComponentUuid()
 {
-    if (m_component)
-    {
-        return m_component->uuid();
-    }
+    if (m_component) return m_component->uuid();
 
     // get parent component item
-    GtProcessConnectionItem* parentComp =
-            qobject_cast<GtProcessConnectionItem*>(parent());
+    auto* parentComp = qobject_cast<GtProcessConnectionItem*>(parent());
 
     // check parent component item
-    if (!parentComp)
-    {
-        return QString();
-    }
+    if (!parentComp) return {};
 
     return parentComp->componentUuid();
 }
@@ -342,11 +301,9 @@ GtProcessConnectionItem::propertyId()
         {
             return GtPropertyReference(m_property->ident()).toString();
         }
-
-
     }
 
-    return QString();
+    return QString{};
 }
 
 QVariant
@@ -361,7 +318,7 @@ GtProcessConnectionItem::propertyValue()
         }
     }
 
-    return QVariant();
+    return {};
 }
 
 QString
@@ -373,48 +330,31 @@ GtProcessConnectionItem::propertyClassName()
         if (m_property)
         {
             return m_property->metaObject()->className();
-            //return GT_CLASSNAME(m_property->metaObject()->c);
         }
     }
 
-    return QString();
+    return {};
 }
 
 GtProcessConnectionItem*
 GtProcessConnectionItem::itemById(const QString& uuid, const QString& propId)
 {
     // check uuid
-    if (uuid.isEmpty())
-    {
-        return nullptr;
-    }
+    if (uuid.isEmpty()) return nullptr;
 
     // check property id
-    if (propId.isEmpty())
-    {
-        return nullptr;
-    }
+    if (propId.isEmpty()) return nullptr;
 
     // check item type
     if (m_type != GtProcessConnectionItem::PROCESS_COMPONENT)
     {
-        if (propertyId() != propId)
-        {
-            return nullptr;
-        }
+        if (propertyId() != propId) return nullptr;
 
-        GtProcessConnectionItem* parentItem =
-                qobject_cast<GtProcessConnectionItem*>(parent());
+        auto* parentItem = qobject_cast<GtProcessConnectionItem*>(parent());
 
-        if (!parentItem)
-        {
-            return nullptr;
-        }
+        if (!parentItem) return nullptr;
 
-        if (parentItem->componentUuid() == uuid)
-        {
-            return this;
-        }
+        if (parentItem->componentUuid() == uuid) return this;
     }
 
     // iterate over children
@@ -423,10 +363,7 @@ GtProcessConnectionItem::itemById(const QString& uuid, const QString& propId)
     {
         GtProcessConnectionItem* retval = child->itemById(uuid, propId);
 
-        if (retval)
-        {
-            return retval;
-        }
+        if (retval) return retval;
     }
 
     return nullptr;


### PR DESCRIPTION
The introduced changes activate bool properties in the connection editor.

There is needed some discussion how to handle this in detail as some default properties, like "Skip" are then added to the property connection editor as well.

Now it looks like this:

<img width="784" height="385" alt="image" src="https://github.com/user-attachments/assets/63df4e04-6ff0-43d5-82c0-d7a3070a3cd8" />


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Activate boolean properties for selection in the process property connection editor.

New Features:
- Enable boolean properties in the process connection editor and identify them with a dedicated icon.

Enhancements:
- Simplify connection item data access and empty-value handling without changing behavior.