### PR TITLE
Add task memento diff and task state to run_task_from_memento

### DIFF
--- a/docs/user/headless/01_overview.rst
+++ b/docs/user/headless/01_overview.rst
@@ -23,9 +23,11 @@ process. The project input is the ``GtObjectGroup`` Memento produced by
        --project-memento project_memento.xml \
        --task-memento task.xml \
        --output-diff result.diff.xml \
+	   [--task-diff task.diff.xml] \
+	   [--task-state taskstate.json] \
        [--working-directory working_dir]
 
-The short option names are ``-p``, ``-t``, ``-o``, and ``-w``. If no working
+The short option names are ``-p``, ``-t``, ``-o``, ``-m``, ``-s`` and ``-w``. If no working
 directory is supplied, the directory containing the project Memento is used.
 During execution this directory is both the process working directory and the
 project path exposed by the execution context. Therefore existing calculators

--- a/src/batch/gt_consoleruntaskfrommemento.cpp
+++ b/src/batch/gt_consoleruntaskfrommemento.cpp
@@ -28,6 +28,9 @@
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <qjsondocument.h>
+#include <qjsonobject.h>
+#include <qmetaobject.h>
 
 namespace
 {
@@ -39,6 +42,79 @@ namespace
         {
         }
     };
+
+    int
+    checkFiles(const QFileInfo projectFile,
+               const QFileInfo taskFile,
+               const QString outputProjectFile,
+               const QString outputTaskDiffFile,
+               const QString outputTaskStateFile,
+               const QString workingDirectory )
+    {
+
+        if (outputProjectFile == projectFile.absoluteFilePath() ||
+            outputProjectFile == taskFile.absoluteFilePath())
+        {
+            gtError() << QObject::tr(
+                "Output project diff must not overwrite an input Memento");
+            return 2;
+        }
+
+        if (outputTaskDiffFile == projectFile.absoluteFilePath() ||
+            outputTaskDiffFile == taskFile.absoluteFilePath())
+        {
+            gtError() << QObject::tr(
+                "Output task diff must not overwrite an input Memento");
+            return 2;
+        }
+
+        if (outputTaskStateFile == projectFile.absoluteFilePath() ||
+            outputTaskStateFile == taskFile.absoluteFilePath())
+        {
+            gtError() << QObject::tr(
+                "Output task state must not overwrite an input Memento");
+            return 2;
+        }
+
+
+        if (!outputTaskDiffFile.isEmpty() &&
+            QStringList{outputProjectFile, outputTaskStateFile}.contains(outputTaskDiffFile))
+        {
+            gtError() << QObject::tr(
+                "Output files cannot have the same name");
+            return 2;
+        }
+
+        if (!outputTaskStateFile.isEmpty() &&
+            QStringList{outputProjectFile, outputTaskDiffFile}.contains(outputTaskStateFile))
+        {
+            gtError() << QObject::tr(
+                "Output files cannot have the same name");
+            return 2;
+        }
+
+
+        if (!projectFile.isFile())
+        {
+            gtError() << QObject::tr("Project Memento does not exist: %1")
+            .arg(projectFile.absoluteFilePath());
+            return 3;
+        }
+        if (!taskFile.isFile())
+        {
+            gtError() << QObject::tr("Task Memento does not exist: %1")
+            .arg(taskFile.absoluteFilePath());
+            return 3;
+        }
+        if (!QFileInfo(workingDirectory).isDir())
+        {
+            gtError() << QObject::tr("Working directory does not exist: %1")
+            .arg(workingDirectory);
+            return 3;
+        }
+
+        return 0;
+    }
 
     std::unique_ptr<GtObjectGroup> restoreProjectData(QString const& fileName)
     {
@@ -161,6 +237,41 @@ namespace
         return true;
     }
 
+    bool writeTaskState(QString const& fileName, QJsonObject const& taskstate)
+    {
+        if (fileName.isEmpty())
+        {
+            return true;
+        }
+
+        QJsonDocument statusOutputDoc(taskstate);
+
+        QSaveFile file(fileName);
+        if (!file.open(QIODevice::WriteOnly))
+        {
+            gtError() << QObject::tr("Cannot write output task state json '%1': %2")
+                             .arg(fileName, file.errorString());
+            return false;
+        }
+
+        if (file.write(statusOutputDoc.toJson(QJsonDocument::Indented)) == -1)
+        {
+            gtError() << QObject::tr("Cannot write complete output task state json '%1': %2")
+                             .arg(fileName, file.errorString());
+            file.cancelWriting();
+            return false;
+        }
+
+        if (!file.commit())
+        {
+            gtError() << QObject::tr("Cannot publish output task state json '%1': %2")
+                             .arg(fileName, file.errorString());
+            return false;
+        }
+
+        return true;
+    }
+
     bool removeExistingOutput(QString const& fileName)
     {
         QFile outputFile(fileName);
@@ -186,11 +297,16 @@ gt::console::runTaskFromMementoOptions()
 {
     return {{{"project-memento", "p"}, "Serialized project-data Memento path"},
             {{"task-memento", "t"}, "Serialized task Memento path"},
-            {{"output-diff", "o"}, "Output Memento-Diff path"},
+            {{"output-diff", "o"}, "Output Project Memento-Diff path"},
+            {{"task-diff", "m"}, "Output Task Memento-Diff path"},
+            {{"task-state", "s"}, "Output Task State path"},
             {{"working-directory", "w"},
              "Execution working directory (defaults to project Memento "
              "directory)"}};
 }
+
+
+
 
 int
 gt::console::runTaskFromMemento(QStringList const& args)
@@ -207,14 +323,20 @@ gt::console::runTaskFromMemento(QStringList const& args)
                                         QObject::tr("Task Memento"),
                                         QObject::tr("path"));
     const QCommandLineOption outputOption({"o", "output-diff"},
-                                          QObject::tr("Output Memento-Diff"),
+                                          QObject::tr("Output Project Memento-Diff"),
                                           QObject::tr("path"));
+    const QCommandLineOption taskdiffOption({"m", "task-diff"},
+                                            QObject::tr("Output Task Memento-Diff"),
+                                            QObject::tr("path"));
+    const QCommandLineOption taskstateOption({"s", "task-state"},
+                                            QObject::tr("Output Task Memento-Diff"),
+                                            QObject::tr("path"));
     const QCommandLineOption workingDirectoryOption(
         {"w", "working-directory"}, QObject::tr("Execution working directory"),
         QObject::tr("path"));
 
     parser.addOptions(
-        {projectOption, taskOption, outputOption, workingDirectoryOption});
+        {projectOption, taskOption, outputOption, taskdiffOption, taskstateOption, workingDirectoryOption});
 
     QStringList commandLine{QStringLiteral("run_task_from_memento")};
     commandLine.append(args);
@@ -250,39 +372,24 @@ gt::console::runTaskFromMemento(QStringList const& args)
 
     const QFileInfo projectFile(parser.value(projectOption));
     const QFileInfo taskFile(parser.value(taskOption));
-    const QString outputFile =
-        QFileInfo(parser.value(outputOption)).absoluteFilePath();
+    const QString outputProjectFile = QFileInfo(parser.value(outputOption)).absoluteFilePath();
+
     const QString workingDirectory =
         parser.isSet(workingDirectoryOption)
             ? QFileInfo(parser.value(workingDirectoryOption)).absoluteFilePath()
             : projectFile.absolutePath();
 
-    if (outputFile == projectFile.absoluteFilePath() ||
-        outputFile == taskFile.absoluteFilePath())
+    const QString outputTaskDiffFile = parser.value(taskdiffOption);
+    const QString outputTaskStateFile = parser.value(taskstateOption);
+
+
+    int checkFilesReturn = checkFiles(projectFile, taskFile, outputProjectFile,
+                                      outputTaskDiffFile, outputTaskStateFile, workingDirectory);
+    if (checkFilesReturn != 0)
     {
-        gtError() << QObject::tr(
-            "Output diff must not overwrite an input Memento");
-        return 2;
+        return checkFilesReturn;
     }
 
-    if (!projectFile.isFile())
-    {
-        gtError() << QObject::tr("Project Memento does not exist: %1")
-                         .arg(projectFile.absoluteFilePath());
-        return 3;
-    }
-    if (!taskFile.isFile())
-    {
-        gtError() << QObject::tr("Task Memento does not exist: %1")
-                         .arg(taskFile.absoluteFilePath());
-        return 3;
-    }
-    if (!QFileInfo(workingDirectory).isDir())
-    {
-        gtError() << QObject::tr("Working directory does not exist: %1")
-                         .arg(workingDirectory);
-        return 3;
-    }
 
     auto projectData = restoreProjectData(projectFile.absoluteFilePath());
     auto task = restoreTask(taskFile.absoluteFilePath());
@@ -292,6 +399,8 @@ gt::console::runTaskFromMemento(QStringList const& args)
     }
 
     const GtObjectMemento initialProjectMemento = projectData->toMemento(true);
+    const GtObjectMemento initialTaskMemento = task->toMemento(true);
+    QJsonObject taskStateOutput;
 
     MementoExecutionProject project(workingDirectory);
     project.setObjectName(projectData->objectName());
@@ -310,7 +419,19 @@ gt::console::runTaskFromMemento(QStringList const& args)
     }
     task.release();
 
-    if (!removeExistingOutput(outputFile))
+    if (!removeExistingOutput(outputProjectFile))
+    {
+        return 6;
+    }
+    if (!removeExistingOutput(outputProjectFile))
+    {
+        return 6;
+    }
+    if (!removeExistingOutput(outputTaskDiffFile))
+    {
+        return 6;
+    }
+    if (!removeExistingOutput(outputTaskStateFile))
     {
         return 6;
     }
@@ -335,6 +456,17 @@ gt::console::runTaskFromMemento(QStringList const& args)
     }
 
     const auto taskState = executionTask->currentState();
+
+    taskStateOutput["taskStateNumeric"] = static_cast<int>(taskState);
+    taskStateOutput["taskStateString"] =  QString::fromLatin1(
+        QMetaEnum::fromType<GtProcessComponent::STATE>().valueToKey(taskState)
+        );
+    if(!writeTaskState(outputTaskStateFile, taskStateOutput))
+    {
+        gtWarning() <<  QObject::tr("Cannot write task state json: %1")
+                           .arg(outputTaskStateFile);
+    }
+
     if (state != GtCoreProcessExecutor::TaskExecState::Started ||
         (taskState != GtProcessComponent::FINISHED &&
          taskState != GtProcessComponent::WARN_FINISHED))
@@ -346,10 +478,19 @@ gt::console::runTaskFromMemento(QStringList const& args)
     GtObjectMemento resultProjectMemento = project.toProjectDataMemento();
     resultProjectMemento.setIdent(initialProjectMemento.ident());
     GtObjectMementoDiff diff(initialProjectMemento, resultProjectMemento);
-    if (!writeDiff(outputFile, diff))
+    if (!writeDiff(outputProjectFile, diff))
     {
         return 6;
     }
+
+    GtObjectMemento resultTaskMemento = executionTask->toMemento(true);
+    resultTaskMemento.setIdent(initialTaskMemento.ident());
+    GtObjectMementoDiff taskdiff(initialTaskMemento, resultTaskMemento);
+    if (!outputTaskDiffFile.isEmpty() && !writeDiff(outputTaskDiffFile, taskdiff))
+    {
+        return 6;
+    }
+
 
     return 0;
 }

--- a/src/batch/gt_consoleruntaskfrommemento.cpp
+++ b/src/batch/gt_consoleruntaskfrommemento.cpp
@@ -24,15 +24,12 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QSaveFile>
-
-#include <algorithm>
-#include <array>
-#include <memory>
-#include <qjsondocument.h>
-#include <qjsonobject.h>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMetaObject>
+#include <QMetaEnum>
 
 #include <algorithm>
 #include <array>
@@ -49,78 +46,134 @@ namespace
         }
     };
 
-    int
-    checkFiles(const QFileInfo projectFile,
-               const QFileInfo taskFile,
-               const QString outputProjectFile,
-               const QString outputTaskDiffFile,
-               const QString outputTaskStateFile,
-               const QString workingDirectory )
+
+    struct MementoExecutionOptions
     {
+        const QCommandLineOption project{ {"p", "project-memento"},
+                                               QObject::tr("Serialized project-data memento path"),
+                                               QObject::tr("path") };
+        const QCommandLineOption task{ {"t", "task-memento"},
+                                            QObject::tr("Serialized task memento path"),
+                                            QObject::tr("path") };
 
-        if (outputProjectFile == projectFile.absoluteFilePath() ||
-            outputProjectFile == taskFile.absoluteFilePath())
+        const QCommandLineOption outputProject{ {"o", "output-diff"},
+                                                     QObject::tr("Output project memento-diff"),
+                                                     QObject::tr("path")};
+        const QCommandLineOption outputTask{ {"m", "task-diff"},
+                                            QObject::tr("Optional: Output task memento-diff"),
+                                            QObject::tr("path")};
+        const QCommandLineOption outputState{ {"s", "task-state"},
+                                                   QObject::tr("Optional: Output task state JSON"),
+                                                   QObject::tr("path") };
+        const QCommandLineOption workingDirectory{ {"w", "working-directory"},
+                                                        QObject::tr("Optional: Execution working directory (defaults to project memento directory)"),
+                                                        QObject::tr("path")};
+
+        const QList<QCommandLineOption> list()
         {
-            gtError() << QObject::tr(
-                "Output project diff must not overwrite an input Memento");
-            return 2;
+            return {project, task, outputProject, outputTask, outputState, workingDirectory};
         }
+    };
 
-        if (outputTaskDiffFile == projectFile.absoluteFilePath() ||
-            outputTaskDiffFile == taskFile.absoluteFilePath())
-        {
-            gtError() << QObject::tr(
-                "Output task diff must not overwrite an input Memento");
-            return 2;
-        }
-
-        if (outputTaskStateFile == projectFile.absoluteFilePath() ||
-            outputTaskStateFile == taskFile.absoluteFilePath())
-        {
-            gtError() << QObject::tr(
-                "Output task state must not overwrite an input Memento");
-            return 2;
-        }
-
-
-        if (!outputTaskDiffFile.isEmpty() &&
-            QStringList{outputProjectFile, outputTaskStateFile}.contains(outputTaskDiffFile))
-        {
-            gtError() << QObject::tr(
-                "Output files cannot have the same name");
-            return 2;
-        }
-
-        if (!outputTaskStateFile.isEmpty() &&
-            QStringList{outputProjectFile, outputTaskDiffFile}.contains(outputTaskStateFile))
-        {
-            gtError() << QObject::tr(
-                "Output files cannot have the same name");
-            return 2;
-        }
-
-
-        if (!projectFile.isFile())
-        {
-            gtError() << QObject::tr("Project Memento does not exist: %1")
-            .arg(projectFile.absoluteFilePath());
-            return 3;
-        }
-        if (!taskFile.isFile())
-        {
-            gtError() << QObject::tr("Task Memento does not exist: %1")
-            .arg(taskFile.absoluteFilePath());
-            return 3;
-        }
-        if (!QFileInfo(workingDirectory).isDir())
-        {
-            gtError() << QObject::tr("Working directory does not exist: %1")
-            .arg(workingDirectory);
-            return 3;
-        }
-
-        return 0;
+    const QString normalizedFilePath(const QString& filepath) {
+        return QDir::cleanPath(QFileInfo(filepath).absoluteFilePath());
     }
+
+    struct MementoExecutionPaths
+    {
+        QString inputProject;
+        QString inputTask;
+        QString outputProject;
+        QString outputTask;
+        QString outputState;
+        QString workingDirectory;
+
+        static MementoExecutionPaths fromParser(
+            const QCommandLineParser& parser,
+            const MementoExecutionOptions& options)
+        {
+            const QString projectFile = normalizedFilePath(parser.value(options.project));
+
+            MementoExecutionPaths retval;
+
+            retval.inputProject = projectFile;
+            retval.inputTask = normalizedFilePath(parser.value(options.task));
+
+            retval.outputProject = normalizedFilePath(parser.value(options.outputProject));
+
+            retval.outputTask = parser.isSet(options.outputTask)
+                                    ? normalizedFilePath(parser.value(options.outputTask))
+                                    : QString();
+
+            retval.outputState = parser.isSet(options.outputState)
+                                     ? normalizedFilePath(parser.value(options.outputState))
+                                     : QString();
+
+            retval.workingDirectory = parser.isSet(options.workingDirectory)
+                                          ? normalizedFilePath(parser.value(options.workingDirectory))
+                                          : QFileInfo{projectFile}.absolutePath();
+            return retval;
+        }
+
+        bool sanityCheck()
+        {
+            auto outputPaths = { outputProject, outputTask, outputState };
+            auto inputPaths = { inputProject, inputTask };
+
+            for (QString const& outputPath : outputPaths)
+            {
+                // check if output would overwrite an input file
+                for (QString const& inputPath : inputPaths)
+                {
+                    if (outputPath == inputPath)
+                    {
+                        gtError() << QObject::tr("Output file must not overwrite the input file '%1'!")
+                        .arg(inputPath);
+                        return false;
+                    }
+                }
+
+                // check if output would overwrite another output file
+                auto count = std::accumulate(outputPaths.begin(), outputPaths.end(), unsigned{0}, [&outputPath ](unsigned count, QString const& nextOutput){
+                    return count + unsigned{outputPath == nextOutput};
+                });
+                if (!outputPath.isEmpty() && count > 1)
+                {
+                    gtError() << QObject::tr("Output files must not overwrite each other (file: '%1')!")
+                    .arg(outputPath);
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        bool checkInputExists()
+        {
+            if (!QFileInfo(inputProject).isFile())
+            {
+                gtError() << QObject::tr("Project Memento does not exist: %1")
+                .arg(inputProject);
+                return false;
+            }
+            if (!QFileInfo(inputTask).isFile())
+            {
+                gtError() << QObject::tr("Task Memento does not exist: %1")
+                .arg(inputTask);
+                return false;
+            }
+            if (!QFileInfo(workingDirectory).isDir())
+            {
+                gtError() << QObject::tr("Working directory does not exist: %1")
+                .arg(workingDirectory);
+                return false;
+            }
+
+            return true;
+        }
+
+    };
+
 
     std::unique_ptr<GtObjectGroup> restoreProjectData(QString const& fileName)
     {
@@ -298,17 +351,18 @@ namespace
 
 } // namespace
 
+
 QList<GtCommandLineOption>
 gt::console::runTaskFromMementoOptions()
 {
-    return {{{"project-memento", "p"}, "Serialized project-data Memento path"},
-            {{"task-memento", "t"}, "Serialized task Memento path"},
-            {{"output-diff", "o"}, "Output Project Memento-Diff path"},
-            {{"task-diff", "m"}, "Optional: Output Task Memento-Diff path"},
-            {{"task-state", "s"}, "Optional: Output Task State path"},
-            {{"working-directory", "w"},
-             "Execution working directory (defaults to project Memento "
-             "directory)"}};
+    MementoExecutionOptions options;
+    QList<GtCommandLineOption> theList;
+
+    for(auto& option: options.list())
+    {
+        theList.append(GtCommandLineOption{option.names(), option.description()});
+    }
+    return theList;
 }
 
 
@@ -318,31 +372,13 @@ int
 gt::console::runTaskFromMemento(QStringList const& args)
 {
     QCommandLineParser parser;
+
     parser.setApplicationDescription(
         QObject::tr("Execute a task from project and task Mementos"));
     parser.addHelpOption();
 
-    const QCommandLineOption projectOption({"p", "project-memento"},
-                                           QObject::tr("Project-data Memento"),
-                                           QObject::tr("path"));
-    const QCommandLineOption taskOption({"t", "task-memento"},
-                                        QObject::tr("Task Memento"),
-                                        QObject::tr("path"));
-    const QCommandLineOption outputOption({"o", "output-diff"},
-                                          QObject::tr("Output Project Memento-Diff"),
-                                          QObject::tr("path"));
-    const QCommandLineOption taskdiffOption({"m", "task-diff"},
-                                            QObject::tr("Output Task Memento-Diff"),
-                                            QObject::tr("path"));
-    const QCommandLineOption taskstateOption({"s", "task-state"},
-                                            QObject::tr("Output Task State JSON"),
-                                            QObject::tr("path"));
-    const QCommandLineOption workingDirectoryOption(
-        {"w", "working-directory"}, QObject::tr("Execution working directory"),
-        QObject::tr("path"));
-
-    parser.addOptions(
-        {projectOption, taskOption, outputOption, taskdiffOption, taskstateOption, workingDirectoryOption});
+    MementoExecutionOptions options;
+    parser.addOptions(options.list());
 
     QStringList commandLine{QStringLiteral("run_task_from_memento")};
     commandLine.append(args);
@@ -356,8 +392,7 @@ gt::console::runTaskFromMemento(QStringList const& args)
         parser.showHelp(0);
     }
 
-    const std::array requiredOptions{&projectOption, &taskOption,
-                                     &outputOption};
+    const std::array requiredOptions{&options.project, &options.task, &options.outputProject};
     auto missingOption = std::find_if(
         requiredOptions.cbegin(), requiredOptions.cend(),
         [&parser](auto const* option) {
@@ -376,40 +411,23 @@ gt::console::runTaskFromMemento(QStringList const& args)
         return 2;
     }
 
-    const QFileInfo projectFile(parser.value(projectOption));
-    const QFileInfo taskFile(parser.value(taskOption));
-    const QString outputProjectFile = QFileInfo(parser.value(outputOption)).absoluteFilePath();
 
-    const QString workingDirectory =
-        parser.isSet(workingDirectoryOption)
-            ? QFileInfo(parser.value(workingDirectoryOption)).absoluteFilePath()
-            : projectFile.absolutePath();
+    auto runPaths = MementoExecutionPaths::fromParser(parser, options);
 
-    QString outputTaskDiffFile0 = "";
-    if (!parser.value(taskdiffOption).isEmpty())
+
+    if (!runPaths.sanityCheck())
     {
-        outputTaskDiffFile0 = QFileInfo(parser.value(taskdiffOption)).absoluteFilePath();
+        return 2;
     }
-    const QString outputTaskDiffFile = outputTaskDiffFile0;
 
-    QString outputTaskStateFile0 = "";
-    if (!parser.value(taskstateOption).isEmpty())
+    if(!runPaths.checkInputExists())
     {
-        outputTaskStateFile0 = QFileInfo(parser.value(taskstateOption)).absoluteFilePath();
-    }
-    const QString outputTaskStateFile = outputTaskStateFile0;
-
-
-    int checkFilesReturn = checkFiles(projectFile, taskFile, outputProjectFile,
-                                      outputTaskDiffFile, outputTaskStateFile, workingDirectory);
-    if (checkFilesReturn != 0)
-    {
-        return checkFilesReturn;
+        return 3;
     }
 
 
-    auto projectData = restoreProjectData(projectFile.absoluteFilePath());
-    auto task = restoreTask(taskFile.absoluteFilePath());
+    auto projectData = restoreProjectData(runPaths.inputProject);
+    auto task = restoreTask(runPaths.inputTask);
     if (!projectData || !task)
     {
         return 4;
@@ -419,7 +437,7 @@ gt::console::runTaskFromMemento(QStringList const& args)
     const GtObjectMemento initialTaskMemento = task->toMemento(true);
     QJsonObject taskStateOutput;
 
-    MementoExecutionProject project(workingDirectory);
+    MementoExecutionProject project(runPaths.workingDirectory);
     project.setObjectName(projectData->objectName());
     project.setUuid(projectData->uuid());
     if (!populateProject(*projectData, project))
@@ -436,30 +454,30 @@ gt::console::runTaskFromMemento(QStringList const& args)
     }
     task.release();
 
-    if (!removeExistingOutput(outputProjectFile))
+    if (!removeExistingOutput(runPaths.outputProject))
     {
         return 6;
     }
-    if (!removeExistingOutput(outputTaskDiffFile))
+    if (!removeExistingOutput(runPaths.outputTask))
     {
         return 6;
     }
-    if (!removeExistingOutput(outputTaskStateFile))
+    if (!removeExistingOutput(runPaths.outputState))
     {
         return 6;
     }
 
     const QString previousWorkingDirectory = QDir::currentPath();
-    if (!QDir::setCurrent(workingDirectory))
+    if (!QDir::setCurrent(runPaths.workingDirectory))
     {
         gtError() << QObject::tr("Cannot use working directory: %1")
-                         .arg(workingDirectory);
+                         .arg(runPaths.workingDirectory);
         return 3;
     }
 
     GtCoreProcessExecutor executor;
     executor.setSource(&project);
-    executor.setCustomProjectPath(workingDirectory);
+    executor.setCustomProjectPath(runPaths.workingDirectory);
     const auto state = executor.startTask(executionTask);
 
     if (!QDir::setCurrent(previousWorkingDirectory))
@@ -473,10 +491,10 @@ gt::console::runTaskFromMemento(QStringList const& args)
     taskStateOutput["taskState"] =  QString::fromLatin1(
         QMetaEnum::fromType<GtProcessComponent::STATE>().valueToKey(taskState)
     );
-    if(!writeTaskState(outputTaskStateFile, taskStateOutput))
+    if(!writeTaskState(runPaths.outputState, taskStateOutput))
     {
         gtError() <<  QObject::tr("Cannot write task state json: %1")
-                           .arg(outputTaskStateFile);
+                           .arg(runPaths.outputState);
         return 6;
     }
 
@@ -491,7 +509,7 @@ gt::console::runTaskFromMemento(QStringList const& args)
     GtObjectMemento resultProjectMemento = project.toProjectDataMemento();
     resultProjectMemento.setIdent(initialProjectMemento.ident());
     GtObjectMementoDiff diff(initialProjectMemento, resultProjectMemento);
-    if (!writeDiff(outputProjectFile, diff))
+    if (!writeDiff(runPaths.outputProject, diff))
     {
         return 6;
     }
@@ -499,7 +517,7 @@ gt::console::runTaskFromMemento(QStringList const& args)
     GtObjectMemento resultTaskMemento = executionTask->toMemento(true);
     resultTaskMemento.setIdent(initialTaskMemento.ident());
     GtObjectMementoDiff taskdiff(initialTaskMemento, resultTaskMemento);
-    if (!outputTaskDiffFile.isEmpty() && !writeDiff(outputTaskDiffFile, taskdiff))
+    if (!runPaths.outputTask.isEmpty() && !writeDiff(runPaths.outputTask, taskdiff))
     {
         return 6;
     }

--- a/src/batch/gt_consoleruntaskfrommemento.cpp
+++ b/src/batch/gt_consoleruntaskfrommemento.cpp
@@ -123,14 +123,12 @@ namespace
             for (QString const& outputPath : outputPaths)
             {
                 // check if output would overwrite an input file
-                for (QString const& inputPath : inputPaths)
+                auto inputPath = std::find(inputPaths.begin(), inputPaths.end(), outputPath);
+                if (inputPath != inputPaths.end())
                 {
-                    if (outputPath == inputPath)
-                    {
-                        gtError() << QObject::tr("Output file must not overwrite the input file '%1'!")
-                        .arg(inputPath);
-                        return false;
-                    }
+                    gtError() << QObject::tr("Output file must not overwrite the input file '%1'!")
+                    .arg(*inputPath);
+                    return false;
                 }
 
                 // check if output would overwrite another output file

--- a/src/batch/gt_consoleruntaskfrommemento.cpp
+++ b/src/batch/gt_consoleruntaskfrommemento.cpp
@@ -329,7 +329,7 @@ gt::console::runTaskFromMemento(QStringList const& args)
                                             QObject::tr("Output Task Memento-Diff"),
                                             QObject::tr("path"));
     const QCommandLineOption taskstateOption({"s", "task-state"},
-                                            QObject::tr("Output Task Memento-Diff"),
+                                            QObject::tr("Output Task State JSON"),
                                             QObject::tr("path"));
     const QCommandLineOption workingDirectoryOption(
         {"w", "working-directory"}, QObject::tr("Execution working directory"),
@@ -379,8 +379,19 @@ gt::console::runTaskFromMemento(QStringList const& args)
             ? QFileInfo(parser.value(workingDirectoryOption)).absoluteFilePath()
             : projectFile.absolutePath();
 
-    const QString outputTaskDiffFile = parser.value(taskdiffOption);
-    const QString outputTaskStateFile = parser.value(taskstateOption);
+    QString outputTaskDiffFile0 = "";
+    if (!parser.value(taskdiffOption).isEmpty())
+    {
+        outputTaskDiffFile0 = QFileInfo(parser.value(taskdiffOption)).absoluteFilePath();
+    }
+    const QString outputTaskDiffFile = outputTaskDiffFile0;
+
+    QString outputTaskStateFile0 = "";
+    if (!parser.value(taskstateOption).isEmpty())
+    {
+        outputTaskStateFile0 = QFileInfo(parser.value(taskstateOption)).absoluteFilePath();
+    }
+    const QString outputTaskStateFile = outputTaskStateFile0;
 
 
     int checkFilesReturn = checkFiles(projectFile, taskFile, outputProjectFile,
@@ -423,10 +434,6 @@ gt::console::runTaskFromMemento(QStringList const& args)
     {
         return 6;
     }
-    if (!removeExistingOutput(outputProjectFile))
-    {
-        return 6;
-    }
     if (!removeExistingOutput(outputTaskDiffFile))
     {
         return 6;
@@ -463,8 +470,9 @@ gt::console::runTaskFromMemento(QStringList const& args)
         );
     if(!writeTaskState(outputTaskStateFile, taskStateOutput))
     {
-        gtWarning() <<  QObject::tr("Cannot write task state json: %1")
+        gtError() <<  QObject::tr("Cannot write task state json: %1")
                            .arg(outputTaskStateFile);
+        return 6;
     }
 
     if (state != GtCoreProcessExecutor::TaskExecState::Started ||

--- a/src/batch/gt_consoleruntaskfrommemento.cpp
+++ b/src/batch/gt_consoleruntaskfrommemento.cpp
@@ -30,7 +30,13 @@
 #include <memory>
 #include <qjsondocument.h>
 #include <qjsonobject.h>
-#include <qmetaobject.h>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMetaObject>
+
+#include <algorithm>
+#include <array>
+#include <memory>
 
 namespace
 {
@@ -298,8 +304,8 @@ gt::console::runTaskFromMementoOptions()
     return {{{"project-memento", "p"}, "Serialized project-data Memento path"},
             {{"task-memento", "t"}, "Serialized task Memento path"},
             {{"output-diff", "o"}, "Output Project Memento-Diff path"},
-            {{"task-diff", "m"}, "Output Task Memento-Diff path"},
-            {{"task-state", "s"}, "Output Task State path"},
+            {{"task-diff", "m"}, "Optional: Output Task Memento-Diff path"},
+            {{"task-state", "s"}, "Optional: Output Task State path"},
             {{"working-directory", "w"},
              "Execution working directory (defaults to project Memento "
              "directory)"}};
@@ -464,10 +470,9 @@ gt::console::runTaskFromMemento(QStringList const& args)
 
     const auto taskState = executionTask->currentState();
 
-    taskStateOutput["taskStateNumeric"] = static_cast<int>(taskState);
-    taskStateOutput["taskStateString"] =  QString::fromLatin1(
+    taskStateOutput["taskState"] =  QString::fromLatin1(
         QMetaEnum::fromType<GtProcessComponent::STATE>().valueToKey(taskState)
-        );
+    );
     if(!writeTaskState(outputTaskStateFile, taskStateOutput))
     {
         gtError() <<  QObject::tr("Cannot write task state json: %1")

--- a/tests/unittests/core/test_gt_consoleruntaskfrommemento.cpp
+++ b/tests/unittests/core/test_gt_consoleruntaskfrommemento.cpp
@@ -475,6 +475,27 @@ namespace
                   4);
     }
 
+    TEST_F(TestGtConsoleRunTaskFromMemento, RejectsOutputfilesWithSameName)
+    {
+        ASSERT_TRUE(writeFile(projectPath, "input"));
+
+        EXPECT_NE(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-m", outputProjectPath}),
+                  0);
+        EXPECT_TRUE(QFileInfo::exists(projectPath));
+
+        EXPECT_NE(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-s", outputProjectPath}),
+                  0);
+        EXPECT_TRUE(QFileInfo::exists(projectPath));
+
+        EXPECT_NE(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-m", outputTaskdiffPath, "-s", outputTaskdiffPath}),
+                  0);
+        EXPECT_TRUE(QFileInfo::exists(projectPath));
+
+    }
+
     TEST_F(TestGtConsoleRunTaskFromMemento, ExposesAllCommandLineOptions)
     {
         EXPECT_EQ(gt::console::runTaskFromMementoOptions().size(), 6);

--- a/tests/unittests/core/test_gt_consoleruntaskfrommemento.cpp
+++ b/tests/unittests/core/test_gt_consoleruntaskfrommemento.cpp
@@ -18,6 +18,7 @@
 #include "gt_package.h"
 #include "gt_project.h"
 #include "gt_task.h"
+#include "gt_taskgroup.h"
 
 #include <QCoreApplication>
 #include <QDir>
@@ -25,6 +26,8 @@
 #include <QTemporaryDir>
 
 #include <memory>
+#include <qjsondocument.h>
+#include <qjsonobject.h>
 
 namespace
 {
@@ -70,9 +73,11 @@ namespace
     public:
         Q_INVOKABLE MementoTestCalculator() :
             packageLink("package", "Package", "Package", this,
-                        {GT_CLASSNAME(MementoTestPackage)})
+                        {GT_CLASSNAME(MementoTestPackage)}),
+            dummyStrProp("dummyStrProp", "Dummy String", "Dummy String", "", gt::rex::onlyLettersAndNumbers())
         {
             registerProperty(packageLink);
+            registerMonitoringProperty(dummyStrProp);
         }
 
         bool run() override
@@ -85,6 +90,9 @@ namespace
                                       ? gtApp->currentProject()->path()
                                       : QString{};
             observedWorkingDirectory = QDir::currentPath();
+
+            dummyStrProp.setVal("abc123");
+
             for (auto const& object : linkedObjects())
             {
                 if (auto* package = qobject_cast<MementoTestPackage*>(object))
@@ -94,6 +102,7 @@ namespace
                     return true;
                 }
             }
+
             return false;
         }
 
@@ -109,6 +118,7 @@ namespace
 
     private:
         GtObjectLinkProperty packageLink;
+        GtStringProperty dummyStrProp;
     };
 
     QString MementoTestCalculator::observedProjectPath;
@@ -164,6 +174,8 @@ namespace
                 MementoTestPackage::staticMetaObject);
             gtObjectFactory->registerClass(
                 MementoTestObject::staticMetaObject);
+            gtObjectFactory->registerClass(
+                MementoTestCalculator::staticMetaObject);
             gtCalculatorFactory->registerClass(
                 MementoTestCalculator::staticMetaObject);
             ASSERT_TRUE(tempDir.isValid());
@@ -173,7 +185,9 @@ namespace
             projectPath =
                 QDir(workingDirectory).filePath("project memento.xml");
             taskPath = QDir(workingDirectory).filePath("task memento.xml");
-            outputPath = QDir(workingDirectory).filePath("result diff.xml");
+            outputProjectPath = QDir(workingDirectory).filePath("result diff.xml");
+            outputTaskdiffPath = QDir(workingDirectory).filePath("task diff.xml");
+            outputTaskstatePath = QDir(workingDirectory).filePath("task state.json");
         }
 
         std::unique_ptr<TestApplication> application;
@@ -181,7 +195,9 @@ namespace
         QString workingDirectory;
         QString projectPath;
         QString taskPath;
-        QString outputPath;
+        QString outputProjectPath;
+        QString outputTaskdiffPath;
+        QString outputTaskstatePath;
     };
 
     TEST_F(TestGtConsoleRunTaskFromMemento,
@@ -197,10 +213,12 @@ namespace
         ASSERT_TRUE(projectData.appendChild(package.get()));
         package.release();
 
-        GtObjectMemento original = projectData.toMemento(true);
-        ASSERT_TRUE(writeFile(projectPath, original.toByteArray()));
+        GtObjectMemento originalProject = projectData.toMemento(true);
+        ASSERT_TRUE(writeFile(projectPath, originalProject.toByteArray()));
 
+        GtTaskGroup taskGroup;
         GtTask task;
+        taskGroup.appendChild(&task);
         task.setFactory(gtObjectFactory);
         auto calculator = std::make_unique<MementoTestCalculator>();
         calculator->setFactory(gtCalculatorFactory);
@@ -209,27 +227,72 @@ namespace
         calculator.release();
         ASSERT_TRUE(writeFile(taskPath, task.toMemento().toByteArray()));
 
-        EXPECT_EQ(gt::console::runTaskFromMemento({"-p", projectPath, "-t",
-                                                   taskPath, "-o", outputPath,
+        GtObjectMemento originalTask = task.toMemento(true);
+
+
+        EXPECT_EQ(gt::console::runTaskFromMemento({"-p", projectPath,
+                                                   "-t", taskPath,
+                                                   "-o", outputProjectPath,
+                                                   "-m", outputTaskdiffPath,
+                                                   "-s", outputTaskstatePath,
                                                    "-w", workingDirectory}),
                   0);
         EXPECT_EQ(MementoTestCalculator::observedProjectPath, workingDirectory);
         EXPECT_EQ(MementoTestCalculator::observedWorkingDirectory,
                   workingDirectory);
 
-        QFile output(outputPath);
-        ASSERT_TRUE(output.open(QIODevice::ReadOnly));
-        GtObjectMementoDiff diff(output.readAll());
-        EXPECT_FALSE(diff.isNull());
-        auto restored = std::unique_ptr<GtObjectGroup>(
-            original.restore<GtObjectGroup*>(gtObjectFactory));
-        ASSERT_TRUE(restored);
-        ASSERT_TRUE(restored->applyDiff(diff));
-        EXPECT_EQ(restored->objectName(), "Memento Root");
-        auto* restoredPackage =
-            restored->findDirectChild<MementoTestPackage*>();
-        ASSERT_TRUE(restoredPackage);
-        EXPECT_EQ(restoredPackage->value.getVal(), 42);
+        {
+            QFile output(outputProjectPath);
+            ASSERT_TRUE(output.open(QIODevice::ReadOnly));
+            GtObjectMementoDiff diff(output.readAll());
+            EXPECT_FALSE(diff.isNull());
+            auto restored = std::unique_ptr<GtObjectGroup>(
+                originalProject.restore<GtObjectGroup*>(gtObjectFactory));
+            ASSERT_TRUE(restored);
+            ASSERT_TRUE(restored->applyDiff(diff));
+            EXPECT_EQ(restored->objectName(), "Memento Root");
+            auto* restoredPackage =
+                restored->findDirectChild<MementoTestPackage*>();
+            ASSERT_TRUE(restoredPackage);
+            EXPECT_EQ(restoredPackage->value.getVal(), 42);
+        }
+
+        {
+            QFile output(outputTaskdiffPath);
+            ASSERT_TRUE(output.open(QIODevice::ReadOnly));
+            GtObjectMementoDiff diff(output.readAll());
+            EXPECT_FALSE(diff.isNull());
+            auto restored = std::unique_ptr<GtTask>(
+                originalTask.restore<GtTask*>(gtObjectFactory));
+            ASSERT_TRUE(restored);
+            ASSERT_TRUE(restored->applyDiff(diff));
+            EXPECT_EQ(restored->objectName(), task.objectName());
+            auto* restoredCalc =
+                restored->findDirectChild<MementoTestCalculator*>();
+            ASSERT_TRUE(restoredCalc);
+
+            auto propAbstract = restoredCalc->findProperty("dummyStrProp");
+            ASSERT_TRUE(propAbstract);
+
+            auto propString = qobject_cast<GtStringProperty*>(propAbstract);
+            ASSERT_TRUE(propString);
+            EXPECT_EQ(propString->getVal(), "abc123");
+        }
+
+        {
+            QFile output(outputTaskstatePath);
+            ASSERT_TRUE(output.open(QIODevice::ReadOnly));
+
+            const QJsonDocument doc = QJsonDocument::fromJson(output.readAll());
+            ASSERT_TRUE(doc.isObject());
+
+            const QJsonObject obj = doc.object();
+
+            ASSERT_TRUE(obj.contains("taskStateNumeric"));
+            EXPECT_EQ(obj["taskStateNumeric"], 4);
+            ASSERT_TRUE(obj.contains("taskStateString"));
+            EXPECT_EQ(obj["taskStateString"], "FINISHED");
+        }
     }
 
     TEST_F(TestGtConsoleRunTaskFromMemento,
@@ -237,14 +300,28 @@ namespace
     {
         ASSERT_TRUE(writeFile(projectPath, "not xml"));
         ASSERT_TRUE(writeFile(taskPath, "not xml"));
-        ASSERT_TRUE(writeFile(outputPath, "stale diff"));
+        ASSERT_TRUE(writeFile(outputProjectPath, "stale diff"));
+        ASSERT_TRUE(writeFile(outputTaskdiffPath, "stale diff"));
+        ASSERT_TRUE(writeFile(outputTaskstatePath, "not json"));
         EXPECT_NE(gt::console::runTaskFromMemento(
-                      {"--project-memento", projectPath, "--task-memento",
-                       taskPath, "--output-diff", outputPath}),
+                      {"--project-memento", projectPath,
+                       "--task-memento", taskPath,
+                       "--output-diff", outputProjectPath,
+                       "--task-diff", outputTaskdiffPath,
+                       "--task-state", outputTaskstatePath}
+                      ),
                   0);
-        QFile output(outputPath);
-        ASSERT_TRUE(output.open(QIODevice::ReadOnly));
-        EXPECT_EQ(output.readAll(), "stale diff");
+        QFile outputProject(outputProjectPath);
+        ASSERT_TRUE(outputProject.open(QIODevice::ReadOnly));
+        EXPECT_EQ(outputProject.readAll(), "stale diff");
+
+        QFile outputTaskdiff(outputTaskdiffPath);
+        ASSERT_TRUE(outputTaskdiff.open(QIODevice::ReadOnly));
+        EXPECT_EQ(outputTaskdiff.readAll(), "stale diff");
+
+        QFile outputTaskstate(outputTaskstatePath);
+        ASSERT_TRUE(outputTaskstate.open(QIODevice::ReadOnly));
+        EXPECT_EQ(outputTaskstate.readAll(), "not json");
     }
 
     TEST_F(TestGtConsoleRunTaskFromMemento, OutputCannotOverwriteInputMemento)
@@ -254,7 +331,23 @@ namespace
                       {"-p", projectPath, "-t", taskPath, "-o", projectPath}),
                   0);
         EXPECT_TRUE(QFileInfo::exists(projectPath));
+
+        EXPECT_NE(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", projectPath, "-o", outputProjectPath}),
+                  0);
+        EXPECT_TRUE(QFileInfo::exists(projectPath));
+
+        EXPECT_NE(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-m", projectPath}),
+                  0);
+        EXPECT_TRUE(QFileInfo::exists(projectPath));
+
+        EXPECT_NE(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-s", projectPath}),
+                  0);
+        EXPECT_TRUE(QFileInfo::exists(projectPath));
     }
+
 
     TEST_F(TestGtConsoleRunTaskFromMemento,
            WarningFinishedTaskProducesApplicableDiff)
@@ -283,10 +376,10 @@ namespace
 
         MementoTestCalculator::produceWarning = true;
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath}),
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-s", outputTaskstatePath}),
                   0);
 
-        QFile output(outputPath);
+        QFile output(outputProjectPath);
         ASSERT_TRUE(output.open(QIODevice::ReadOnly));
         GtObjectMementoDiff diff(output.readAll());
         EXPECT_FALSE(diff.isNull());
@@ -298,6 +391,21 @@ namespace
             restored->findDirectChild<MementoTestPackage*>();
         ASSERT_TRUE(restoredPackage);
         EXPECT_EQ(restoredPackage->value.getVal(), 42);
+
+        {
+            QFile output(outputTaskstatePath);
+            ASSERT_TRUE(output.open(QIODevice::ReadOnly));
+
+            const QJsonDocument doc = QJsonDocument::fromJson(output.readAll());
+            ASSERT_TRUE(doc.isObject());
+
+            const QJsonObject obj = doc.object();
+
+            ASSERT_TRUE(obj.contains("taskStateNumeric"));
+            EXPECT_EQ(obj["taskStateNumeric"], 5);
+            ASSERT_TRUE(obj.contains("taskStateString"));
+            EXPECT_EQ(obj["taskStateString"], "WARN_FINISHED");
+        }
     }
 
     TEST_F(TestGtConsoleRunTaskFromMemento, RejectsInvalidCommandLineArguments)
@@ -305,7 +413,7 @@ namespace
         EXPECT_EQ(gt::console::runTaskFromMemento({"--unknown"}), 2);
         EXPECT_EQ(gt::console::runTaskFromMemento({"-p", projectPath}), 2);
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath,
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath,
                        "unexpected"}),
                   2);
     }
@@ -315,14 +423,14 @@ namespace
     {
         ASSERT_TRUE(writeFile(projectPath, "project"));
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath}),
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath}),
                   3);
 
         ASSERT_TRUE(writeFile(taskPath, "task"));
         const QString missingDirectory =
             QDir(tempDir.path()).filePath("missing directory");
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath,
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath,
                        "-w", missingDirectory}),
                   3);
     }
@@ -337,7 +445,7 @@ namespace
             QDir(tempDir.path()).filePath("valid project.xml"), taskPath));
 
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath}),
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath}),
                   4);
     }
 
@@ -351,7 +459,7 @@ namespace
             projectPath, GtObjectGroup().toMemento(true).toByteArray()));
         EXPECT_EQ(gt::console::runTaskFromMemento(
                       {"-p", validProjectPath, "-t", projectPath, "-o",
-                       outputPath}),
+                       outputProjectPath}),
                   4);
 
         GtObjectGroup projectData;
@@ -363,36 +471,71 @@ namespace
             writeFile(projectPath, projectData.toMemento(true).toByteArray()));
         ASSERT_TRUE(writeRunnableMementos(validProjectPath, taskPath));
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath}),
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath}),
                   4);
     }
 
     TEST_F(TestGtConsoleRunTaskFromMemento, ExposesAllCommandLineOptions)
     {
-        EXPECT_EQ(gt::console::runTaskFromMementoOptions().size(), 4);
+        EXPECT_EQ(gt::console::runTaskFromMementoOptions().size(), 6);
     }
 
     TEST_F(TestGtConsoleRunTaskFromMemento,
            RejectsOutputDirectory)
     {
         ASSERT_TRUE(writeRunnableMementos(projectPath, taskPath));
-        ASSERT_TRUE(QDir().mkpath(outputPath));
+        ASSERT_TRUE(QDir().mkpath(outputProjectPath));
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath}),
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath}),
                   6);
-        ASSERT_TRUE(QDir(outputPath).removeRecursively());
+        ASSERT_TRUE(QDir(outputProjectPath).removeRecursively());
+
+        ASSERT_TRUE(QDir().mkpath(outputTaskdiffPath));
+        EXPECT_EQ(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-m", outputTaskdiffPath}),
+                  6);
+        ASSERT_TRUE(QDir(outputTaskdiffPath).removeRecursively());
+
+        ASSERT_TRUE(QDir().mkpath(outputTaskstatePath));
+        EXPECT_EQ(gt::console::runTaskFromMemento(
+                      {"-p", projectPath, "-t", taskPath, "-o", outputProjectPath, "-s", outputTaskstatePath}),
+                  6);
+        ASSERT_TRUE(QDir(outputTaskstatePath).removeRecursively());
     }
 
     TEST_F(TestGtConsoleRunTaskFromMemento,
            TaskFailureRemovesExistingOutput)
     {
         ASSERT_TRUE(writeRunnableMementos(projectPath, taskPath));
-        ASSERT_TRUE(writeFile(outputPath, "stale diff"));
+        ASSERT_TRUE(writeFile(outputProjectPath, "stale diff"));
+        ASSERT_TRUE(writeFile(outputTaskdiffPath, "stale diff"));
+        ASSERT_TRUE(writeFile(outputTaskstatePath, "stale state"));
         MementoTestCalculator::shouldSucceed = false;
         EXPECT_EQ(gt::console::runTaskFromMemento(
-                      {"-p", projectPath, "-t", taskPath, "-o", outputPath}),
+                      {"-p", projectPath,
+                       "-t", taskPath,
+                       "-o", outputProjectPath,
+                       "-m", outputTaskdiffPath,
+                       "-s", outputTaskstatePath}),
                   5);
-        EXPECT_FALSE(QFileInfo::exists(outputPath));
+        EXPECT_FALSE(QFileInfo::exists(outputProjectPath));
+        EXPECT_FALSE(QFileInfo::exists(outputTaskdiffPath));
+        EXPECT_TRUE(QFileInfo::exists(outputTaskstatePath));
+
+        {
+            QFile output(outputTaskstatePath);
+            ASSERT_TRUE(output.open(QIODevice::ReadOnly));
+
+            const QJsonDocument doc = QJsonDocument::fromJson(output.readAll());
+            ASSERT_TRUE(doc.isObject());
+
+            const QJsonObject obj = doc.object();
+
+            ASSERT_TRUE(obj.contains("taskStateNumeric"));
+            EXPECT_EQ(obj["taskStateNumeric"], 3);
+            ASSERT_TRUE(obj.contains("taskStateString"));
+            EXPECT_EQ(obj["taskStateString"], "FAILED");
+        }
     }
 
 } // namespace

--- a/tests/unittests/core/test_gt_consoleruntaskfrommemento.cpp
+++ b/tests/unittests/core/test_gt_consoleruntaskfrommemento.cpp
@@ -288,10 +288,8 @@ namespace
 
             const QJsonObject obj = doc.object();
 
-            ASSERT_TRUE(obj.contains("taskStateNumeric"));
-            EXPECT_EQ(obj["taskStateNumeric"], 4);
-            ASSERT_TRUE(obj.contains("taskStateString"));
-            EXPECT_EQ(obj["taskStateString"], "FINISHED");
+            ASSERT_TRUE(obj.contains("taskState"));
+            EXPECT_EQ(obj["taskState"], "FINISHED");
         }
     }
 
@@ -401,10 +399,8 @@ namespace
 
             const QJsonObject obj = doc.object();
 
-            ASSERT_TRUE(obj.contains("taskStateNumeric"));
-            EXPECT_EQ(obj["taskStateNumeric"], 5);
-            ASSERT_TRUE(obj.contains("taskStateString"));
-            EXPECT_EQ(obj["taskStateString"], "WARN_FINISHED");
+            ASSERT_TRUE(obj.contains("taskState"));
+            EXPECT_EQ(obj["taskState"], "WARN_FINISHED");
         }
     }
 
@@ -552,10 +548,8 @@ namespace
 
             const QJsonObject obj = doc.object();
 
-            ASSERT_TRUE(obj.contains("taskStateNumeric"));
-            EXPECT_EQ(obj["taskStateNumeric"], 3);
-            ASSERT_TRUE(obj.contains("taskStateString"));
-            EXPECT_EQ(obj["taskStateString"], "FAILED");
+            ASSERT_TRUE(obj.contains("taskState"));
+            EXPECT_EQ(obj["taskState"], "FAILED");
         }
     }
 


### PR DESCRIPTION
## Description
Adds optional commandline arguments for run_task_from_memento to output the task diff and task state
Task diff provides the changes in monitoring properties which occured during the task.
Task state is a JSON file which provides the resulting GtProcessComponent::STATE, as the numeric value and the string id of the enum value.
Implements #1547 

Actual names of the cli arguments are open for discussion
Actual content of the task state JSON is open for discussion.

## How Has This Been Tested?
Existing tests have been extended.

## Checklist:

- [x] A test for the new functionality was added (if applicable).
- [x] All tests run without failure.
- [ ] The changelog has been extended, if this MR contains important changes from the users's point of view.
- [x] The new code complies with the GTlab's style guide.
- [x] New interface methods / functions are exported via `EXPORT`. Non-interface functions are NOT exported.
- [x] The number of code quality warnings is not increasing.

## Summary by Sourcery

Extend run_task_from_memento to optionally write task changes and the resulting execution state alongside the project memento diff.

New Features:
- Add optional CLI outputs for task memento diffs and task execution state JSON.
- Expose the resulting task state through its enum string identifier.

Bug Fixes:
- Prevent project, task, and optional output files from overwriting one another.

Enhancements:
- Refactor memento execution option and path handling while preserving existing project diff generation.

Documentation:
- Update headless execution documentation with the additional memento output options.

Tests:
- Extend console execution tests to cover task diffs, task state output, output path validation, and finished, warning, and failed task states.