### PR TITLE
Fix typo in 'Company' label in process info dialog

### DIFF
--- a/src/gui/dock_widgets/process/pages/gt_processinfodialog.cpp
+++ b/src/gui/dock_widgets/process/pages/gt_processinfodialog.cpp
@@ -97,7 +97,7 @@ GtProcessInfoPopup::GtProcessInfoPopup(
         addLine(tr("Contact"), processInfos.contact);
 
     if (processInfos.company != "-")
-        addLine(tr("Copany"), processInfos.company);
+        addLine(tr("Company"), processInfos.company);
 
     cardLayout->addWidget(header);
     cardLayout->addWidget(content);


### PR DESCRIPTION
Fix of a typo

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] A test for the new functionality was added (if applicable).
- [ ] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [ ] The new code complies with the GTlab's style guide.
- [ ] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [ ] The number of code quality warnings is not increasing.

## Summary by Sourcery

Bug Fixes:
- Correct the misspelled “Company” label in the process information dialog.