### PR TITLE
Fix concurrent module loading on 2.0.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ As such, many functions needed to be deprecated and should be replaced according
     - Replace `gt::re::XXX` with `gt::rex::XXX` (just replace the namespace)
 
 ### Fixed
+ - Fixed modules being incorrectly disabled when multiple GTlab instances start concurrently. - #1538
  - Connecting GtStringMonitoringProperty to GtStringProperty in the connection editor now works as expected - #1379
  - Fixed Output Dock not resizing new rows correctly. - #1260
  - Fixed crash in Process Explorer, when no project is currently open. - #1393

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -194,6 +194,9 @@ getMatchedModuleIds(const QString& dependency,
 
 } // namespace
 
+QStringList getSortedModulesToLoad(const QStringList& modulesIdsToLoad,
+                                   const ModuleMetaMap& metaMap);
+
 class ModuleLoadingLock
 {
 public:
@@ -247,7 +250,7 @@ public:
      * @return
      */
     bool performLoading(GtModuleLoader& moduleLoader,
-                        const QStringList& modulesToLoad,
+                        const QStringList& sortedModuleIds,
                         const ModuleMetaMap &metaMap,
                         QStringList& failedModules);
     /**
@@ -566,6 +569,24 @@ ModuleMetaData loadModuleMeta(const QString& moduleFileName)
     return meta;
 }
 
+ModuleMetaMap
+filterCrashedModules(const ModuleMetaMap& metaData)
+{
+    const auto crashedModules = CrashedModulesLog().crashedModules();
+
+    return filterModules(metaData, [&](const ModuleMetaData& m){
+        if (crashedModules.contains(m.location()))
+        {
+            logWarnOnce(
+                QObject::tr("Module '%1' caused a crash in a previous run. "
+                            "Skipping module!").arg(m.moduleId())
+            );
+            return false;
+        }
+        return true;
+    });
+}
+
 ModuleMetaMap loadModuleMeta()
 {
     std::map<QString, ModuleMetaData> metaData;
@@ -589,21 +610,6 @@ ModuleMetaMap loadModuleMeta()
                      insertResult.first->second.location()));
         }
     }
-
-    const auto crashed_mods = CrashedModulesLog().crashedModules();
-
-    // Remove all modules, that have been crashed earlies
-    metaData = filterModules(metaData, [&](const ModuleMetaData& m){
-        if (crashed_mods.contains(m.location()))
-        {
-            logWarnOnce(
-                QObject::tr("Module '%1' caused a crash in a previous run. "
-                            "Skipping module!").arg(m.moduleId())
-            );
-            return false;
-        }
-        return true;
-    });
 
     // Remove all modules, that should be exluded
     const auto excludeList = getModulesToExclude();
@@ -632,13 +638,6 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
         gtError() << QObject::tr("Cannot load module. "
                                  "Module File '%1' does not exists.")
                          .arg(moduleLocation);
-        return false;
-    }
-
-    ModuleLoadingLock moduleLoadingLock;
-    if (!moduleLoadingLock.locked())
-    {
-        gtError() << QObject::tr("Cannot acquire the module loading lock.");
         return false;
     }
 
@@ -673,8 +672,39 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
         moduleMetaMap.insert(std::make_pair(moduleMeta.moduleId(), moduleMeta));
     }
 
+    const auto sortedModuleIds =
+        getSortedModulesToLoad(modulesToLoad, moduleMetaMap);
+
+    ModuleLoadingLock moduleLoadingLock;
+    if (!moduleLoadingLock.locked())
+    {
+        gtError() << QObject::tr("Cannot acquire the module loading lock.");
+        return false;
+    }
+
+    m_pimpl->m_metaData = filterCrashedModules(m_pimpl->m_metaData);
+    moduleMetaMap = m_pimpl->m_metaData;
+
+    const auto currentModuleIt = moduleMetaMap.find(moduleMeta.moduleId());
+    if (currentModuleIt != moduleMetaMap.end())
+    {
+        currentModuleIt->second = moduleMeta;
+    }
+    else
+    {
+        moduleMetaMap.insert(std::make_pair(moduleMeta.moduleId(), moduleMeta));
+    }
+
+    QStringList loadableModuleIds = sortedModuleIds;
+    loadableModuleIds.erase(
+        std::remove_if(loadableModuleIds.begin(), loadableModuleIds.end(),
+                       [&moduleMetaMap](const QString& moduleId){
+            return moduleMetaMap.find(moduleId) == moduleMetaMap.end();
+        }),
+        loadableModuleIds.end());
+
     QStringList failedModules;
-    if (!m_pimpl->performLoading(*this, modulesToLoad,
+    if (!m_pimpl->performLoading(*this, loadableModuleIds,
                                  moduleMetaMap, failedModules))
     {
         gtError().verbose() << QObject::tr("Some modules failed to load!");
@@ -688,6 +718,12 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
 void
 GtModuleLoader::load()
 {
+    m_pimpl->m_metaData = loadModuleMeta();
+
+    const auto allModulesIds = m_pimpl->getAllLoadableModuleIds();
+    const auto sortedModuleIds =
+        getSortedModulesToLoad(allModulesIds, m_pimpl->m_metaData);
+
     ModuleLoadingLock moduleLoadingLock;
     if (!moduleLoadingLock.locked())
     {
@@ -695,30 +731,29 @@ GtModuleLoader::load()
         return;
     }
 
-    m_pimpl->m_metaData = loadModuleMeta();
+    m_pimpl->m_metaData = filterCrashedModules(m_pimpl->m_metaData);
 
-    auto allModulesIds = m_pimpl->getAllLoadableModuleIds();
-    auto moduleMetaMap = m_pimpl->m_metaData;
+    QStringList loadableModuleIds = sortedModuleIds;
+    loadableModuleIds.erase(
+        std::remove_if(loadableModuleIds.begin(), loadableModuleIds.end(),
+                       [this](const QString& moduleId){
+            return m_pimpl->m_metaData.find(moduleId) ==
+                   m_pimpl->m_metaData.end();
+        }),
+        loadableModuleIds.end());
 
     QStringList failedModules;
-    if (!m_pimpl->performLoading(*this, allModulesIds,
-                                 moduleMetaMap, failedModules))
+    if (!m_pimpl->performLoading(*this, loadableModuleIds,
+                                 m_pimpl->m_metaData, failedModules))
     {
         gtError().verbose() << QObject::tr("Some modules failed to load!");
-        Impl::printDependencies(failedModules, moduleMetaMap);
+        Impl::printDependencies(failedModules, m_pimpl->m_metaData);
     }
 }
 
 QMap<QString, QString>
 GtModuleLoader::moduleEnvironmentVars()
 {
-    ModuleLoadingLock moduleLoadingLock;
-    if (!moduleLoadingLock.locked())
-    {
-        gtError() << QObject::tr("Cannot acquire the module loading lock.");
-        return {};
-    }
-
     auto moduleMeta = loadModuleMeta();
 
     QMap<QString, QString> retval;
@@ -1042,14 +1077,12 @@ getSortedModulesToLoad(const QStringList& modulesIdsToLoad,
 
 bool
 GtModuleLoader::Impl::performLoading(GtModuleLoader& moduleLoader,
-                                 const QStringList& moduleIds,
+                                 const QStringList& sortedModuleIds,
                                  const ModuleMetaMap& metaMap,
                                  QStringList& failedModules)
 {
     // initialize loading fail log
     CrashedModulesLog crashLog;
-
-    auto sortedModuleIds = getSortedModulesToLoad(moduleIds, metaMap);
 
     QStringList successfullyLoaded{};
 

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -233,6 +233,12 @@ private:
     bool m_locked{false};
 };
 
+enum class PreviousCrashPolicy
+{
+    Skip,
+    Ignore
+};
+
 class GtModuleLoader::Impl
 {
 public:
@@ -260,7 +266,9 @@ public:
     bool performLoading(GtModuleLoader& moduleLoader,
                         const QStringList& modulesToLoad,
                         const ModuleMetaMap &metaMap,
-                        QStringList& failedModules);
+                        QStringList& failedModules,
+                        PreviousCrashPolicy previousCrashPolicy =
+                            PreviousCrashPolicy::Skip);
     /**
      * @brief checkDependency
      * The dependencies of the module are given by a list and are compared
@@ -618,6 +626,32 @@ ModuleMetaMap loadModuleMeta()
     return metaData;
 }
 
+ModuleMetaMap
+loadModuleMetaExcludingCrashed()
+{
+    auto metaData = loadModuleMeta();
+
+    ModuleLoadingLock moduleLoadingLock;
+    if (!moduleLoadingLock.locked())
+    {
+        gtError() << QObject::tr("Cannot acquire the module loading lock.");
+        return {};
+    }
+
+    const auto crashedModules = CrashedModulesLog().crashedModules();
+    return filterModules(metaData, [&](const ModuleMetaData& moduleMeta){
+        if (crashedModules.contains(moduleMeta.location()))
+        {
+            logWarnOnce(
+                QObject::tr("Module '%1' caused a crash in a previous run. "
+                            "Skipping module!").arg(moduleMeta.moduleId())
+            );
+            return false;
+        }
+        return true;
+    });
+}
+
 } // namespace
 
 bool
@@ -659,7 +693,8 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
 
     QStringList failedModules;
     if (!m_pimpl->performLoading(*this, modulesToLoad,
-                                 moduleMetaMap, failedModules))
+                                 moduleMetaMap, failedModules,
+                                 PreviousCrashPolicy::Ignore))
     {
         gtError().verbose() << QObject::tr("Some modules failed to load!");
         Impl::printDependencies(failedModules, moduleMetaMap);
@@ -687,7 +722,7 @@ GtModuleLoader::load()
 QMap<QString, QString>
 GtModuleLoader::moduleEnvironmentVars()
 {
-    auto moduleMeta = loadModuleMeta();
+    auto moduleMeta = loadModuleMetaExcludingCrashed();
 
     QMap<QString, QString> retval;
     for (const auto& mod : moduleMeta)
@@ -1012,7 +1047,8 @@ bool
 GtModuleLoader::Impl::performLoading(GtModuleLoader& moduleLoader,
                                  const QStringList& moduleIds,
                                  const ModuleMetaMap& metaMap,
-                                 QStringList& failedModules)
+                                 QStringList& failedModules,
+                                 PreviousCrashPolicy previousCrashPolicy)
 {
     auto sortedModuleIds = getSortedModulesToLoad(moduleIds, metaMap);
 
@@ -1037,7 +1073,8 @@ GtModuleLoader::Impl::performLoading(GtModuleLoader& moduleLoader,
 
         const ModuleMetaData& moduleMeta = moduleIt->second;
 
-        if (crashedModules.contains(moduleMeta.location()))
+        if (previousCrashPolicy == PreviousCrashPolicy::Skip &&
+            crashedModules.contains(moduleMeta.location()))
         {
             logWarnOnce(
                 QObject::tr("Module '%1' caused a crash in a previous run. "

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -30,6 +30,7 @@
 #include <QJsonObject>
 #include <QSettings>
 #include <QLockFile>
+#include <QThread>
 #include <QDomElement>
 
 #include "gt_algorithms.h"
@@ -194,9 +195,6 @@ getMatchedModuleIds(const QString& dependency,
 
 } // namespace
 
-QStringList getSortedModulesToLoad(const QStringList& modulesIdsToLoad,
-                                   const ModuleMetaMap& metaMap);
-
 class ModuleLoadingLock
 {
 public:
@@ -204,7 +202,17 @@ public:
         m_lockFile(GtCoreApplication::localApplicationIniFilePath() +
                    QStringLiteral(".module-loading.lock"))
     {
-        m_locked = m_lockFile.lock();
+        while (!m_lockFile.tryLock(0))
+        {
+            if (m_lockFile.error() != QLockFile::LockFailedError)
+            {
+                return;
+            }
+
+            QThread::msleep(10);
+        }
+
+        m_locked = true;
     }
 
     ~ModuleLoadingLock()
@@ -234,7 +242,7 @@ public:
     /// Mapping of suppressed plugins to their suppressors
     QMap<QString, QSet<QString>> m_suppressedPlugins;
 
-    ModuleMetaMap m_metaData;
+    const std::map<QString, ModuleMetaData> m_metaData{loadModuleMeta()};
 
     /// Modules initialized indicator.
     bool m_modulesInitialized{false};
@@ -250,7 +258,7 @@ public:
      * @return
      */
     bool performLoading(GtModuleLoader& moduleLoader,
-                        const QStringList& sortedModuleIds,
+                        const QStringList& modulesToLoad,
                         const ModuleMetaMap &metaMap,
                         QStringList& failedModules);
     /**
@@ -569,24 +577,6 @@ ModuleMetaData loadModuleMeta(const QString& moduleFileName)
     return meta;
 }
 
-ModuleMetaMap
-filterCrashedModules(const ModuleMetaMap& metaData)
-{
-    const auto crashedModules = CrashedModulesLog().crashedModules();
-
-    return filterModules(metaData, [&](const ModuleMetaData& m){
-        if (crashedModules.contains(m.location()))
-        {
-            logWarnOnce(
-                QObject::tr("Module '%1' caused a crash in a previous run. "
-                            "Skipping module!").arg(m.moduleId())
-            );
-            return false;
-        }
-        return true;
-    });
-}
-
 ModuleMetaMap loadModuleMeta()
 {
     std::map<QString, ModuleMetaData> metaData;
@@ -652,11 +642,6 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
 
     const QStringList modulesToLoad{moduleMeta.moduleId()};
 
-    if (m_pimpl->m_metaData.empty())
-    {
-        m_pimpl->m_metaData = loadModuleMeta();
-    }
-
     // the meta data from the module directory
     auto moduleMetaMap = m_pimpl->m_metaData;
 
@@ -672,39 +657,8 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
         moduleMetaMap.insert(std::make_pair(moduleMeta.moduleId(), moduleMeta));
     }
 
-    const auto sortedModuleIds =
-        getSortedModulesToLoad(modulesToLoad, moduleMetaMap);
-
-    ModuleLoadingLock moduleLoadingLock;
-    if (!moduleLoadingLock.locked())
-    {
-        gtError() << QObject::tr("Cannot acquire the module loading lock.");
-        return false;
-    }
-
-    m_pimpl->m_metaData = filterCrashedModules(m_pimpl->m_metaData);
-    moduleMetaMap = m_pimpl->m_metaData;
-
-    const auto currentModuleIt = moduleMetaMap.find(moduleMeta.moduleId());
-    if (currentModuleIt != moduleMetaMap.end())
-    {
-        currentModuleIt->second = moduleMeta;
-    }
-    else
-    {
-        moduleMetaMap.insert(std::make_pair(moduleMeta.moduleId(), moduleMeta));
-    }
-
-    QStringList loadableModuleIds = sortedModuleIds;
-    loadableModuleIds.erase(
-        std::remove_if(loadableModuleIds.begin(), loadableModuleIds.end(),
-                       [&moduleMetaMap](const QString& moduleId){
-            return moduleMetaMap.find(moduleId) == moduleMetaMap.end();
-        }),
-        loadableModuleIds.end());
-
     QStringList failedModules;
-    if (!m_pimpl->performLoading(*this, loadableModuleIds,
+    if (!m_pimpl->performLoading(*this, modulesToLoad,
                                  moduleMetaMap, failedModules))
     {
         gtError().verbose() << QObject::tr("Some modules failed to load!");
@@ -718,36 +672,15 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
 void
 GtModuleLoader::load()
 {
-    m_pimpl->m_metaData = loadModuleMeta();
-
-    const auto allModulesIds = m_pimpl->getAllLoadableModuleIds();
-    const auto sortedModuleIds =
-        getSortedModulesToLoad(allModulesIds, m_pimpl->m_metaData);
-
-    ModuleLoadingLock moduleLoadingLock;
-    if (!moduleLoadingLock.locked())
-    {
-        gtError() << QObject::tr("Cannot acquire the module loading lock.");
-        return;
-    }
-
-    m_pimpl->m_metaData = filterCrashedModules(m_pimpl->m_metaData);
-
-    QStringList loadableModuleIds = sortedModuleIds;
-    loadableModuleIds.erase(
-        std::remove_if(loadableModuleIds.begin(), loadableModuleIds.end(),
-                       [this](const QString& moduleId){
-            return m_pimpl->m_metaData.find(moduleId) ==
-                   m_pimpl->m_metaData.end();
-        }),
-        loadableModuleIds.end());
+    auto allModulesIds = m_pimpl->getAllLoadableModuleIds();
+    auto moduleMetaMap = m_pimpl->m_metaData;
 
     QStringList failedModules;
-    if (!m_pimpl->performLoading(*this, loadableModuleIds,
-                                 m_pimpl->m_metaData, failedModules))
+    if (!m_pimpl->performLoading(*this, allModulesIds,
+                                 moduleMetaMap, failedModules))
     {
         gtError().verbose() << QObject::tr("Some modules failed to load!");
-        Impl::printDependencies(failedModules, m_pimpl->m_metaData);
+        Impl::printDependencies(failedModules, moduleMetaMap);
     }
 }
 
@@ -1077,14 +1010,24 @@ getSortedModulesToLoad(const QStringList& modulesIdsToLoad,
 
 bool
 GtModuleLoader::Impl::performLoading(GtModuleLoader& moduleLoader,
-                                 const QStringList& sortedModuleIds,
+                                 const QStringList& moduleIds,
                                  const ModuleMetaMap& metaMap,
                                  QStringList& failedModules)
 {
-    // initialize loading fail log
+    auto sortedModuleIds = getSortedModulesToLoad(moduleIds, metaMap);
+
+    ModuleLoadingLock moduleLoadingLock;
+    if (!moduleLoadingLock.locked())
+    {
+        gtError() << QObject::tr("Cannot acquire the module loading lock.");
+        return false;
+    }
+
     CrashedModulesLog crashLog;
+    const auto crashedModules = crashLog.crashedModules();
 
     QStringList successfullyLoaded{};
+    QStringList previouslyCrashed{};
 
     // loading procedure
     for (const auto& currentModuleId : qAsConst(sortedModuleIds))
@@ -1093,6 +1036,16 @@ GtModuleLoader::Impl::performLoading(GtModuleLoader& moduleLoader,
         assert(moduleIt != metaMap.end());
 
         const ModuleMetaData& moduleMeta = moduleIt->second;
+
+        if (crashedModules.contains(moduleMeta.location()))
+        {
+            logWarnOnce(
+                QObject::tr("Module '%1' caused a crash in a previous run. "
+                            "Skipping module!").arg(moduleMeta.moduleId())
+            );
+            previouslyCrashed.push_back(currentModuleId);
+            continue;
+        }
 
         if (isSuppressed(moduleMeta) || !dependenciesOkay(moduleMeta))
         {
@@ -1131,8 +1084,14 @@ GtModuleLoader::Impl::performLoading(GtModuleLoader& moduleLoader,
 
     failedModules = std::move(sortedModuleIds);
 
-    // remove successfully loaded from sortedModuleIds
+    // remove modules which were successfully loaded or skipped because
+    // they crashed during a previous run
     for (const auto& modId : qAsConst(successfullyLoaded))
+    {
+        failedModules.removeAll(modId);
+    }
+
+    for (const auto& modId : qAsConst(previouslyCrashed))
     {
         failedModules.removeAll(modId);
     }

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -201,16 +201,25 @@ public:
         m_lockFile(GtCoreApplication::localApplicationIniFilePath() +
                    QStringLiteral(".module-loading.lock"))
     {
-        m_lockFile.lock();
+        m_locked = m_lockFile.lock();
     }
 
     ~ModuleLoadingLock()
     {
-        m_lockFile.unlock();
+        if (m_locked)
+        {
+            m_lockFile.unlock();
+        }
+    }
+
+    bool locked() const
+    {
+        return m_locked;
     }
 
 private:
     QLockFile m_lockFile;
+    bool m_locked{false};
 };
 
 class GtModuleLoader::Impl
@@ -627,6 +636,11 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
     }
 
     ModuleLoadingLock moduleLoadingLock;
+    if (!moduleLoadingLock.locked())
+    {
+        gtError() << QObject::tr("Cannot acquire the module loading lock.");
+        return false;
+    }
 
     const auto moduleMeta = loadModuleMeta(moduleLocation);
     if (moduleMeta.moduleId().isEmpty())
@@ -675,6 +689,11 @@ void
 GtModuleLoader::load()
 {
     ModuleLoadingLock moduleLoadingLock;
+    if (!moduleLoadingLock.locked())
+    {
+        gtError() << QObject::tr("Cannot acquire the module loading lock.");
+        return;
+    }
 
     m_pimpl->m_metaData = loadModuleMeta();
 
@@ -694,6 +713,11 @@ QMap<QString, QString>
 GtModuleLoader::moduleEnvironmentVars()
 {
     ModuleLoadingLock moduleLoadingLock;
+    if (!moduleLoadingLock.locked())
+    {
+        gtError() << QObject::tr("Cannot acquire the module loading lock.");
+        return {};
+    }
 
     auto moduleMeta = loadModuleMeta();
 

--- a/src/core/gt_moduleloader.cpp
+++ b/src/core/gt_moduleloader.cpp
@@ -29,6 +29,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QSettings>
+#include <QLockFile>
 #include <QDomElement>
 
 #include "gt_algorithms.h"
@@ -193,6 +194,25 @@ getMatchedModuleIds(const QString& dependency,
 
 } // namespace
 
+class ModuleLoadingLock
+{
+public:
+    ModuleLoadingLock() :
+        m_lockFile(GtCoreApplication::localApplicationIniFilePath() +
+                   QStringLiteral(".module-loading.lock"))
+    {
+        m_lockFile.lock();
+    }
+
+    ~ModuleLoadingLock()
+    {
+        m_lockFile.unlock();
+    }
+
+private:
+    QLockFile m_lockFile;
+};
+
 class GtModuleLoader::Impl
 {
 public:
@@ -202,7 +222,7 @@ public:
     /// Mapping of suppressed plugins to their suppressors
     QMap<QString, QSet<QString>> m_suppressedPlugins;
 
-    const std::map<QString, ModuleMetaData> m_metaData{loadModuleMeta()};
+    ModuleMetaMap m_metaData;
 
     /// Modules initialized indicator.
     bool m_modulesInitialized{false};
@@ -606,6 +626,8 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
         return false;
     }
 
+    ModuleLoadingLock moduleLoadingLock;
+
     const auto moduleMeta = loadModuleMeta(moduleLocation);
     if (moduleMeta.moduleId().isEmpty())
     {
@@ -616,6 +638,11 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
     }
 
     const QStringList modulesToLoad{moduleMeta.moduleId()};
+
+    if (m_pimpl->m_metaData.empty())
+    {
+        m_pimpl->m_metaData = loadModuleMeta();
+    }
 
     // the meta data from the module directory
     auto moduleMetaMap = m_pimpl->m_metaData;
@@ -647,6 +674,10 @@ GtModuleLoader::loadSingleModule(const QString& moduleLocation)
 void
 GtModuleLoader::load()
 {
+    ModuleLoadingLock moduleLoadingLock;
+
+    m_pimpl->m_metaData = loadModuleMeta();
+
     auto allModulesIds = m_pimpl->getAllLoadableModuleIds();
     auto moduleMetaMap = m_pimpl->m_metaData;
 
@@ -662,6 +693,8 @@ GtModuleLoader::load()
 QMap<QString, QString>
 GtModuleLoader::moduleEnvironmentVars()
 {
+    ModuleLoadingLock moduleLoadingLock;
+
     auto moduleMeta = loadModuleMeta();
 
     QMap<QString, QString> retval;


### PR DESCRIPTION
## Description

Fixes #1538.

Serialize the shared `loading_crashed` transaction during actual module initialization with a `QLockFile` located next to `GTlab.ini`. Metadata discovery and dependency ordering remain lock-free; the lock covers only crash-marker access and plugin instantiation/initialization. A short linear retry avoids `QLockFile::lock()` backoff under concurrent startup.

The existing `GTlab.ini` format and crash-recovery behaviour remain unchanged. If a loading process terminates unexpectedly, its `loading_crashed` entry remains available to the next start.

## How Has This Been Tested?

- `cmake -S . -B build -DBUILD_TESTMODULES=ON && make -C build -j$(nproc)`
- `build/GTlabConsole enable_modules --all`
- Started ten `GTlabConsole --help` instances concurrently with the reproduction script from #1538.
  - All ten completed with exit code `0` (about 1.27 s wall-clock time).
  - No `caused a crash in a previous run`, `Cannot load module`, or `Some modules failed to load` entries occurred in captured stderr logs.

## Checklist:

- [ ] A test for the new functionality was added (not applicable; the regression is exercised through concurrent processes).
- [ ] All tests run without failure.
- [x] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [x] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [x] The number of code quality warnings is not increasing.

## Summary by Sourcery

Serialize concurrent module initialization to prevent false crash detection and incorrect module disabling.

Bug Fixes:
- Prevent modules from being incorrectly disabled when multiple GTlab instances start concurrently.
- Preserve crash-recovery behavior while avoiding false crash markers during concurrent module initialization.

Enhancements:
- Serialize crash-marker access and module initialization across concurrent GTlab processes while keeping metadata discovery and dependency ordering concurrent.